### PR TITLE
feat(player): add alien-signals runtime state prototype

### DIFF
--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -38,6 +38,7 @@
     "fast-bmp": "^4.0.1",
     "fast-png": "^8.0.0",
     "jpeg-js": "^0.4.4",
+    "alien-signals": "^3.1.2",
     "node-web-audio-api": "^1.0.8"
   },
   "devDependencies": {

--- a/packages/player/src/core/player-engine.ts
+++ b/packages/player/src/core/player-engine.ts
@@ -92,6 +92,7 @@ export interface PlayerOptions {
   audioLeadStepDownMs?: number;
   tui?: boolean;
   onLoadProgress?: (progress: PlayerLoadProgress) => void;
+  onStateChange?: (snapshot: PlayerRuntimeStateSnapshot) => void;
   onHighSpeedChange?: (highSpeed: number) => void;
   laneModeExtension?: string;
 }
@@ -116,6 +117,20 @@ export interface PlayerLoadProgress {
 }
 
 export type PlayerInterruptReason = 'escape' | 'ctrl-c';
+export type PlayerRuntimeMode = 'auto' | 'manual';
+export type PlayerRuntimePhase = 'loading' | 'ready' | 'playing' | 'paused' | 'result' | 'interrupted';
+
+export interface PlayerRuntimeStateSnapshot {
+  mode: PlayerRuntimeMode;
+  phase: PlayerRuntimePhase;
+  speed: number;
+  highSpeed: number;
+  currentSeconds: number;
+  totalSeconds: number;
+  combo: number;
+  summary: PlayerSummary;
+  interruptedReason?: PlayerInterruptReason;
+}
 
 export class PlayerInterruptedError extends Error {
   readonly reason: PlayerInterruptReason;
@@ -248,6 +263,17 @@ function reportLoadProgress(options: PlayerOptions, ratio: number, message: stri
   });
 }
 
+function reportRuntimeState(options: PlayerOptions, snapshot: PlayerRuntimeStateSnapshot): void {
+  const listener = options.onStateChange;
+  if (!listener) {
+    return;
+  }
+  listener({
+    ...snapshot,
+    summary: { ...snapshot.summary },
+  });
+}
+
 interface AudioSessionLoadProgress {
   ratio: number;
   message: string;
@@ -308,6 +334,24 @@ export async function autoPlay(json: BeMusicJson, options: PlayerOptions = {}): 
   let combo = 0;
   let interruptedReason: PlayerInterruptReason | undefined;
   let highSpeed = resolveHighSpeedMultiplier(options.highSpeed);
+  const emitRuntimeState = (
+    phase: PlayerRuntimePhase,
+    currentSeconds: number,
+    interrupted?: PlayerInterruptReason,
+  ): void => {
+    reportRuntimeState(options, {
+      mode: 'auto',
+      phase,
+      speed,
+      highSpeed,
+      currentSeconds: Math.max(0, currentSeconds),
+      totalSeconds,
+      combo,
+      summary,
+      interruptedReason: interrupted,
+    });
+  };
+  emitRuntimeState('loading', 0);
 
   reportLoadProgress(options, 0.18, 'Preparing BGA...');
   const tui = createTuiIfEnabled(resolvedJson, options, 'AUTO', laneBindings, laneDisplayMode, speed, 0);
@@ -326,6 +370,7 @@ export async function autoPlay(json: BeMusicJson, options: PlayerOptions = {}): 
   });
   const audioBackendLabel = resolveAudioBackendLabel(options, audioSession);
   reportLoadProgress(options, 1, 'Ready');
+  emitRuntimeState('ready', 0);
   const autoDebugAudioEstimator = options.debugActiveAudio
     ? await createDebugActiveAudioEstimator(resolvedJson, options.audioBaseDir)
     : undefined;
@@ -377,6 +422,12 @@ export async function autoPlay(json: BeMusicJson, options: PlayerOptions = {}): 
   const canCaptureInput = process.stdin.isTTY;
   let inputCaptureStopped = false;
   let playbackClock: PlaybackClock | undefined;
+  const resolvePlaybackSeconds = (): number => {
+    if (!playbackClock) {
+      return 0;
+    }
+    return elapsedMsToGameSeconds(playbackClock.nowMs(), speed);
+  };
 
   const stopInputCapture = (): void => {
     if (!canCaptureInput || inputCaptureStopped) {
@@ -397,6 +448,7 @@ export async function autoPlay(json: BeMusicJson, options: PlayerOptions = {}): 
       }
       audioSession?.resume();
       tui?.setPaused(false);
+      emitRuntimeState('playing', resolvePlaybackSeconds());
       if (!tui) {
         process.stdout.write('RESUME\n');
       }
@@ -408,6 +460,7 @@ export async function autoPlay(json: BeMusicJson, options: PlayerOptions = {}): 
     }
     audioSession?.pause();
     tui?.setPaused(true);
+    emitRuntimeState('paused', resolvePlaybackSeconds());
     if (!tui) {
       process.stdout.write('PAUSE\n');
     }
@@ -434,6 +487,8 @@ export async function autoPlay(json: BeMusicJson, options: PlayerOptions = {}): 
         highSpeed = nextHighSpeed;
         tui?.setHighSpeed(highSpeed);
         options.onHighSpeedChange?.(highSpeed);
+        const phase = playbackClock ? (playbackClock.isPaused() ? 'paused' : 'playing') : 'ready';
+        emitRuntimeState(phase, resolvePlaybackSeconds());
       }
       if (!tui) {
         process.stdout.write(`HIGH-SPEED x${highSpeed.toFixed(1)}\n`);
@@ -461,6 +516,7 @@ export async function autoPlay(json: BeMusicJson, options: PlayerOptions = {}): 
         performance.now() + audioOffsetMs + (audioSession?.chartStartDelayMs ?? 0),
       );
       playbackClock = chartClock;
+      emitRuntimeState('playing', 0);
       const badWindowSeconds = IIDX_BAD_WINDOW_MS / 1000;
       let landmineExpireCursor = 0;
       let invisibleExpireCursor = 0;
@@ -504,6 +560,7 @@ export async function autoPlay(json: BeMusicJson, options: PlayerOptions = {}): 
             return;
           }
           if (chartClock.isPaused()) {
+            emitRuntimeState('paused', elapsedMsToGameSeconds(nowMs, speed));
             await waitPrecise(PAUSE_POLL_INTERVAL_MS);
             continue;
           }
@@ -521,6 +578,7 @@ export async function autoPlay(json: BeMusicJson, options: PlayerOptions = {}): 
             ...resolveDebugActiveAudioState(nowSec),
             ...createBgaRenderFrame(bgaRenderer, nowSec),
           });
+          emitRuntimeState('playing', nowSec);
           await waitPrecise(Math.max(1, Math.min(TUI_FRAME_INTERVAL_MS, targetMs - nowMs)));
         }
       };
@@ -564,6 +622,7 @@ export async function autoPlay(json: BeMusicJson, options: PlayerOptions = {}): 
 
         markExpiredLandmines(note.seconds);
         markExpiredInvisibleNotes(note.seconds);
+        emitRuntimeState('playing', note.seconds);
       }
 
       if (!interruptedReason) {
@@ -587,9 +646,13 @@ export async function autoPlay(json: BeMusicJson, options: PlayerOptions = {}): 
           ...resolveDebugActiveAudioState(totalSeconds),
           ...createBgaRenderFrame(bgaRenderer, totalSeconds),
         });
+        emitRuntimeState('result', totalSeconds);
       }
     }
   } finally {
+    if (interruptedReason) {
+      emitRuntimeState('interrupted', resolvePlaybackSeconds(), interruptedReason);
+    }
     detachBgaResizeHandler();
     if (interruptedReason) {
       await disposeAudioSessionSafely(audioSession);
@@ -659,6 +722,24 @@ export async function manualPlay(json: BeMusicJson, options: PlayerOptions = {})
   const scoreTracker = createScoreTracker();
   let combo = 0;
   let highSpeed = resolveHighSpeedMultiplier(options.highSpeed);
+  const emitRuntimeState = (
+    phase: PlayerRuntimePhase,
+    currentSeconds: number,
+    interrupted?: PlayerInterruptReason,
+  ): void => {
+    reportRuntimeState(options, {
+      mode: 'manual',
+      phase,
+      speed,
+      highSpeed,
+      currentSeconds: Math.max(0, currentSeconds),
+      totalSeconds,
+      combo,
+      summary,
+      interruptedReason: interrupted,
+    });
+  };
+  emitRuntimeState('loading', 0);
 
   reportLoadProgress(options, 0.18, 'Preparing BGA...');
   const tui = createTuiIfEnabled(
@@ -685,6 +766,7 @@ export async function manualPlay(json: BeMusicJson, options: PlayerOptions = {})
   });
   const audioBackendLabel = resolveAudioBackendLabel(options, audioSession);
   reportLoadProgress(options, 1, 'Ready');
+  emitRuntimeState('ready', 0);
   const resolveDebugActiveAudioState = (): { activeAudioFiles?: string[]; activeAudioVoiceCount?: number } => {
     if (options.debugActiveAudio !== true) {
       return {};
@@ -737,6 +819,8 @@ export async function manualPlay(json: BeMusicJson, options: PlayerOptions = {})
   audioSession?.start();
 
   const playbackClock = createPlaybackClock(performance.now() + audioOffsetMs + (audioSession?.chartStartDelayMs ?? 0));
+  const resolvePlaybackSeconds = (): number => elapsedMsToGameSeconds(playbackClock.nowMs(), speed);
+  emitRuntimeState('playing', 0);
   const horizon = (totalSeconds * 1000) / speed + leadInMs + badWindowMs + 1000;
   let interruptedReason: PlayerInterruptReason | undefined;
   const longHoldUntilMsByChannel = new Map<string, number>();
@@ -1066,6 +1150,7 @@ export async function manualPlay(json: BeMusicJson, options: PlayerOptions = {})
       highSpeed = nextHighSpeed;
       tui?.setHighSpeed(highSpeed);
       options.onHighSpeedChange?.(highSpeed);
+      emitRuntimeState(playbackClock.isPaused() ? 'paused' : 'playing', resolvePlaybackSeconds());
     }
     if (!tui) {
       process.stdout.write(`HIGH-SPEED x${highSpeed.toFixed(1)}\n`);
@@ -1080,6 +1165,7 @@ export async function manualPlay(json: BeMusicJson, options: PlayerOptions = {})
       }
       audioSession?.resume();
       tui?.setPaused(false);
+      emitRuntimeState('playing', resolvePlaybackSeconds());
       if (!tui) {
         process.stdout.write('RESUME\n');
       }
@@ -1090,6 +1176,7 @@ export async function manualPlay(json: BeMusicJson, options: PlayerOptions = {})
     }
     audioSession?.pause();
     tui?.setPaused(true);
+    emitRuntimeState('paused', resolvePlaybackSeconds());
     if (!tui) {
       process.stdout.write('PAUSE\n');
     }
@@ -1219,6 +1306,7 @@ export async function manualPlay(json: BeMusicJson, options: PlayerOptions = {})
           ...resolveDebugActiveAudioState(),
           ...createBgaRenderFrame(bgaRenderer, nowSec),
         });
+        emitRuntimeState('paused', nowSec);
         await waitPrecise(PAUSE_POLL_INTERVAL_MS);
         continue;
       }
@@ -1268,6 +1356,7 @@ export async function manualPlay(json: BeMusicJson, options: PlayerOptions = {})
         ...resolveDebugActiveAudioState(),
         ...createBgaRenderFrame(bgaRenderer, nowSec),
       });
+      emitRuntimeState('playing', nowSec);
 
       markExpiredLandmines(nowSec);
       markExpiredInvisibleNotes(nowSec);
@@ -1309,6 +1398,9 @@ export async function manualPlay(json: BeMusicJson, options: PlayerOptions = {})
       }
     }
   } finally {
+    if (interruptedReason) {
+      emitRuntimeState('interrupted', resolvePlaybackSeconds(), interruptedReason);
+    }
     detachBgaResizeHandler();
     if (interruptedReason) {
       await disposeAudioSessionSafely(audioSession);
@@ -1321,12 +1413,14 @@ export async function manualPlay(json: BeMusicJson, options: PlayerOptions = {})
 
   if (interruptedReason) {
     if (interruptedReason === 'escape') {
+      emitRuntimeState('result', resolvePlaybackSeconds());
       process.stdout.write(renderSummary(summary));
       return summary;
     }
     throw new PlayerInterruptedError(interruptedReason);
   }
 
+  emitRuntimeState('result', totalSeconds);
   process.stdout.write(renderSummary(summary));
   return summary;
 }

--- a/packages/player/src/core/player-signals.ts
+++ b/packages/player/src/core/player-signals.ts
@@ -1,0 +1,184 @@
+import { computed, effect, signal } from 'alien-signals';
+import type {
+  PlayerInterruptReason,
+  PlayerLoadProgress,
+  PlayerOptions,
+  PlayerRuntimeMode,
+  PlayerRuntimePhase,
+  PlayerSummary,
+} from './player-engine.ts';
+
+export interface PlayerSignalsState {
+  mode: PlayerRuntimeMode;
+  phase: PlayerRuntimePhase;
+  speed: number;
+  highSpeed: number;
+  currentSeconds: number;
+  totalSeconds: number;
+  combo: number;
+  summary: PlayerSummary;
+  loadProgress: PlayerLoadProgress | null;
+  interruptedReason?: PlayerInterruptReason;
+}
+
+export interface PlayerStateSignals {
+  state: () => PlayerSignalsState;
+  phase: () => PlayerRuntimePhase;
+  isPlaying: () => boolean;
+  isPaused: () => boolean;
+  progressRatio: () => number;
+  progressPercent: () => number;
+  options: PlayerOptions;
+  subscribe: (listener: (state: PlayerSignalsState) => void) => () => void;
+  reset: () => void;
+}
+
+function createEmptySummary(total = 0): PlayerSummary {
+  return {
+    total,
+    perfect: 0,
+    fast: 0,
+    slow: 0,
+    great: 0,
+    good: 0,
+    bad: 0,
+    poor: 0,
+    exScore: 0,
+    score: 0,
+  };
+}
+
+function cloneSummary(summary: PlayerSummary): PlayerSummary {
+  return {
+    total: summary.total,
+    perfect: summary.perfect,
+    fast: summary.fast,
+    slow: summary.slow,
+    great: summary.great,
+    good: summary.good,
+    bad: summary.bad,
+    poor: summary.poor,
+    exScore: summary.exScore,
+    score: summary.score,
+  };
+}
+
+function cloneState(state: PlayerSignalsState): PlayerSignalsState {
+  return {
+    ...state,
+    summary: cloneSummary(state.summary),
+    loadProgress: state.loadProgress ? { ...state.loadProgress } : null,
+  };
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(1, value));
+}
+
+function createInitialState(options: PlayerOptions): PlayerSignalsState {
+  return {
+    mode: options.auto ? 'auto' : 'manual',
+    phase: 'loading',
+    speed: options.speed ?? 1,
+    highSpeed: options.highSpeed ?? 1,
+    currentSeconds: 0,
+    totalSeconds: 0,
+    combo: 0,
+    summary: createEmptySummary(),
+    loadProgress: null,
+    interruptedReason: undefined,
+  };
+}
+
+export function createPlayerStateSignals(baseOptions: PlayerOptions = {}): PlayerStateSignals {
+  const initialState = createInitialState(baseOptions);
+  const state = signal<PlayerSignalsState>(cloneState(initialState));
+
+  const setState = (nextState: PlayerSignalsState): void => {
+    state(cloneState(nextState));
+  };
+
+  const updateState = (updater: (current: PlayerSignalsState) => PlayerSignalsState): void => {
+    setState(updater(state()));
+  };
+
+  const onLoadProgress = baseOptions.onLoadProgress;
+  const onStateChange = baseOptions.onStateChange;
+  const onHighSpeedChange = baseOptions.onHighSpeedChange;
+
+  const options: PlayerOptions = {
+    ...baseOptions,
+    onLoadProgress: (progress) => {
+      updateState((current) => ({
+        ...current,
+        loadProgress: {
+          ratio: clamp01(progress.ratio),
+          message: progress.message,
+          detail: progress.detail,
+        },
+      }));
+      onLoadProgress?.(progress);
+    },
+    onStateChange: (snapshot) => {
+      updateState((current) => ({
+        ...current,
+        mode: snapshot.mode,
+        phase: snapshot.phase,
+        speed: snapshot.speed,
+        highSpeed: snapshot.highSpeed,
+        currentSeconds: snapshot.currentSeconds,
+        totalSeconds: snapshot.totalSeconds,
+        combo: snapshot.combo,
+        summary: cloneSummary(snapshot.summary),
+        interruptedReason: snapshot.phase === 'interrupted' ? snapshot.interruptedReason : undefined,
+      }));
+      onStateChange?.(snapshot);
+    },
+    onHighSpeedChange: (highSpeed) => {
+      updateState((current) => ({
+        ...current,
+        highSpeed,
+      }));
+      onHighSpeedChange?.(highSpeed);
+    },
+  };
+
+  const phase = computed(() => state().phase);
+  const isPlaying = computed(() => state().phase === 'playing');
+  const isPaused = computed(() => state().phase === 'paused');
+  const progressRatio = computed(() => {
+    const current = state();
+    if (current.totalSeconds > 0) {
+      return clamp01(current.currentSeconds / current.totalSeconds);
+    }
+    if (current.phase === 'result') {
+      return 1;
+    }
+    return clamp01(current.loadProgress?.ratio ?? 0);
+  });
+  const progressPercent = computed(() => Math.round(progressRatio() * 100));
+
+  const subscribe = (listener: (state: PlayerSignalsState) => void): (() => void) =>
+    effect(() => {
+      listener(cloneState(state()));
+    });
+
+  const reset = (): void => {
+    setState(createInitialState(baseOptions));
+  };
+
+  return {
+    state,
+    phase,
+    isPlaying,
+    isPaused,
+    progressRatio,
+    progressPercent,
+    options,
+    subscribe,
+    reset,
+  };
+}

--- a/packages/player/src/index.test.ts
+++ b/packages/player/src/index.test.ts
@@ -89,6 +89,29 @@ test('player: auto play ignores landmine notes in score totals', async () => {
   expect(summary.poor).toBe(0);
 });
 
+test('player: emits runtime state transitions via onStateChange', async () => {
+  const json = createEmptyJson('bms');
+  json.metadata.bpm = 120;
+  json.events = [{ measure: 0, channel: '11', position: [0, 1], value: '01' }];
+
+  const phases: string[] = [];
+  await autoPlay(json, {
+    auto: true,
+    speed: 48,
+    leadInMs: 0,
+    audio: false,
+    tui: false,
+    onStateChange: (snapshot) => {
+      phases.push(snapshot.phase);
+    },
+  });
+
+  expect(phases[0]).toBe('loading');
+  expect(phases).toContain('ready');
+  expect(phases).toContain('playing');
+  expect(phases.at(-1)).toBe('result');
+});
+
 test('player: ignores free-zone channel for score and judgment totals', async () => {
   const json = createEmptyJson('bms');
   json.metadata.bpm = 120;

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -3,3 +3,4 @@
  * Implementation modules are split under `./core/`.
  */
 export * from './core/player-engine.ts';
+export * from './core/player-signals.ts';

--- a/packages/player/src/player-signals.test.ts
+++ b/packages/player/src/player-signals.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test, vi } from 'vitest';
+import type { PlayerRuntimeStateSnapshot, PlayerSummary } from './index.ts';
+import { createPlayerStateSignals } from './index.ts';
+
+function createSummary(overrides: Partial<PlayerSummary> = {}): PlayerSummary {
+  return {
+    total: 10,
+    perfect: 0,
+    fast: 0,
+    slow: 0,
+    great: 0,
+    good: 0,
+    bad: 0,
+    poor: 0,
+    exScore: 0,
+    score: 0,
+    ...overrides,
+  };
+}
+
+function createSnapshot(overrides: Partial<PlayerRuntimeStateSnapshot> = {}): PlayerRuntimeStateSnapshot {
+  return {
+    mode: 'manual',
+    phase: 'playing',
+    speed: 1,
+    highSpeed: 1,
+    currentSeconds: 10,
+    totalSeconds: 20,
+    combo: 3,
+    summary: createSummary({ great: 2, exScore: 4, score: 40000 }),
+    ...overrides,
+  };
+}
+
+describe('player signals', () => {
+  test('tracks load progress and runtime snapshots', () => {
+    const signals = createPlayerStateSignals();
+
+    signals.options.onLoadProgress?.({
+      ratio: 0.25,
+      message: 'Loading chart',
+    });
+
+    expect(signals.state().loadProgress?.ratio).toBeCloseTo(0.25, 9);
+    expect(signals.progressRatio()).toBeCloseTo(0.25, 9);
+    expect(signals.progressPercent()).toBe(25);
+
+    signals.options.onStateChange?.(
+      createSnapshot({
+        currentSeconds: 12,
+        totalSeconds: 24,
+        highSpeed: 2,
+      }),
+    );
+
+    expect(signals.phase()).toBe('playing');
+    expect(signals.isPlaying()).toBe(true);
+    expect(signals.isPaused()).toBe(false);
+    expect(signals.state().highSpeed).toBe(2);
+    expect(signals.progressRatio()).toBeCloseTo(0.5, 9);
+    expect(signals.progressPercent()).toBe(50);
+    expect(signals.state().summary.great).toBe(2);
+  });
+
+  test('forwards wrapped callbacks while updating signal state', () => {
+    const onLoadProgress = vi.fn();
+    const onStateChange = vi.fn();
+    const onHighSpeedChange = vi.fn();
+    const signals = createPlayerStateSignals({
+      auto: true,
+      onLoadProgress,
+      onStateChange,
+      onHighSpeedChange,
+    });
+
+    const snapshot = createSnapshot({ mode: 'auto', phase: 'paused' });
+    signals.options.onLoadProgress?.({ ratio: 0.6, message: 'Audio ready' });
+    signals.options.onStateChange?.(snapshot);
+    signals.options.onHighSpeedChange?.(3.5);
+
+    expect(onLoadProgress).toHaveBeenCalledTimes(1);
+    expect(onStateChange).toHaveBeenCalledWith(snapshot);
+    expect(onHighSpeedChange).toHaveBeenCalledWith(3.5);
+    expect(signals.state().mode).toBe('auto');
+    expect(signals.state().phase).toBe('paused');
+    expect(signals.state().highSpeed).toBe(3.5);
+  });
+
+  test('subscribe receives updates and reset restores initial state', () => {
+    const signals = createPlayerStateSignals({ auto: true, speed: 2, highSpeed: 4 });
+    const phases: string[] = [];
+    const stop = signals.subscribe((state) => {
+      phases.push(state.phase);
+    });
+
+    signals.options.onStateChange?.(createSnapshot({ mode: 'auto', phase: 'playing' }));
+    signals.reset();
+    stop();
+
+    expect(phases[0]).toBe('loading');
+    expect(phases).toContain('playing');
+    expect(signals.state().mode).toBe('auto');
+    expect(signals.state().phase).toBe('loading');
+    expect(signals.state().speed).toBe(2);
+    expect(signals.state().highSpeed).toBe(4);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       '@uwx/libav.js-fat':
         specifier: 6.0.0-nightly.29.f420ff.ffmpeg.6.1.1
         version: 6.0.0-nightly.29.f420ff.ffmpeg.6.1.1
+      alien-signals:
+        specifier: ^3.1.2
+        version: 3.1.2
       fast-bmp:
         specifier: ^4.0.1
         version: 4.0.1
@@ -921,6 +924,9 @@ packages:
 
   '@wasm-audio-decoders/opus-ml@0.0.2':
     resolution: {integrity: sha512-58rWEqDGg+CKCyEeKm2KoxxSwTWtHh/NLTW9ObR4K8CGF6VwuuGudEI1CtniS/oSRmL1nJq/eh8MKARiluw4DQ==}
+
+  alien-signals@3.1.2:
+    resolution: {integrity: sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -1901,6 +1907,8 @@ snapshots:
   '@wasm-audio-decoders/opus-ml@0.0.2':
     dependencies:
       '@wasm-audio-decoders/common': 9.0.7
+
+  alien-signals@3.1.2: {}
 
   assertion-error@2.0.1: {}
 


### PR DESCRIPTION
## Summary
- add runtime state snapshot API (`onStateChange`) to player options
- emit runtime phases from auto/manual play loops (`loading`, `ready`, `playing`, `paused`, `result`, `interrupted`)
- add `createPlayerStateSignals()` adapter using `alien-signals`
- export the new adapter from package entrypoint
- add tests for runtime state transitions and signal adapter behavior

## Verification
- npx pnpm --filter @be-music/player run typecheck
- npx pnpm --filter @be-music/player exec vitest run src/player-signals.test.ts src/index.test.ts
- npx pnpm --filter @be-music/player run build
