### PR TITLE
fix(test): adopt vitest projects config and improve coverage tests

### DIFF
--- a/packages/editor/src/index.test.ts
+++ b/packages/editor/src/index.test.ts
@@ -31,7 +31,10 @@ describe('editor', () => {
   test('editor: setMetadata handles known keys, extras, and BPM validation', () => {
     let json = createEmptyJson('json');
     json = setMetadata(json, 'title', 'Song');
+    json = setMetadata(json, 'subtitle', 'Sub');
     json = setMetadata(json, 'artist', 'Composer');
+    json = setMetadata(json, 'comment', 'Test comment');
+    json = setMetadata(json, 'stagefile', 'stage.png');
     json = setMetadata(json, 'playlevel', '12.5');
     json = setMetadata(json, 'rank', '3');
     json = setMetadata(json, 'total', '250');
@@ -40,7 +43,10 @@ describe('editor', () => {
     json = setMetadata(json, 'wavcmd', 'legacy');
 
     expect(json.metadata.title).toBe('Song');
+    expect(json.metadata.subtitle).toBe('Sub');
     expect(json.metadata.artist).toBe('Composer');
+    expect(json.metadata.comment).toBe('Test comment');
+    expect(json.metadata.stageFile).toBe('stage.png');
     expect(json.metadata.playLevel).toBe(12.5);
     expect(json.metadata.rank).toBe(3);
     expect(json.metadata.total).toBe(250);
@@ -78,6 +84,13 @@ describe('editor', () => {
     });
     json = addNote(json, {
       measure: 1,
+      channel: '12',
+      positionNumerator: 1,
+      positionDenominator: 2,
+      value: '09',
+    });
+    json = addNote(json, {
+      measure: 1,
       channel: '11',
       positionNumerator: Number.NaN,
       positionDenominator: 0,
@@ -91,6 +104,7 @@ describe('editor', () => {
       [1, '11', 0, 1, '03'],
       [1, '11', 1, 2, '01'],
       [1, '11', 2, 4, '02'],
+      [1, '12', 1, 2, '09'],
       [2, '1A', 3, 4, '0F'],
     ]);
     expect(json.measures.some((measure) => measure.index === 2)).toBe(true);
@@ -113,6 +127,7 @@ describe('editor', () => {
     });
     expect(removedByPosition.events.some((event) => event.value === '01')).toBe(false);
     expect(removedByPosition.events.some((event) => event.value === '02')).toBe(false);
+    expect(removedByPosition.events.some((event) => event.channel === '12' && event.value === '09')).toBe(true);
   });
 
   test('editor: normalizes incomplete JSON to defaults during operations', () => {

--- a/packages/stringifier/src/index.test.ts
+++ b/packages/stringifier/src/index.test.ts
@@ -224,6 +224,74 @@ test('BMS stringify: handles maxResolution/eol options and controlFlow objects',
   expect(output).toContain('\r\n');
 });
 
+test('BMS stringify: writes optional metadata and sorts extension/resource entries', () => {
+  const json = createEmptyJson('bms');
+  json.metadata.title = 'Sort Check';
+  json.metadata.subtitle = 'Sub';
+  json.metadata.artist = 'Codex';
+  json.metadata.genre = 'Genre';
+  json.metadata.comment = 'Comment';
+  json.metadata.stageFile = 'stage.png';
+  json.metadata.playLevel = 7;
+  json.metadata.rank = 2;
+  json.metadata.total = 320;
+  json.metadata.difficulty = 4;
+  json.metadata.extras = {
+    ZZZ: 'last',
+    AAA: 'first',
+    ARGB0A: 'filtered-argb',
+    CHANGEOPTION01: 'filtered-change',
+    SWBGA01: 'filtered-swbga',
+  };
+
+  json.bms.changeOption = { '0B': 'MIRROR', '0A': 'RANDOM' };
+  json.bms.exRank = { '0B': '120,90,60,30', '0A': '100,80,50,20' };
+  json.bms.exWav = { '0B': 'b.wav', '0A': 'a.wav' };
+  json.bms.exBmp = { '0B': 'b.bmp', '0A': 'a.bmp' };
+  json.bms.swBga = { '0B': '0B', '0A': '0A' };
+
+  json.resources.bpm = { '0B': 180, '0A': 150 };
+  json.resources.stop = { '0B': 64, '0A': 32 };
+
+  json.measures = [
+    { index: 2, length: 0.75 },
+    { index: 1, length: 1.5 },
+    { index: 3, length: 1 },
+  ];
+  json.events = [
+    { measure: 0, channel: '13', position: [0, 1], value: '01' },
+    { measure: 0, channel: '11', position: [0, 1], value: '01' },
+  ];
+
+  const output = stringifyBms(json);
+
+  expect(output).toContain('#SUBTITLE Sub');
+  expect(output).toContain('#PLAYLEVEL 7');
+  expect(output).toContain('#RANK 2');
+  expect(output).toContain('#TOTAL 320');
+  expect(output).toContain('#DIFFICULTY 4');
+  expect(output).toContain('#COMMENT Comment');
+  expect(output).toContain('#STAGEFILE stage.png');
+
+  expect(output.indexOf('#AAA first')).toBeGreaterThan(-1);
+  expect(output.indexOf('#ZZZ last')).toBeGreaterThan(output.indexOf('#AAA first'));
+  expect(output).not.toContain('#ARGB0A filtered-argb');
+  expect(output).not.toContain('#CHANGEOPTION01 filtered-change');
+  expect(output).not.toContain('#SWBGA01 filtered-swbga');
+
+  expect(output.indexOf('#CHANGEOPTION0A RANDOM')).toBeLessThan(output.indexOf('#CHANGEOPTION0B MIRROR'));
+  expect(output.indexOf('#EXRANK0A 100,80,50,20')).toBeLessThan(output.indexOf('#EXRANK0B 120,90,60,30'));
+  expect(output.indexOf('#EXWAV0A a.wav')).toBeLessThan(output.indexOf('#EXWAV0B b.wav'));
+  expect(output.indexOf('#EXBMP0A a.bmp')).toBeLessThan(output.indexOf('#EXBMP0B b.bmp'));
+  expect(output.indexOf('#SWBGA0A 0A')).toBeLessThan(output.indexOf('#SWBGA0B 0B'));
+  expect(output.indexOf('#BPM0A 150')).toBeLessThan(output.indexOf('#BPM0B 180'));
+  expect(output.indexOf('#STOP0A 32')).toBeLessThan(output.indexOf('#STOP0B 64'));
+
+  expect(output.indexOf('#00102:1.5')).toBeLessThan(output.indexOf('#00202:0.75'));
+  expect(output).not.toContain('#00302:1');
+  expect(output.indexOf('#00011:01')).toBeLessThan(output.indexOf('#00013:01'));
+});
+
 test('bmson stringify: handles resolution/version/lines normalization and fallback metadata', () => {
   const json = createEmptyJson('json');
   json.metadata.title = 'Fallback';
@@ -238,12 +306,13 @@ test('bmson stringify: handles resolution/version/lines normalization and fallba
   json.resources.stop['AB'] = 96;
   json.events = [
     { measure: 0, channel: '11', position: [0, 1], value: '01' },
+    { measure: 0, channel: '02', position: [0, 1], value: '01' },
     { measure: 0, channel: '03', position: [0, 1], value: '78' },
     { measure: 0, channel: '08', position: [1, 2], value: 'AA' },
     { measure: 0, channel: '09', position: [3, 4], value: 'AB' },
     { measure: 0, channel: 'AA', position: [0, 1], value: 'FF' },
   ];
-  json.bmson.lines = [960, 0, 960];
+  json.bmson.lines = [960, 960];
   json.bmson.info.subartists = ['A', 'B', ''];
   json.bmson.version = '';
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,30 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
+const rootDir = dirname(fileURLToPath(import.meta.url));
+
+const workspacePackages = ['utils', 'json', 'parser', 'stringifier', 'audio-renderer', 'player', 'editor'] as const;
+
+const workspaceAliases = Object.fromEntries(
+  workspacePackages.map((name) => [`@be-music/${name}`, resolve(rootDir, `packages/${name}/src/index.ts`)]),
+);
+
+const workspaceProjects = workspacePackages.map((name) => ({
+  extends: true as const,
+  test: {
+    name: `@be-music/${name}`,
+    include: [`packages/${name}/src/**/*.test.ts`],
+  },
+}));
+
 export default defineConfig({
+  resolve: {
+    alias: workspaceAliases,
+  },
   test: {
     environment: 'node',
-    include: ['packages/*/src/**/*.test.ts'],
+    projects: workspaceProjects,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'text-summary', 'html', 'lcov'],


### PR DESCRIPTION
## Summary
- switch Vitest to `test.projects` for workspace-aware execution
- resolve `@be-music/*` imports to package source entrypoints in tests to avoid `dist` entry resolution failures
- add editor/stringifier test cases for metadata handling, sorting behavior, and bmson line normalization

## Verification
- npm test
- npm run typecheck
- npm run test:coverage
