### PR TITLE
Refactor shared runtime helpers and streamline hot paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,41 +190,17 @@ jobs:
         with:
           script: |
             const fs = require('node:fs');
-            const marker = '<!-- be-music-exports-benchmark -->';
-            const body = fs.readFileSync('tmp/bench/pr-benchmark.md', 'utf8').trim();
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const body = `${fs.readFileSync('tmp/bench/pr-benchmark.md', 'utf8').trim()}\n\n- Workflow run: [#${process.env.GITHUB_RUN_NUMBER}](${runUrl})`;
             const issue_number = context.issue.number;
             const { owner, repo } = context.repo;
 
-            const comments = await github.paginate(github.rest.issues.listComments, {
+            await github.rest.issues.createComment({
               owner,
               repo,
               issue_number,
-              per_page: 100,
+              body,
             });
-
-            const existing = comments.find((comment) => {
-              return (
-                comment.user?.type === 'Bot' &&
-                typeof comment.body === 'string' &&
-                comment.body.includes(marker)
-              );
-            });
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number,
-                body,
-              });
-            }
 
   sea:
     name: SEA (${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,17 +190,41 @@ jobs:
         with:
           script: |
             const fs = require('node:fs');
-            const runUrl = `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
-            const body = `${fs.readFileSync('tmp/bench/pr-benchmark.md', 'utf8').trim()}\n\n- Workflow run: [#${process.env.GITHUB_RUN_NUMBER}](${runUrl})`;
+            const marker = '<!-- be-music-exports-benchmark -->';
+            const body = fs.readFileSync('tmp/bench/pr-benchmark.md', 'utf8').trim();
             const issue_number = context.issue.number;
             const { owner, repo } = context.repo;
 
-            await github.rest.issues.createComment({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner,
               repo,
               issue_number,
-              body,
+              per_page: 100,
             });
+
+            const existing = comments.find((comment) => {
+              return (
+                comment.user?.type === 'Bot' &&
+                typeof comment.body === 'string' &&
+                comment.body.includes(marker)
+              );
+            });
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
 
   sea:
     name: SEA (${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -139,7 +140,7 @@ jobs:
         run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Run head benchmark
-        run: pnpm run bench --output tmp/bench/head.json --time "$BENCH_TIME_MS" --warmup-time "$BENCH_WARMUP_TIME_MS"
+        run: BENCH_GIT_SHA="${{ github.event.pull_request.head.sha }}" pnpm run bench --output tmp/bench/head.json --time "$BENCH_TIME_MS" --warmup-time "$BENCH_WARMUP_TIME_MS"
 
       - name: Run base benchmark
         id: base-benchmark
@@ -165,7 +166,7 @@ jobs:
           if (
             cd "$BASE_DIR"
             pnpm install --frozen-lockfile --prefer-offline
-            pnpm run bench --output tmp/bench/base.json --time "$BENCH_TIME_MS" --warmup-time "$BENCH_WARMUP_TIME_MS"
+            BENCH_GIT_SHA="$BASE_SHA" pnpm run bench --output tmp/bench/base.json --time "$BENCH_TIME_MS" --warmup-time "$BENCH_WARMUP_TIME_MS"
           ); then
             mkdir -p tmp/bench
             cp "$BASE_DIR/tmp/bench/base.json" tmp/bench/base.json

--- a/packages/audio-renderer/src/core/audio-decode.ts
+++ b/packages/audio-renderer/src/core/audio-decode.ts
@@ -1,6 +1,6 @@
 import { extname } from 'node:path';
 import { OggVorbisDecoder } from '@wasm-audio-decoders/ogg-vorbis';
-import { clampSignedUnit, throwIfAborted } from '@be-music/utils';
+import { clampSignedUnit, isAbortError, throwIfAborted } from '@be-music/utils';
 import { MPEGDecoder } from 'mpg123-decoder';
 import { OggOpusDecoder } from 'ogg-opus-decoder';
 
@@ -372,8 +372,4 @@ async function withSuppressedMpg123Warnings<T>(fn: () => Promise<T>): Promise<T>
     console.error = originalConsoleError;
     process.stderr.write = originalStderrWrite;
   }
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof Error && error.name === 'AbortError';
 }

--- a/packages/audio-renderer/src/core/audio-engine.ts
+++ b/packages/audio-renderer/src/core/audio-engine.ts
@@ -16,7 +16,7 @@ import {
   type BeMusicEvent,
   type BeMusicJson,
 } from '@be-music/json';
-import { findLastIndexAtOrBefore, findLastIndexBefore, throwIfAborted } from '@be-music/utils';
+import { findLastIndexAtOrBefore, findLastIndexBefore, isAbortError, throwIfAborted } from '@be-music/utils';
 import { parseChartFile, resolveBmsControlFlow } from '@be-music/parser';
 import { detectAudioFormat, encodeAiff16, encodeWav16 } from './audio-file-codec.ts';
 import { createFallbackTone, decodeAudioSample, resampleLinear } from './audio-decode.ts';
@@ -700,10 +700,6 @@ function mixSample(
     destinationLeft[target] += sourceLeft[source] * gain;
     destinationRight[target] += sourceRight[source] * gain;
   }
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof Error && error.name === 'AbortError';
 }
 
 function createBmsonSamplePlaybackMap(

--- a/packages/audio-renderer/src/core/audio-file-codec.ts
+++ b/packages/audio-renderer/src/core/audio-file-codec.ts
@@ -1,5 +1,5 @@
 import { extname } from 'node:path';
-import { floatToInt16 } from '@be-music/utils';
+import { writeStereoPcm16Be, writeStereoPcm16Le } from '@be-music/utils';
 
 export type AudioFileFormat = 'wav' | 'aiff';
 
@@ -20,7 +20,7 @@ export function detectAudioFormat(path: string): AudioFileFormat {
 export function encodeWav16(result: StereoRenderResult): Buffer {
   const frameCount = Math.min(result.left.length, result.right.length);
   const dataSize = frameCount * 4;
-  const buffer = Buffer.alloc(44 + dataSize);
+  const buffer = Buffer.allocUnsafe(44 + dataSize);
 
   buffer.write('RIFF', 0, 4, 'ascii');
   buffer.writeUInt32LE(36 + dataSize, 4);
@@ -36,12 +36,7 @@ export function encodeWav16(result: StereoRenderResult): Buffer {
   buffer.write('data', 36, 4, 'ascii');
   buffer.writeUInt32LE(dataSize, 40);
 
-  let pointer = 44;
-  for (let index = 0; index < frameCount; index += 1) {
-    buffer.writeInt16LE(floatToInt16(result.left[index]), pointer);
-    buffer.writeInt16LE(floatToInt16(result.right[index]), pointer + 2);
-    pointer += 4;
-  }
+  writeStereoPcm16Le(buffer, 44, result.left, result.right, 0, frameCount);
 
   return buffer;
 }
@@ -52,7 +47,7 @@ export function encodeAiff16(result: StereoRenderResult): Buffer {
   const ssndSize = 8 + dataSize;
   const formSize = 4 + (8 + 18) + (8 + ssndSize);
 
-  const buffer = Buffer.alloc(8 + formSize);
+  const buffer = Buffer.allocUnsafe(8 + formSize);
   let pointer = 0;
 
   buffer.write('FORM', pointer, 4, 'ascii');
@@ -84,11 +79,7 @@ export function encodeAiff16(result: StereoRenderResult): Buffer {
   buffer.writeUInt32BE(0, pointer);
   pointer += 4;
 
-  for (let index = 0; index < frameCount; index += 1) {
-    buffer.writeInt16BE(floatToInt16(result.left[index]), pointer);
-    buffer.writeInt16BE(floatToInt16(result.right[index]), pointer + 2);
-    pointer += 4;
-  }
+  writeStereoPcm16Be(buffer, pointer, result.left, result.right, 0, frameCount);
 
   return buffer;
 }

--- a/packages/audio-renderer/src/core/sample-path.ts
+++ b/packages/audio-renderer/src/core/sample-path.ts
@@ -1,23 +1,12 @@
-import { access } from 'node:fs/promises';
-import { extname, isAbsolute, resolve } from 'node:path';
-import { throwIfAborted } from '@be-music/utils';
+import { extname } from 'node:path';
+import { resolveFirstExistingPath } from '@be-music/utils';
 
 export async function resolveSamplePath(
   baseDir: string,
   samplePath: string,
   signal?: AbortSignal,
 ): Promise<string | undefined> {
-  const candidates = createSamplePathCandidates(samplePath);
-
-  for (const candidate of candidates) {
-    throwIfAborted(signal);
-    const absolute = isAbsolute(candidate) ? candidate : resolve(baseDir, candidate);
-    if (await exists(absolute, signal)) {
-      return absolute;
-    }
-  }
-
-  return undefined;
+  return resolveFirstExistingPath(baseDir, createSamplePathCandidates(samplePath), signal);
 }
 
 function createSamplePathCandidates(samplePath: string): string[] {
@@ -111,18 +100,4 @@ function appendSampleCandidatesByRule(samplePath: string, push: (candidatePath: 
   push(`${withoutExtension}.OGA`);
   push(`${withoutExtension}.opus`);
   push(`${withoutExtension}.OPUS`);
-}
-
-async function exists(filePath: string, signal?: AbortSignal): Promise<boolean> {
-  try {
-    throwIfAborted(signal);
-    await access(filePath);
-    throwIfAborted(signal);
-    return true;
-  } catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') {
-      throw error;
-    }
-    return false;
-  }
 }

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -1,9 +1,10 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import { extname, resolve } from 'node:path';
 import {
+  BMS_JSON_FORMAT,
   DEFAULT_BPM,
+  cloneJson,
   compareEvents,
-  createEmptyJson,
   ensureMeasure,
   normalizeChannel,
   normalizeObjectKey,
@@ -24,7 +25,8 @@ export async function loadJsonFile(filePath: string): Promise<BeMusicJson> {
 }
 
 export async function saveJsonFile(filePath: string, json: BeMusicJson): Promise<void> {
-  await writeFile(resolve(filePath), `${JSON.stringify(normalizeJson(json), null, 2)}\n`, 'utf8');
+  const normalized = canSerializeJsonAsIs(json) ? json : normalizeJson(json);
+  await writeFile(resolve(filePath), `${JSON.stringify(normalized, null, 2)}\n`, 'utf8');
 }
 
 export async function exportChart(filePath: string, json: BeMusicJson): Promise<void> {
@@ -149,11 +151,50 @@ export function listNotes(json: BeMusicJson, measure?: number): BeMusicEvent[] {
 }
 
 export function createBlankJson(): BeMusicJson {
-  return createEmptyJson('json');
+  return {
+    format: BMS_JSON_FORMAT,
+    sourceFormat: 'json',
+    metadata: {
+      bpm: DEFAULT_BPM,
+      extras: {},
+    },
+    resources: {
+      wav: {},
+      bmp: {},
+      bpm: {},
+      stop: {},
+      text: {},
+    },
+    measures: [],
+    events: [],
+    bms: {
+      controlFlow: [],
+      lnObjs: [],
+      exRank: {},
+      argb: {},
+      stp: [],
+      changeOption: {},
+      exWav: {},
+      exBmp: {},
+      bga: {},
+      scroll: {},
+      swBga: {},
+    },
+    bmson: {
+      lines: [],
+      info: {},
+      bga: {
+        header: [],
+        events: [],
+        layerEvents: [],
+        poorEvents: [],
+      },
+    },
+  };
 }
 
 function normalizeJson(json: BeMusicJson): BeMusicJson {
-  const cloned = structuredClone(json);
+  const cloned = canCloneJsonFast(json) ? cloneJson(json) : structuredClone(json);
   if (!cloned.metadata) {
     cloned.metadata = {
       bpm: DEFAULT_BPM,
@@ -175,11 +216,95 @@ function normalizeJson(json: BeMusicJson): BeMusicJson {
   cloned.resources.bpm = cloned.resources.bpm ?? {};
   cloned.resources.stop = cloned.resources.stop ?? {};
   cloned.resources.text = cloned.resources.text ?? {};
-  cloned.measures = (cloned.measures ?? []).filter(
-    (measure) => Number.isFinite(measure.index) && Number.isFinite(measure.length),
-  );
-  cloned.events = sortEvents(cloned.events ?? []);
+  if (!hasOnlyFiniteMeasures(cloned.measures)) {
+    cloned.measures = (cloned.measures ?? []).filter(
+      (measure) => Number.isFinite(measure.index) && Number.isFinite(measure.length),
+    );
+  }
+  if (!areEventsSorted(cloned.events)) {
+    cloned.events = sortEvents(cloned.events ?? []);
+  }
   return cloned;
+}
+
+function canSerializeJsonAsIs(json: BeMusicJson): boolean {
+  return (
+    json.format === BMS_JSON_FORMAT &&
+    json.metadata !== undefined &&
+    Number.isFinite(json.metadata.bpm) &&
+    json.metadata.bpm > 0 &&
+    json.metadata.extras !== undefined &&
+    json.resources !== undefined &&
+    json.resources.wav !== undefined &&
+    json.resources.bmp !== undefined &&
+    json.resources.bpm !== undefined &&
+    json.resources.stop !== undefined &&
+    json.resources.text !== undefined &&
+    Array.isArray(json.measures) &&
+    hasOnlyFiniteMeasures(json.measures) &&
+    Array.isArray(json.events) &&
+    areEventsSorted(json.events)
+  );
+}
+
+function canCloneJsonFast(json: BeMusicJson): boolean {
+  return (
+    json.metadata !== undefined &&
+    json.metadata.extras !== undefined &&
+    json.resources !== undefined &&
+    json.resources.wav !== undefined &&
+    json.resources.bmp !== undefined &&
+    json.resources.bpm !== undefined &&
+    json.resources.stop !== undefined &&
+    json.resources.text !== undefined &&
+    Array.isArray(json.measures) &&
+    Array.isArray(json.events) &&
+    json.bms !== undefined &&
+    Array.isArray(json.bms.controlFlow) &&
+    (json.bms.lnObjs === undefined || Array.isArray(json.bms.lnObjs)) &&
+    json.bms.exRank !== undefined &&
+    json.bms.argb !== undefined &&
+    Array.isArray(json.bms.stp) &&
+    json.bms.changeOption !== undefined &&
+    json.bms.exWav !== undefined &&
+    json.bms.exBmp !== undefined &&
+    json.bms.bga !== undefined &&
+    json.bms.scroll !== undefined &&
+    json.bms.swBga !== undefined &&
+    json.bmson !== undefined &&
+    Array.isArray(json.bmson.lines) &&
+    json.bmson.info !== undefined &&
+    json.bmson.bga !== undefined &&
+    Array.isArray(json.bmson.bga.header) &&
+    Array.isArray(json.bmson.bga.events) &&
+    Array.isArray(json.bmson.bga.layerEvents) &&
+    Array.isArray(json.bmson.bga.poorEvents)
+  );
+}
+
+function hasOnlyFiniteMeasures(measures: BeMusicJson['measures'] | undefined): boolean {
+  if (!Array.isArray(measures)) {
+    return false;
+  }
+  for (let index = 0; index < measures.length; index += 1) {
+    const measure = measures[index]!;
+    if (!Number.isFinite(measure.index) || !Number.isFinite(measure.length)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function areEventsSorted(events: BeMusicJson['events'] | undefined): boolean {
+  if (!Array.isArray(events)) {
+    return false;
+  }
+  for (let index = 1; index < events.length; index += 1) {
+    if (compareEvents(events[index - 1]!, events[index]!) > 0) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function normalizePositionFraction(numerator: number, denominator: number): { numerator: number; denominator: number } {

--- a/packages/json/src/index.test.ts
+++ b/packages/json/src/index.test.ts
@@ -133,6 +133,21 @@ test('json: ensureMeasure / getMeasureBeats', () => {
     expect(resolver.eventToBeat(event)).toBe(12);
   });
 
+  test('json: createBeatResolver handles charts without explicit measure lengths', () => {
+    const json = createEmptyJson();
+    const resolver = createBeatResolver(json);
+
+    expect(resolver.measureToBeat(3, 0.5)).toBe(14);
+    expect(
+      resolver.eventToBeat({
+        measure: 2,
+        channel: '11',
+        position: [1, 4],
+        value: '01',
+      }),
+    ).toBe(9);
+  });
+
 test('json: sortEvents stabilizes by measure/position/channel/value order', () => {
     const events: BeMusicEvent[] = [
       { measure: 1, channel: '12', position: [1, 3], value: '02' },
@@ -165,12 +180,14 @@ test('json: sortEvents stabilizes by measure/position/channel/value order', () =
 test('json: classifies channel types', () => {
   expect(isTempoChannel('03')).toBe(true);
   expect(isTempoChannel('08')).toBe(true);
+  expect(isTempoChannel('sc')).toBe(false);
   expect(isTempoChannel('11')).toBe(false);
 
     expect(isStopChannel('09')).toBe(true);
     expect(isStopChannel('19')).toBe(false);
 
     expect(isScrollChannel('SC')).toBe(true);
+    expect(isScrollChannel('sc')).toBe(true);
     expect(isScrollChannel('11')).toBe(false);
 
     expect(isLandmineChannel('D1')).toBe(true);
@@ -191,10 +208,12 @@ test('json: classifies channel types', () => {
   expect(isPlayableChannel('01')).toBe(false);
 
   expect(isBmsLongNoteChannel('51')).toBe(true);
+  expect(isBmsLongNoteChannel('6a')).toBe(false);
   expect(isBmsLongNoteChannel('69')).toBe(true);
   expect(isBmsLongNoteChannel('5A')).toBe(false);
   expect(isBmsLongNoteChannel('11')).toBe(false);
   expect(mapBmsLongNoteChannelToPlayable('51')).toBe('11');
+  expect(mapBmsLongNoteChannelToPlayable('61')).toBe('21');
   expect(mapBmsLongNoteChannelToPlayable('69')).toBe('29');
   expect(mapBmsLongNoteChannelToPlayable('5A')).toBeUndefined();
 });

--- a/packages/json/src/index.ts
+++ b/packages/json/src/index.ts
@@ -1,4 +1,4 @@
-import { compareFractions, normalizeAsciiBase36Code } from '@be-music/utils';
+import { normalizeAsciiBase36Code } from '@be-music/utils';
 
 export const BMS_JSON_FORMAT = 'be-music-json/0.1.0' as const;
 
@@ -180,6 +180,11 @@ const BASE36_PAD_1_DIVISOR = 36;
 const BASE36_PAD_2_DIVISOR = BASE36_PAD_1_DIVISOR * BASE36_PAD_1_DIVISOR;
 const BMS_LONG_NOTE_PLAYABLE_1P = ['11', '12', '13', '14', '15', '16', '17', '18', '19'] as const;
 const BMS_LONG_NOTE_PLAYABLE_2P = ['21', '22', '23', '24', '25', '26', '27', '28', '29'] as const;
+const PACKED_CHANNEL_01 = 0x3031;
+const PACKED_CHANNEL_03 = 0x3033;
+const PACKED_CHANNEL_08 = 0x3038;
+const PACKED_CHANNEL_09 = 0x3039;
+const PACKED_CHANNEL_SC = 0x5343;
 
 export function createEmptyJson(sourceFormat: BeMusicSourceFormat = 'bms'): BeMusicJson {
   return {
@@ -453,34 +458,71 @@ export function compareEvents(left: BeMusicEvent, right: BeMusicEvent): number {
 }
 
 export function isTempoChannel(channel: string): boolean {
+  const packed = tryPackNormalizedChannel(channel);
+  if (packed >= 0) {
+    return packed === PACKED_CHANNEL_03 || packed === PACKED_CHANNEL_08;
+  }
   return isTempoNormalizedChannel(resolveNormalizedChannelForPredicate(channel));
 }
 
 export function isStopChannel(channel: string): boolean {
+  const packed = tryPackNormalizedChannel(channel);
+  if (packed >= 0) {
+    return packed === PACKED_CHANNEL_09;
+  }
   return isStopNormalizedChannel(resolveNormalizedChannelForPredicate(channel));
 }
 
 export function isScrollChannel(channel: string): boolean {
+  const packed = tryPackNormalizedChannel(channel);
+  if (packed >= 0) {
+    return packed === PACKED_CHANNEL_SC;
+  }
   return isScrollNormalizedChannel(resolveNormalizedChannelForPredicate(channel));
 }
 
 export function isLandmineChannel(channel: string): boolean {
+  const packed = tryPackNormalizedChannel(channel);
+  if (packed >= 0) {
+    return isPackedLandmineChannel(packed);
+  }
   return isLandmineNormalizedChannel(resolveNormalizedChannelForPredicate(channel));
 }
 
 export function isSampleTriggerChannel(channel: string): boolean {
+  const packed = tryPackNormalizedChannel(channel);
+  if (packed >= 0) {
+    return isPackedSampleTriggerChannel(packed);
+  }
   return isSampleTriggerNormalizedChannel(resolveNormalizedChannelForPredicate(channel));
 }
 
 export function isPlayableChannel(channel: string): boolean {
+  const packed = tryPackNormalizedChannel(channel);
+  if (packed >= 0) {
+    return isPackedPlayableChannel(packed);
+  }
   return isPlayableNormalizedChannel(resolveNormalizedChannelForPredicate(channel));
 }
 
 export function isBmsLongNoteChannel(channel: string): boolean {
+  const packed = tryPackNormalizedChannel(channel);
+  if (packed >= 0) {
+    return isPackedBmsLongNoteChannel(packed);
+  }
   return isBmsLongNoteNormalizedChannel(resolveNormalizedChannelForPredicate(channel));
 }
 
 export function mapBmsLongNoteChannelToPlayable(channel: string): string | undefined {
+  const packed = tryPackNormalizedChannel(channel);
+  if (packed >= 0) {
+    if (!isPackedBmsLongNoteChannel(packed)) {
+      return undefined;
+    }
+    const high = ((packed >> 8) & 0xff) - 4;
+    const low = packed & 0xff;
+    return String.fromCharCode(high, low);
+  }
   return mapBmsLongNoteNormalizedChannelToPlayable(resolveNormalizedChannelForPredicate(channel));
 }
 
@@ -880,7 +922,31 @@ function compareEventPosition(left: BeMusicEvent, right: BeMusicEvent): number {
   const leftNumerator = normalizePositionNumerator(left.position[0], leftDenominator);
   const rightDenominator = normalizePositionDenominator(right.position[1]);
   const rightNumerator = normalizePositionNumerator(right.position[0], rightDenominator);
-  return compareFractions(leftNumerator, leftDenominator, rightNumerator, rightDenominator);
+  if (leftDenominator === rightDenominator) {
+    return leftNumerator - rightNumerator;
+  }
+
+  const leftScaled = leftNumerator * rightDenominator;
+  const rightScaled = rightNumerator * leftDenominator;
+  if (Number.isSafeInteger(leftScaled) && Number.isSafeInteger(rightScaled)) {
+    if (leftScaled < rightScaled) {
+      return -1;
+    }
+    if (leftScaled > rightScaled) {
+      return 1;
+    }
+    return 0;
+  }
+
+  const leftScaledBigInt = BigInt(leftNumerator) * BigInt(rightDenominator);
+  const rightScaledBigInt = BigInt(rightNumerator) * BigInt(leftDenominator);
+  if (leftScaledBigInt < rightScaledBigInt) {
+    return -1;
+  }
+  if (leftScaledBigInt > rightScaledBigInt) {
+    return 1;
+  }
+  return 0;
 }
 
 function normalizePositionDenominator(value: number): number {
@@ -924,6 +990,54 @@ function resolveNormalizedChannelForPredicate(channel: string): string {
 
 function isNormalizedBase36Code(code: number): boolean {
   return (code >= 0x30 && code <= 0x39) || (code >= 0x41 && code <= 0x5a);
+}
+
+function tryPackNormalizedChannel(channel: string): number {
+  if (channel.length !== 2) {
+    return -1;
+  }
+  const high = normalizeAsciiBase36Code(channel.charCodeAt(0));
+  const low = normalizeAsciiBase36Code(channel.charCodeAt(1));
+  if (high < 0 || low < 0) {
+    return -1;
+  }
+  return (high << 8) | low;
+}
+
+function isPackedLandmineChannel(packed: number): boolean {
+  const high = (packed >> 8) & 0xff;
+  if (high !== 0x44 && high !== 0x45) {
+    return false;
+  }
+  const low = packed & 0xff;
+  return low >= 0x31 && low <= 0x39;
+}
+
+function isPackedSampleTriggerChannel(packed: number): boolean {
+  if (packed === PACKED_CHANNEL_01) {
+    return true;
+  }
+  if (((packed >> 8) & 0xff) === 0x30) {
+    return false;
+  }
+  return packed !== PACKED_CHANNEL_03 && packed !== PACKED_CHANNEL_08 && packed !== PACKED_CHANNEL_09 && packed !== PACKED_CHANNEL_SC;
+}
+
+function isPackedPlayableChannel(packed: number): boolean {
+  if (!isPackedSampleTriggerChannel(packed)) {
+    return false;
+  }
+  const high = (packed >> 8) & 0xff;
+  return high === 0x31 || high === 0x32;
+}
+
+function isPackedBmsLongNoteChannel(packed: number): boolean {
+  const low = packed & 0xff;
+  if (low < 0x31 || low > 0x39) {
+    return false;
+  }
+  const high = (packed >> 8) & 0xff;
+  return high === 0x35 || high === 0x36;
 }
 
 function isTempoNormalizedChannel(normalized: string): boolean {

--- a/packages/json/src/index.ts
+++ b/packages/json/src/index.ts
@@ -178,6 +178,11 @@ export const DEFAULT_BPM = 130;
 const BASE36_UPPER_DIGITS = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 const BASE36_PAD_1_DIVISOR = 36;
 const BASE36_PAD_2_DIVISOR = BASE36_PAD_1_DIVISOR * BASE36_PAD_1_DIVISOR;
+const BASE36_PAD_2_TABLE = Array.from({ length: BASE36_PAD_2_DIVISOR }, (_value, index) => {
+  const high = Math.floor(index / BASE36_PAD_1_DIVISOR);
+  const low = index % BASE36_PAD_1_DIVISOR;
+  return `${BASE36_UPPER_DIGITS[high]}${BASE36_UPPER_DIGITS[low]}`;
+});
 const BMS_LONG_NOTE_PLAYABLE_1P = ['11', '12', '13', '14', '15', '16', '17', '18', '19'] as const;
 const BMS_LONG_NOTE_PLAYABLE_2P = ['21', '22', '23', '24', '25', '26', '27', '28', '29'] as const;
 const PACKED_CHANNEL_01 = 0x3031;
@@ -331,10 +336,7 @@ export function intToBase36(value: number, pad = 2): string {
     return BASE36_UPPER_DIGITS[normalized % BASE36_PAD_1_DIVISOR] ?? '0';
   }
   if (pad === 2) {
-    const valuePad2 = Math.floor(normalized % BASE36_PAD_2_DIVISOR);
-    const high = Math.floor(valuePad2 / BASE36_PAD_1_DIVISOR);
-    const low = valuePad2 % BASE36_PAD_1_DIVISOR;
-    return `${BASE36_UPPER_DIGITS[high]}${BASE36_UPPER_DIGITS[low]}`;
+    return BASE36_PAD_2_TABLE[normalized % BASE36_PAD_2_DIVISOR] ?? '00';
   }
   const encoded = normalized.toString(36).toUpperCase();
   return encoded.padStart(pad, '0').slice(-pad);
@@ -353,6 +355,21 @@ export function parseBpmFrom03Token(value: string): number {
 }
 
 export function ensureMeasure(json: BeMusicJson, index: number): BeMusicMeasure {
+  const measureCount = json.measures.length;
+  if (measureCount > 0) {
+    const lastMeasure = json.measures[measureCount - 1]!;
+    if (lastMeasure.index === index) {
+      return lastMeasure;
+    }
+    if (lastMeasure.index < index) {
+      const created: BeMusicMeasure = {
+        index,
+        length: 1,
+      };
+      json.measures.push(created);
+      return created;
+    }
+  }
   for (let measureIndex = 0; measureIndex < json.measures.length; measureIndex += 1) {
     const measure = json.measures[measureIndex]!;
     if (measure.index === index) {
@@ -387,6 +404,21 @@ export function eventToBeat(json: BeMusicJson, event: BeMusicEvent): number {
 }
 
 export function createBeatResolver(json: BeMusicJson): BeatResolver {
+  if (json.measures.length === 0) {
+    return {
+      measureToBeat: (measure, position = 0) => {
+        const safeMeasure = Math.max(0, Math.floor(measure));
+        return safeMeasure * 4 + 4 * clamp01(position);
+      },
+      eventToBeat: (event) => {
+        const safeMeasure = Math.max(0, Math.floor(event.measure));
+        const denominator = normalizePositionDenominator(event.position[1]);
+        const numerator = normalizePositionNumerator(event.position[0], denominator);
+        return safeMeasure * 4 + (4 * numerator) / denominator;
+      },
+    };
+  }
+
   const measureLengths: number[] = [];
   let maxDefinedMeasure = -1;
   for (const measure of json.measures) {
@@ -444,9 +476,35 @@ export function compareEvents(left: BeMusicEvent, right: BeMusicEvent): number {
   if (left.measure !== right.measure) {
     return left.measure - right.measure;
   }
-  const positionDelta = compareEventPosition(left, right);
-  if (positionDelta !== 0) {
-    return positionDelta;
+  const leftDenominator = normalizePositionDenominator(left.position[1]);
+  const leftNumerator = normalizePositionNumerator(left.position[0], leftDenominator);
+  const rightDenominator = normalizePositionDenominator(right.position[1]);
+  const rightNumerator = normalizePositionNumerator(right.position[0], rightDenominator);
+  if (leftDenominator === rightDenominator) {
+    const numeratorDelta = leftNumerator - rightNumerator;
+    if (numeratorDelta !== 0) {
+      return numeratorDelta;
+    }
+  } else {
+    const leftScaled = leftNumerator * rightDenominator;
+    const rightScaled = rightNumerator * leftDenominator;
+    if (Number.isSafeInteger(leftScaled) && Number.isSafeInteger(rightScaled)) {
+      if (leftScaled < rightScaled) {
+        return -1;
+      }
+      if (leftScaled > rightScaled) {
+        return 1;
+      }
+    } else {
+      const leftScaledBigInt = BigInt(leftNumerator) * BigInt(rightDenominator);
+      const rightScaledBigInt = BigInt(rightNumerator) * BigInt(leftDenominator);
+      if (leftScaledBigInt < rightScaledBigInt) {
+        return -1;
+      }
+      if (leftScaledBigInt > rightScaledBigInt) {
+        return 1;
+      }
+    }
   }
   if (left.channel !== right.channel) {
     return left.channel < right.channel ? -1 : 1;
@@ -458,7 +516,7 @@ export function compareEvents(left: BeMusicEvent, right: BeMusicEvent): number {
 }
 
 export function isTempoChannel(channel: string): boolean {
-  const packed = tryPackNormalizedChannel(channel);
+  const packed = tryPackChannel(channel);
   if (packed >= 0) {
     return packed === PACKED_CHANNEL_03 || packed === PACKED_CHANNEL_08;
   }
@@ -466,7 +524,7 @@ export function isTempoChannel(channel: string): boolean {
 }
 
 export function isStopChannel(channel: string): boolean {
-  const packed = tryPackNormalizedChannel(channel);
+  const packed = tryPackChannel(channel);
   if (packed >= 0) {
     return packed === PACKED_CHANNEL_09;
   }
@@ -474,7 +532,7 @@ export function isStopChannel(channel: string): boolean {
 }
 
 export function isScrollChannel(channel: string): boolean {
-  const packed = tryPackNormalizedChannel(channel);
+  const packed = tryPackChannel(channel);
   if (packed >= 0) {
     return packed === PACKED_CHANNEL_SC;
   }
@@ -482,7 +540,7 @@ export function isScrollChannel(channel: string): boolean {
 }
 
 export function isLandmineChannel(channel: string): boolean {
-  const packed = tryPackNormalizedChannel(channel);
+  const packed = tryPackChannel(channel);
   if (packed >= 0) {
     return isPackedLandmineChannel(packed);
   }
@@ -490,7 +548,7 @@ export function isLandmineChannel(channel: string): boolean {
 }
 
 export function isSampleTriggerChannel(channel: string): boolean {
-  const packed = tryPackNormalizedChannel(channel);
+  const packed = tryPackChannel(channel);
   if (packed >= 0) {
     return isPackedSampleTriggerChannel(packed);
   }
@@ -498,7 +556,7 @@ export function isSampleTriggerChannel(channel: string): boolean {
 }
 
 export function isPlayableChannel(channel: string): boolean {
-  const packed = tryPackNormalizedChannel(channel);
+  const packed = tryPackChannel(channel);
   if (packed >= 0) {
     return isPackedPlayableChannel(packed);
   }
@@ -506,7 +564,7 @@ export function isPlayableChannel(channel: string): boolean {
 }
 
 export function isBmsLongNoteChannel(channel: string): boolean {
-  const packed = tryPackNormalizedChannel(channel);
+  const packed = tryPackChannel(channel);
   if (packed >= 0) {
     return isPackedBmsLongNoteChannel(packed);
   }
@@ -514,14 +572,14 @@ export function isBmsLongNoteChannel(channel: string): boolean {
 }
 
 export function mapBmsLongNoteChannelToPlayable(channel: string): string | undefined {
-  const packed = tryPackNormalizedChannel(channel);
+  const packed = tryPackChannel(channel);
   if (packed >= 0) {
     if (!isPackedBmsLongNoteChannel(packed)) {
       return undefined;
     }
-    const high = ((packed >> 8) & 0xff) - 4;
     const low = packed & 0xff;
-    return String.fromCharCode(high, low);
+    const laneIndex = low - 0x31;
+    return ((packed >> 8) & 0xff) === 0x35 ? BMS_LONG_NOTE_PLAYABLE_1P[laneIndex] : BMS_LONG_NOTE_PLAYABLE_2P[laneIndex];
   }
   return mapBmsLongNoteNormalizedChannelToPlayable(resolveNormalizedChannelForPredicate(channel));
 }
@@ -917,38 +975,6 @@ function getEventPosition(event: BeMusicEvent): number {
   return numerator / denominator;
 }
 
-function compareEventPosition(left: BeMusicEvent, right: BeMusicEvent): number {
-  const leftDenominator = normalizePositionDenominator(left.position[1]);
-  const leftNumerator = normalizePositionNumerator(left.position[0], leftDenominator);
-  const rightDenominator = normalizePositionDenominator(right.position[1]);
-  const rightNumerator = normalizePositionNumerator(right.position[0], rightDenominator);
-  if (leftDenominator === rightDenominator) {
-    return leftNumerator - rightNumerator;
-  }
-
-  const leftScaled = leftNumerator * rightDenominator;
-  const rightScaled = rightNumerator * leftDenominator;
-  if (Number.isSafeInteger(leftScaled) && Number.isSafeInteger(rightScaled)) {
-    if (leftScaled < rightScaled) {
-      return -1;
-    }
-    if (leftScaled > rightScaled) {
-      return 1;
-    }
-    return 0;
-  }
-
-  const leftScaledBigInt = BigInt(leftNumerator) * BigInt(rightDenominator);
-  const rightScaledBigInt = BigInt(rightNumerator) * BigInt(leftDenominator);
-  if (leftScaledBigInt < rightScaledBigInt) {
-    return -1;
-  }
-  if (leftScaledBigInt > rightScaledBigInt) {
-    return 1;
-  }
-  return 0;
-}
-
 function normalizePositionDenominator(value: number): number {
   if (!Number.isFinite(value) || value <= 0) {
     return 1;
@@ -992,16 +1018,27 @@ function isNormalizedBase36Code(code: number): boolean {
   return (code >= 0x30 && code <= 0x39) || (code >= 0x41 && code <= 0x5a);
 }
 
-function tryPackNormalizedChannel(channel: string): number {
+function tryPackChannel(channel: string): number {
   if (channel.length !== 2) {
     return -1;
   }
-  const high = normalizeAsciiBase36Code(channel.charCodeAt(0));
-  const low = normalizeAsciiBase36Code(channel.charCodeAt(1));
+  const high = normalizeAsciiBase36CodeFast(channel.charCodeAt(0));
+  const low = normalizeAsciiBase36CodeFast(channel.charCodeAt(1));
   if (high < 0 || low < 0) {
     return -1;
   }
   return (high << 8) | low;
+}
+
+function normalizeAsciiBase36CodeFast(code: number): number {
+  if (code >= 0x30 && code <= 0x39) {
+    return code;
+  }
+  const uppercase = code & 0xdf;
+  if (uppercase >= 0x41 && uppercase <= 0x5a) {
+    return uppercase;
+  }
+  return -1;
 }
 
 function isPackedLandmineChannel(packed: number): boolean {

--- a/packages/json/src/index.ts
+++ b/packages/json/src/index.ts
@@ -235,6 +235,59 @@ export function createEmptyJson(sourceFormat: BeMusicSourceFormat = 'bms'): BeMu
 }
 
 export function cloneJson(json: BeMusicJson): BeMusicJson {
+  const sourceMeasures = json.measures;
+  const measures = new Array<BeMusicMeasure>(sourceMeasures.length);
+  for (let index = 0; index < sourceMeasures.length; index += 1) {
+    const measure = sourceMeasures[index]!;
+    measures[index] = { index: measure.index, length: measure.length };
+  }
+
+  const sourceEvents = json.events;
+  const events = new Array<BeMusicEvent>(sourceEvents.length);
+  for (let index = 0; index < sourceEvents.length; index += 1) {
+    events[index] = cloneEvent(sourceEvents[index]!);
+  }
+
+  const sourceControlFlow = json.bms.controlFlow;
+  const controlFlow = new Array<BmsControlFlowEntry>(sourceControlFlow.length);
+  for (let index = 0; index < sourceControlFlow.length; index += 1) {
+    controlFlow[index] = cloneControlFlowEntry(sourceControlFlow[index]!);
+  }
+
+  const sourceLines = json.bmson.lines;
+  const lines = new Array<number>(sourceLines.length);
+  for (let index = 0; index < sourceLines.length; index += 1) {
+    lines[index] = sourceLines[index]!;
+  }
+
+  const sourceHeader = json.bmson.bga.header;
+  const header = new Array<BmsonBgaHeaderEntry>(sourceHeader.length);
+  for (let index = 0; index < sourceHeader.length; index += 1) {
+    const entry = sourceHeader[index]!;
+    header[index] = { id: entry.id, name: entry.name };
+  }
+
+  const sourceBgaEvents = json.bmson.bga.events;
+  const bgaEvents = new Array<BmsonBgaEvent>(sourceBgaEvents.length);
+  for (let index = 0; index < sourceBgaEvents.length; index += 1) {
+    const event = sourceBgaEvents[index]!;
+    bgaEvents[index] = { y: event.y, id: event.id };
+  }
+
+  const sourceLayerEvents = json.bmson.bga.layerEvents;
+  const layerEvents = new Array<BmsonBgaEvent>(sourceLayerEvents.length);
+  for (let index = 0; index < sourceLayerEvents.length; index += 1) {
+    const event = sourceLayerEvents[index]!;
+    layerEvents[index] = { y: event.y, id: event.id };
+  }
+
+  const sourcePoorEvents = json.bmson.bga.poorEvents;
+  const poorEvents = new Array<BmsonBgaEvent>(sourcePoorEvents.length);
+  for (let index = 0; index < sourcePoorEvents.length; index += 1) {
+    const event = sourcePoorEvents[index]!;
+    poorEvents[index] = { y: event.y, id: event.id };
+  }
+
   return {
     format: json.format,
     sourceFormat: json.sourceFormat,
@@ -249,11 +302,11 @@ export function cloneJson(json: BeMusicJson): BeMusicJson {
       stop: { ...json.resources.stop },
       text: { ...json.resources.text },
     },
-    measures: json.measures.map((measure) => ({ index: measure.index, length: measure.length })),
-    events: json.events.map(cloneEvent),
+    measures,
+    events,
     bms: {
       ...json.bms,
-      controlFlow: json.bms.controlFlow.map(cloneControlFlowEntry),
+      controlFlow,
       lnObjs: json.bms.lnObjs ? [...json.bms.lnObjs] : undefined,
       exRank: { ...json.bms.exRank },
       argb: { ...json.bms.argb },
@@ -267,22 +320,35 @@ export function cloneJson(json: BeMusicJson): BeMusicJson {
     },
     bmson: {
       ...json.bmson,
-      lines: [...json.bmson.lines],
+      lines,
       info: {
         ...json.bmson.info,
         subartists: json.bmson.info.subartists ? [...json.bmson.info.subartists] : undefined,
       },
       bga: {
-        header: json.bmson.bga.header.map((entry) => ({ id: entry.id, name: entry.name })),
-        events: json.bmson.bga.events.map((event) => ({ y: event.y, id: event.id })),
-        layerEvents: json.bmson.bga.layerEvents.map((event) => ({ y: event.y, id: event.id })),
-        poorEvents: json.bmson.bga.poorEvents.map((event) => ({ y: event.y, id: event.id })),
+        header,
+        events: bgaEvents,
+        layerEvents,
+        poorEvents,
       },
     },
   };
 }
 
 export function normalizeObjectKey(value: string): string {
+  if (value.length === 2) {
+    const code0 = normalizeAsciiBase36CodeFast(value.charCodeAt(0));
+    const code1 = normalizeAsciiBase36CodeFast(value.charCodeAt(1));
+    if (code0 >= 0 && code1 >= 0) {
+      return String.fromCharCode(code0, code1);
+    }
+  }
+  if (value.length === 1) {
+    const code = normalizeAsciiBase36CodeFast(value.charCodeAt(0));
+    if (code >= 0) {
+      return String.fromCharCode(0x30, code);
+    }
+  }
   const trimmed = value.trim();
   if (trimmed.length === 0) {
     return '00';
@@ -313,14 +379,9 @@ export function normalizeObjectKey(value: string): string {
 
 export function normalizeChannel(value: string): string {
   if (value.length === 2) {
-    const sourceCode0 = value.charCodeAt(0);
-    const sourceCode1 = value.charCodeAt(1);
-    const code0 = normalizeAsciiBase36Code(sourceCode0);
-    const code1 = normalizeAsciiBase36Code(sourceCode1);
+    const code0 = normalizeAsciiBase36CodeFast(value.charCodeAt(0));
+    const code1 = normalizeAsciiBase36CodeFast(value.charCodeAt(1));
     if (code0 >= 0 && code1 >= 0) {
-      if (code0 === sourceCode0 && code1 === sourceCode1) {
-        return value;
-      }
       return String.fromCharCode(code0, code1);
     }
   }
@@ -344,8 +405,8 @@ export function intToBase36(value: number, pad = 2): string {
 
 export function parseBpmFrom03Token(value: string): number {
   if (value.length === 2) {
-    const high = parseHexDigit(value.charCodeAt(0));
-    const low = parseHexDigit(value.charCodeAt(1));
+    const high = parseHexDigitFast(value.charCodeAt(0));
+    const low = parseHexDigitFast(value.charCodeAt(1));
     if (high >= 0 && low >= 0) {
       return (high << 4) + low;
     }
@@ -389,17 +450,27 @@ export function getMeasureBeats(length: number): number {
 }
 
 export function measureToBeat(json: BeMusicJson, measure: number, position = 0): number {
+  const safeMeasure = Math.max(0, Math.floor(measure));
+  if (json.measures.length === 0) {
+    return safeMeasure * 4 + 4 * clamp01(position);
+  }
   const safePosition = clamp01(position);
   const measureLengths = createExactMeasureLengthRecord(json);
   let beats = 0;
-  for (let current = 0; current < measure; current += 1) {
+  for (let current = 0; current < safeMeasure; current += 1) {
     beats += getMeasureBeats(measureLengths[current] ?? 1);
   }
-  beats += getMeasureBeats(measureLengths[measure] ?? 1) * safePosition;
+  beats += getMeasureBeats(measureLengths[safeMeasure] ?? 1) * safePosition;
   return beats;
 }
 
 export function eventToBeat(json: BeMusicJson, event: BeMusicEvent): number {
+  if (json.measures.length === 0) {
+    const measure = Math.max(0, Math.floor(event.measure));
+    const denominator = normalizePositionDenominator(event.position[1]);
+    const numerator = normalizePositionNumerator(event.position[0], denominator);
+    return measure * 4 + (4 * numerator) / denominator;
+  }
   return measureToBeat(json, event.measure, getEventPosition(event));
 }
 
@@ -469,6 +540,20 @@ export function createBeatResolver(json: BeMusicJson): BeatResolver {
 }
 
 export function sortEvents(events: BeMusicEvent[]): BeMusicEvent[] {
+  if (events.length <= 1) {
+    return [...events];
+  }
+
+  let sorted = true;
+  for (let index = 1; index < events.length; index += 1) {
+    if (compareEvents(events[index - 1]!, events[index]!) > 0) {
+      sorted = false;
+      break;
+    }
+  }
+  if (sorted) {
+    return [...events];
+  }
   return [...events].sort(compareEvents);
 }
 
@@ -516,6 +601,13 @@ export function compareEvents(left: BeMusicEvent, right: BeMusicEvent): number {
 }
 
 export function isTempoChannel(channel: string): boolean {
+  if (channel.length === 2) {
+    const high = channel.charCodeAt(0);
+    const low = channel.charCodeAt(1);
+    if (high === 0x30 && (low === 0x33 || low === 0x38)) {
+      return true;
+    }
+  }
   const packed = tryPackChannel(channel);
   if (packed >= 0) {
     return packed === PACKED_CHANNEL_03 || packed === PACKED_CHANNEL_08;
@@ -524,6 +616,9 @@ export function isTempoChannel(channel: string): boolean {
 }
 
 export function isStopChannel(channel: string): boolean {
+  if (channel.length === 2 && channel.charCodeAt(0) === 0x30 && channel.charCodeAt(1) === 0x39) {
+    return true;
+  }
   const packed = tryPackChannel(channel);
   if (packed >= 0) {
     return packed === PACKED_CHANNEL_09;
@@ -532,6 +627,13 @@ export function isStopChannel(channel: string): boolean {
 }
 
 export function isScrollChannel(channel: string): boolean {
+  if (channel.length === 2) {
+    const high = channel.charCodeAt(0) & 0xdf;
+    const low = channel.charCodeAt(1) & 0xdf;
+    if (high === 0x53 && low === 0x43) {
+      return true;
+    }
+  }
   const packed = tryPackChannel(channel);
   if (packed >= 0) {
     return packed === PACKED_CHANNEL_SC;
@@ -540,6 +642,13 @@ export function isScrollChannel(channel: string): boolean {
 }
 
 export function isLandmineChannel(channel: string): boolean {
+  if (channel.length === 2) {
+    const high = channel.charCodeAt(0) & 0xdf;
+    const low = channel.charCodeAt(1);
+    if ((high === 0x44 || high === 0x45) && low >= 0x31 && low <= 0x39) {
+      return true;
+    }
+  }
   const packed = tryPackChannel(channel);
   if (packed >= 0) {
     return isPackedLandmineChannel(packed);
@@ -548,6 +657,17 @@ export function isLandmineChannel(channel: string): boolean {
 }
 
 export function isSampleTriggerChannel(channel: string): boolean {
+  if (channel.length === 2) {
+    const highCode = channel.charCodeAt(0);
+    const lowCode = channel.charCodeAt(1);
+    if (highCode === 0x30) {
+      return lowCode === 0x31;
+    }
+    if ((highCode & 0xdf) === 0x53 && (lowCode & 0xdf) === 0x43) {
+      return false;
+    }
+    return true;
+  }
   const packed = tryPackChannel(channel);
   if (packed >= 0) {
     return isPackedSampleTriggerChannel(packed);
@@ -556,6 +676,13 @@ export function isSampleTriggerChannel(channel: string): boolean {
 }
 
 export function isPlayableChannel(channel: string): boolean {
+  if (channel.length === 2) {
+    const high = channel.charCodeAt(0);
+    const low = channel.charCodeAt(1);
+    if ((high === 0x31 || high === 0x32) && low >= 0x31 && low <= 0x39) {
+      return true;
+    }
+  }
   const packed = tryPackChannel(channel);
   if (packed >= 0) {
     return isPackedPlayableChannel(packed);
@@ -564,6 +691,13 @@ export function isPlayableChannel(channel: string): boolean {
 }
 
 export function isBmsLongNoteChannel(channel: string): boolean {
+  if (channel.length === 2) {
+    const high = channel.charCodeAt(0);
+    const low = channel.charCodeAt(1);
+    if ((high === 0x35 || high === 0x36) && low >= 0x31 && low <= 0x39) {
+      return true;
+    }
+  }
   const packed = tryPackChannel(channel);
   if (packed >= 0) {
     return isPackedBmsLongNoteChannel(packed);
@@ -932,7 +1066,7 @@ function resolveBmsLongNoteType2SegmentEndBeat(event: BeMusicEvent, beatResolver
 }
 
 function createExactMeasureLengthRecord(json: BeMusicJson): Record<number, number> {
-  const measureLengths: Record<number, number> = {};
+  const measureLengths: number[] = [];
   for (const measure of json.measures) {
     measureLengths[measure.index] = measure.length;
   }
@@ -1003,6 +1137,17 @@ function parseHexDigit(code: number): number {
   return -1;
 }
 
+function parseHexDigitFast(code: number): number {
+  if (code >= 0x30 && code <= 0x39) {
+    return code - 0x30;
+  }
+  const uppercase = code & 0xdf;
+  if (uppercase >= 0x41 && uppercase <= 0x46) {
+    return uppercase - 0x41 + 10;
+  }
+  return -1;
+}
+
 function resolveNormalizedChannelForPredicate(channel: string): string {
   if (channel.length === 2) {
     const code0 = channel.charCodeAt(0);
@@ -1022,8 +1167,13 @@ function tryPackChannel(channel: string): number {
   if (channel.length !== 2) {
     return -1;
   }
-  const high = normalizeAsciiBase36CodeFast(channel.charCodeAt(0));
-  const low = normalizeAsciiBase36CodeFast(channel.charCodeAt(1));
+  const sourceHigh = channel.charCodeAt(0);
+  const sourceLow = channel.charCodeAt(1);
+  if (isNormalizedBase36Code(sourceHigh) && isNormalizedBase36Code(sourceLow)) {
+    return (sourceHigh << 8) | sourceLow;
+  }
+  const high = normalizeAsciiBase36CodeFast(sourceHigh);
+  const low = normalizeAsciiBase36CodeFast(sourceLow);
   if (high < 0 || low < 0) {
     return -1;
   }

--- a/packages/parser/src/core/bms-text-decoder.ts
+++ b/packages/parser/src/core/bms-text-decoder.ts
@@ -31,6 +31,12 @@ export function decodeBmsText(buffer: Buffer): DecodedBmsText {
       text: decodeUtf16BeText(buffer),
     };
   }
+  if (isAsciiText(buffer)) {
+    return {
+      encoding: 'utf8',
+      text: decodeUtf8Text(buffer),
+    };
+  }
 
   const candidates: Array<{ encoding: DetectedBmsEncoding; bias: number }> = [
     { encoding: 'shift_jis', bias: 5 },
@@ -198,4 +204,13 @@ function hasUtf16LeBom(buffer: Buffer): boolean {
 
 function hasUtf16BeBom(buffer: Buffer): boolean {
   return buffer.length >= 2 && buffer[0] === 0xfe && buffer[1] === 0xff;
+}
+
+function isAsciiText(buffer: Buffer): boolean {
+  for (let index = 0; index < buffer.length; index += 1) {
+    if (buffer[index]! >= 0x80) {
+      return false;
+    }
+  }
+  return true;
 }

--- a/packages/parser/src/core/chart-parser.ts
+++ b/packages/parser/src/core/chart-parser.ts
@@ -323,6 +323,13 @@ function parseStructuredChartObject(parsed: Record<string, unknown>): BeMusicJso
 }
 
 export function parseChart(input: string, formatHint?: string): BeMusicJson {
+  if (formatHint === undefined) {
+    const firstCode = input.charCodeAt(0);
+    if (firstCode === 0x23) {
+      return parseBms(input);
+    }
+  }
+
   const hint = formatHint?.toLowerCase();
   if (hint === 'bmson') {
     return parseBmson(input);
@@ -332,9 +339,16 @@ export function parseChart(input: string, formatHint?: string): BeMusicJson {
     return parseStructuredChartObject(parsed);
   }
 
-  const trimmed = input.trimStart();
-  if (trimmed.startsWith('{')) {
-    const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+  let startIndex = 0;
+  while (startIndex < input.length) {
+    const code = input.charCodeAt(startIndex);
+    if (code !== 0x20 && code !== 0x09 && code !== 0x0a && code !== 0x0d) {
+      break;
+    }
+    startIndex += 1;
+  }
+  if (input.charCodeAt(startIndex) === 0x7b) {
+    const parsed = JSON.parse(input.slice(startIndex)) as Record<string, unknown>;
     return parseStructuredChartObject(parsed);
   }
 

--- a/packages/player/src/audio-sink.ts
+++ b/packages/player/src/audio-sink.ts
@@ -1,5 +1,5 @@
 import { setTimeout as delay } from 'node:timers/promises';
-import { throwIfAborted } from '@be-music/utils';
+import { isAbortError, throwIfAborted } from '@be-music/utils';
 
 export type AudioRuntime = 'node' | 'browser';
 export type AudioEngine = 'webaudio';
@@ -209,7 +209,7 @@ async function loadNodeWebAudioContextConstructor(
     }
     return candidate as NodeWebAudioContextConstructor;
   } catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') {
+    if (isAbortError(error)) {
       throw error;
     }
     return undefined;

--- a/packages/player/src/bga-video.ts
+++ b/packages/player/src/bga-video.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import { basename } from 'node:path';
-import { throwIfAborted } from '@be-music/utils';
+import { isAbortError, throwIfAborted } from '@be-music/utils';
 
 const SUPPORTED_VIDEO_CODECS = new Set(['mpeg1video', 'h264', 'mjpeg']);
 // Keep chunks small so ff_decode_multi never allocates too many full-size frames at once.
@@ -452,10 +452,6 @@ function clampToByte(value: number): number {
     return 255;
   }
   return value;
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof Error && error.name === 'AbortError';
 }
 
 async function createLibAvInstance(): Promise<LibAvInstance> {

--- a/packages/player/src/bga.ts
+++ b/packages/player/src/bga.ts
@@ -1,6 +1,6 @@
-import { access, readFile } from 'node:fs/promises';
-import { extname, isAbsolute, resolve } from 'node:path';
-import { invokeWorkerizedFunction, throwIfAborted, workerize } from '@be-music/utils';
+import { readFile } from 'node:fs/promises';
+import { extname } from 'node:path';
+import { invokeWorkerizedFunction, isAbortError, resolveFirstExistingPath, throwIfAborted, workerize } from '@be-music/utils';
 import { normalizeChannel, normalizeObjectKey, sortEvents, type BeMusicEvent, type BeMusicJson } from '@be-music/json';
 import { createTimingResolver } from '@be-music/audio-renderer';
 import { decode as decodeBmpFast } from 'fast-bmp';
@@ -968,15 +968,7 @@ async function loadVideoAsFrameSource(
 }
 
 async function resolveMediaPath(baseDir: string, mediaPath: string, signal?: AbortSignal): Promise<string | undefined> {
-  const candidates = createMediaPathCandidates(mediaPath);
-  for (const candidate of candidates) {
-    throwIfAborted(signal);
-    const absolute = isAbsolute(candidate) ? candidate : resolve(baseDir, candidate);
-    if (await exists(absolute, signal)) {
-      return absolute;
-    }
-  }
-  return undefined;
+  return resolveFirstExistingPath(baseDir, createMediaPathCandidates(mediaPath), signal);
 }
 
 function createMediaPathCandidates(mediaPath: string): string[] {
@@ -1033,24 +1025,6 @@ function createMediaPathCandidates(mediaPath: string): string[] {
   }
 
   return candidates;
-}
-
-async function exists(path: string, signal?: AbortSignal): Promise<boolean> {
-  try {
-    throwIfAborted(signal);
-    await access(path);
-    throwIfAborted(signal);
-    return true;
-  } catch (error) {
-    if (isAbortError(error)) {
-      throw error;
-    }
-    return false;
-  }
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof Error && error.name === 'AbortError';
 }
 
 function decodeImageBuffer(buffer: Buffer, pathHint: string): DecodedImage {

--- a/packages/player/src/cli/chart-preview.ts
+++ b/packages/player/src/cli/chart-preview.ts
@@ -1,6 +1,13 @@
-import { access } from 'node:fs/promises';
 import { dirname, isAbsolute, resolve } from 'node:path';
-import { floatToInt16, invokeWorkerizedFunction, throwIfAborted, workerize } from '@be-music/utils';
+import { setTimeout as delay } from 'node:timers/promises';
+import {
+  invokeWorkerizedFunction,
+  isAbortError,
+  resolveFirstExistingPath,
+  throwIfAborted,
+  workerize,
+  writeStereoPcm16Le,
+} from '@be-music/utils';
 import { createEmptyJson, type BeMusicJson } from '@be-music/json';
 import { parseChartFile, resolveBmsControlFlow } from '@be-music/parser';
 import { collectSampleTriggers, createTimingResolver, type RenderResult, renderJson } from '@be-music/audio-renderer';
@@ -84,7 +91,7 @@ export function createChartPreviewController(): ChartPreviewController {
 
   const stopPlaybackSafely = async (playback: PreviewPlaybackHandle): Promise<void> => {
     playback.stop();
-    await Promise.race([playback.done.catch(() => undefined), createTimeoutPromise(PREVIEW_STOP_TIMEOUT_MS)]);
+    await Promise.race([playback.done.catch(() => undefined), delay(PREVIEW_STOP_TIMEOUT_MS)]);
   };
 
   const stopActivePlayback = async (): Promise<void> => {
@@ -225,17 +232,13 @@ export async function resolvePreviewContinueKeyFromChart(
     return (await resolveFallbackPreviewIdentity(chart, signal))?.continueKey;
   }
   const candidates = createPreviewPathCandidates(chart, previewPath);
-  const baseDir = dirname(chartPath);
-  for (const candidate of candidates) {
-    throwIfAborted(signal);
-    const resolvedCandidate = resolvePreviewCandidatePath(baseDir, candidate);
-    if (await doesFileExist(resolvedCandidate)) {
-      return normalizePreviewContinueKey(resolvedCandidate);
-    }
-  }
-  const firstCandidate = candidates[0];
-  if (!firstCandidate) {
+  if (candidates.length === 0) {
     return (await resolveFallbackPreviewIdentity(chart, signal))?.continueKey;
+  }
+  const baseDir = dirname(chartPath);
+  const resolvedCandidate = await resolveFirstExistingPath(baseDir, candidates, signal);
+  if (resolvedCandidate) {
+    return normalizePreviewContinueKey(resolvedCandidate);
   }
   return (await resolveFallbackPreviewIdentity(chart, signal))?.continueKey;
 }
@@ -274,15 +277,6 @@ async function renderChartPreview(filePath: string, signal?: AbortSignal): Promi
     continueKey: fallbackPreview.continueKey,
     rendered: trimPreviewLeadingSilence(fallbackPreview.rendered),
   };
-}
-
-async function doesFileExist(filePath: string): Promise<boolean> {
-  try {
-    await access(filePath);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 async function renderPreviewSampleFile(
@@ -492,10 +486,6 @@ function computeFallbackContinueKey(payload: FallbackSignaturePayload): string {
   return `fallback:${`${primary}${secondary}`.slice(0, 24)}`;
 }
 
-function isAbortError(error: unknown): boolean {
-  return error instanceof Error && error.name === 'AbortError';
-}
-
 function createPreviewPathCandidates(chart: BeMusicJson, previewPath: string): string[] {
   const normalizedPreview = previewPath.trim();
   if (normalizedPreview.length === 0) {
@@ -618,15 +608,9 @@ async function waitPreviewWritableWithTimeout(
     .waitWritable(shouldStop)
     .then(() => true)
     .catch(() => false);
-  const timeoutTask = createTimeoutPromise(PREVIEW_BACKPRESSURE_TIMEOUT_MS).then(() => false);
+  const timeoutTask = delay(PREVIEW_BACKPRESSURE_TIMEOUT_MS).then(() => false);
   const writable = await Promise.race([waitWritableTask, timeoutTask]);
   return writable && !shouldStop();
-}
-
-function createTimeoutPromise(ms: number): Promise<void> {
-  return new Promise<void>((resolvePromise) => {
-    setTimeout(resolvePromise, ms);
-  });
 }
 
 function writeLoopedPreviewPcmChunk(chunk: Buffer, rendered: RenderResult, startFrame: number): number {
@@ -635,14 +619,16 @@ function writeLoopedPreviewPcmChunk(chunk: Buffer, rendered: RenderResult, start
   if (source >= totalFrames) {
     source %= totalFrames;
   }
-  for (let frame = 0; frame < PREVIEW_CHUNK_FRAMES; frame += 1) {
-    const offset = frame * 4;
-    chunk.writeInt16LE(floatToInt16(rendered.left[source]), offset);
-    chunk.writeInt16LE(floatToInt16(rendered.right[source]), offset + 2);
-    source += 1;
-    if (source >= totalFrames) {
-      source = 0;
-    }
+  const firstChunkFrames = Math.min(PREVIEW_CHUNK_FRAMES, totalFrames - source);
+  writeStereoPcm16Le(chunk, 0, rendered.left, rendered.right, source, firstChunkFrames);
+  source += firstChunkFrames;
+  if (source >= totalFrames) {
+    source = 0;
+  }
+  const remainingFrames = PREVIEW_CHUNK_FRAMES - firstChunkFrames;
+  if (remainingFrames > 0) {
+    writeStereoPcm16Le(chunk, firstChunkFrames * 4, rendered.left, rendered.right, 0, remainingFrames);
+    source = remainingFrames % totalFrames;
   }
   return source;
 }

--- a/packages/player/src/cli/chart-selection.ts
+++ b/packages/player/src/cli/chart-selection.ts
@@ -1,6 +1,6 @@
 import { readdir } from 'node:fs/promises';
 import { relative, resolve } from 'node:path';
-import { invokeWorkerizedFunction, throwIfAborted, workerize } from '@be-music/utils';
+import { invokeWorkerizedFunction, isAbortError, throwIfAborted, workerize } from '@be-music/utils';
 import { type BeMusicJson } from '@be-music/json';
 import { parseChartFile, resolveBmsControlFlow } from '@be-music/parser';
 import { createTimingResolver } from '@be-music/audio-renderer';
@@ -72,12 +72,9 @@ export async function listChartFiles(rootDir: string, options: ListChartFilesOpt
   const files: string[] = [];
   const queue: string[] = [rootDir];
 
-  while (queue.length > 0) {
+  for (let index = 0; index < queue.length; index += 1) {
     throwIfAborted(options.signal);
-    const current = queue.shift();
-    if (!current) {
-      continue;
-    }
+    const current = queue[index]!;
 
     const entries = await readdir(current, { withFileTypes: true });
     for (const entry of entries) {
@@ -303,10 +300,6 @@ async function buildChartSummary(rootDir: string, filePath: string, signal?: Abo
     bpmMin,
     bpmMax,
   };
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof Error && error.name === 'AbortError';
 }
 
 function extractChartBpmSummary(json: BeMusicJson): { initial: number; min: number; max: number } | undefined {

--- a/packages/player/src/cli/runner.ts
+++ b/packages/player/src/cli/runner.ts
@@ -2,7 +2,7 @@
 import { stat } from 'node:fs/promises';
 import { dirname, extname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { resolveCliPath } from '@be-music/utils';
+import { isAbortError, resolveCliPath } from '@be-music/utils';
 import readline from 'node:readline';
 import { parseChartFile } from '@be-music/parser';
 import { renderJson, writeAudioFile } from '@be-music/audio-renderer';
@@ -1107,10 +1107,6 @@ function beginLoadingAbortCapture(): LoadingAbortCapture | undefined {
       inputCapture.restore();
     },
   };
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof Error && error.name === 'AbortError';
 }
 
 function resolveLoadingCancelReason(

--- a/packages/player/src/core/high-speed-control.ts
+++ b/packages/player/src/core/high-speed-control.ts
@@ -51,6 +51,21 @@ export function applyHighSpeedControlAction(current: number, action: HighSpeedCo
 }
 
 function resolvePlayableLaneIndex(channel: string): number | undefined {
+  if (channel.length === 2) {
+    const sideCode = channel.charCodeAt(0);
+    if (sideCode === 0x31 || sideCode === 0x32) {
+      const laneCode = channel.charCodeAt(1);
+      if (laneCode >= 0x31 && laneCode <= 0x39) {
+        return laneCode - 0x30;
+      }
+      const uppercaseLaneCode = laneCode & 0xdf;
+      if (uppercaseLaneCode >= 0x41 && uppercaseLaneCode <= 0x5a) {
+        return uppercaseLaneCode - 0x41 + 10;
+      }
+      return undefined;
+    }
+  }
+
   const normalized = channel.trim().toUpperCase();
   if (normalized.length !== 2) {
     return undefined;

--- a/packages/player/src/core/player-engine.ts
+++ b/packages/player/src/core/player-engine.ts
@@ -260,13 +260,12 @@ export function applyFastSlowForJudge(
   judge: 'PERFECT' | 'GREAT' | 'GOOD',
   signedDeltaMs: number,
 ): void {
-  if (judge !== 'GREAT' && judge !== 'GOOD') {
-    return;
-  }
-  if (signedDeltaMs < 0) {
-    summary.fast += 1;
-  } else if (signedDeltaMs > 0) {
-    summary.slow += 1;
+  if (judge === 'GREAT' || judge === 'GOOD') {
+    if (signedDeltaMs < 0) {
+      summary.fast += 1;
+    } else if (signedDeltaMs > 0) {
+      summary.slow += 1;
+    }
   }
 }
 
@@ -370,15 +369,24 @@ export function resolveBmsControlFlowForPlayback(
 }
 
 export function formatRandomPatternSummary(randomPatterns: ReadonlyArray<RandomPatternSelection>): string | undefined {
-  if (randomPatterns.length === 0) {
+  const count = randomPatterns.length;
+  if (count === 0) {
     return undefined;
   }
-  if (randomPatterns.length === 1) {
+  if (count === 1) {
     const only = randomPatterns[0];
     return `RANDOM ${only.current}/${only.total}`;
   }
-  const parts = randomPatterns.map((pattern) => `#${pattern.index} ${pattern.current}/${pattern.total}`);
-  return `RANDOM ${parts.join('  ')}`;
+
+  let summary = 'RANDOM ';
+  for (let index = 0; index < count; index += 1) {
+    const pattern = randomPatterns[index]!;
+    if (index > 0) {
+      summary += '  ';
+    }
+    summary += `#${pattern.index} ${pattern.current}/${pattern.total}`;
+  }
+  return summary;
 }
 
 function parsePositiveInteger(value?: string): number | undefined {
@@ -2241,6 +2249,23 @@ function stripNonPlayableEvents(json: BeMusicJson): BeMusicJson {
 }
 
 export function isPlayLaneChannelForVolumeControl(channel: string): boolean {
+  if (channel.length === 2) {
+    const sideCode = channel.charCodeAt(0);
+    const laneCode = channel.charCodeAt(1);
+    if (
+      laneCode >= 0x31 &&
+      laneCode <= 0x39 &&
+      (sideCode === 0x31 ||
+        sideCode === 0x32 ||
+        sideCode === 0x33 ||
+        sideCode === 0x34 ||
+        sideCode === 0x35 ||
+        sideCode === 0x36)
+    ) {
+      return true;
+    }
+  }
+
   const normalized = normalizeChannel(channel);
   if (isPlayableEventChannel(normalized)) {
     return true;
@@ -2250,10 +2275,7 @@ export function isPlayLaneChannelForVolumeControl(channel: string): boolean {
   }
   const side = normalized[0];
   const lane = normalized[1];
-  if (lane < '1' || lane > '9') {
-    return false;
-  }
-  return side === '3' || side === '4';
+  return (side === '3' || side === '4') && lane >= '1' && lane <= '9';
 }
 
 function isPlayableEventChannel(channel: string): boolean {
@@ -2485,19 +2507,23 @@ function mixRenderResults(leftResult: RenderResult, rightResult: RenderResult): 
 }
 
 export function resolveBgmHeadroomGain(playableResult: RenderResult, bgmResult: RenderResult): number {
-  const frameLength = Math.max(playableResult.left.length, bgmResult.left.length);
+  const playableLeft = playableResult.left;
+  const playableRight = playableResult.right;
+  const bgmLeft = bgmResult.left;
+  const bgmRight = bgmResult.right;
+  const frameLength = Math.max(playableLeft.length, bgmLeft.length);
   let headroomGain = 1;
 
   // Keep playable/key-sound amplitude intact by shrinking only the BGM side when summed peak would clip.
   for (let frame = 0; frame < frameLength; frame += 1) {
-    const playableLeft = Math.abs(playableResult.left[frame] ?? 0);
-    const playableRight = Math.abs(playableResult.right[frame] ?? 0);
-    const bgmLeft = Math.abs(bgmResult.left[frame] ?? 0);
-    const bgmRight = Math.abs(bgmResult.right[frame] ?? 0);
+    const playableLeftAbs = Math.abs(playableLeft[frame] ?? 0);
+    const playableRightAbs = Math.abs(playableRight[frame] ?? 0);
+    const bgmLeftAbs = Math.abs(bgmLeft[frame] ?? 0);
+    const bgmRightAbs = Math.abs(bgmRight[frame] ?? 0);
     headroomGain = Math.min(
       headroomGain,
-      resolveBgmHeadroomGainForChannel(playableLeft, bgmLeft),
-      resolveBgmHeadroomGainForChannel(playableRight, bgmRight),
+      resolveBgmHeadroomGainForChannel(playableLeftAbs, bgmLeftAbs),
+      resolveBgmHeadroomGainForChannel(playableRightAbs, bgmRightAbs),
     );
   }
 

--- a/packages/player/src/playable-notes.ts
+++ b/packages/player/src/playable-notes.ts
@@ -48,84 +48,25 @@ export interface ExtractPlayableNotesOptions {
   inferBmsLnTypeWhenMissing?: boolean;
 }
 
+interface TimedExtractionContext {
+  resolver: ReturnType<typeof createTimingResolver>;
+  beatResolver: ReturnType<typeof createBeatResolver>;
+  sortedEvents: BeMusicEvent[];
+  bmsonResolution?: number;
+}
+
 export function extractTimedNotes(
   json: BeMusicJson,
   options: ExtractTimedNotesOptions = {},
 ): ExtractTimedNotesResult {
   const includeLandmine = options.includeLandmine !== false;
   const includeInvisible = options.includeInvisible === true;
-  const resolver = createTimingResolver(json);
-  const beatResolver = createBeatResolver(json);
-  const sortedEvents = sortEvents(json.events);
-  const bmsonResolution = json.sourceFormat === 'bmson' ? Math.max(1, json.bmson.info.resolution || 240) : undefined;
-  const playableNotes: TimedPlayableNote[] = [];
-  const landmineNotes: TimedLandmineNote[] = [];
-  const invisibleNotes: TimedPlayableNote[] = [];
+  const context = createTimedExtractionContext(json);
+  const playableNotes = collectPlayableNotes(context);
+  const landmineNotes = includeLandmine ? collectLandmineNotes(context) : [];
+  const invisibleNotes = includeInvisible ? collectInvisibleNotes(context) : [];
 
-  for (const event of sortedEvents) {
-    const normalizedChannel = normalizeChannel(event.channel);
-
-    if (isPlayableChannel(normalizedChannel)) {
-      const beat = beatResolver.eventToBeat(event);
-      const endBeat = resolveLongNoteEndBeat(event, beat, normalizedChannel, bmsonResolution);
-      playableNotes.push({
-        event,
-        channel: normalizedChannel,
-        beat,
-        endBeat,
-        endSeconds: endBeat !== undefined ? resolver.beatToSeconds(endBeat) : undefined,
-        seconds: resolver.beatToSeconds(beat),
-        judged: false,
-      });
-      continue;
-    }
-
-    if (includeLandmine) {
-      const mappedLandmineChannel = mapLandmineNormalizedChannelToPlayableLane(normalizedChannel);
-      if (mappedLandmineChannel) {
-        const beat = beatResolver.eventToBeat(event);
-        landmineNotes.push({
-          event,
-          channel: mappedLandmineChannel,
-          beat,
-          seconds: resolver.beatToSeconds(beat),
-          judged: false,
-          mine: true,
-        });
-        continue;
-      }
-    }
-
-    if (includeInvisible) {
-      const mappedInvisibleChannel = mapInvisibleNormalizedChannelToPlayableLane(normalizedChannel);
-      if (mappedInvisibleChannel) {
-        const beat = beatResolver.eventToBeat(event);
-        invisibleNotes.push({
-          event,
-          channel: mappedInvisibleChannel,
-          beat,
-          seconds: resolver.beatToSeconds(beat),
-          judged: false,
-          invisible: true,
-        });
-      }
-    }
-  }
-
-  applyLnobjEndBeatIfNeeded(json, playableNotes, resolver);
-  appendLegacyLongNotesIfNeeded(json, playableNotes, resolver, options);
-  playableNotes.sort((left, right) => {
-    if (left.beat !== right.beat) {
-      return left.beat - right.beat;
-    }
-    if (left.channel !== right.channel) {
-      return left.channel < right.channel ? -1 : 1;
-    }
-    if (left.event.value !== right.event.value) {
-      return left.event.value < right.event.value ? -1 : 1;
-    }
-    return 0;
-  });
+  finalizePlayableNotes(json, playableNotes, context.resolver, options);
   return {
     playableNotes,
     landmineNotes,
@@ -137,25 +78,116 @@ export function extractPlayableNotes(
   json: BeMusicJson,
   options: ExtractPlayableNotesOptions = {},
 ): TimedPlayableNote[] {
-  return extractTimedNotes(json, {
-    includeLandmine: false,
-    includeInvisible: false,
-    inferBmsLnTypeWhenMissing: options.inferBmsLnTypeWhenMissing,
-  }).playableNotes;
+  const context = createTimedExtractionContext(json);
+  const playableNotes = collectPlayableNotes(context);
+  finalizePlayableNotes(json, playableNotes, context.resolver, options);
+  return playableNotes;
 }
 
 export function extractLandmineNotes(json: BeMusicJson): TimedLandmineNote[] {
-  return extractTimedNotes(json, {
-    includeLandmine: true,
-    includeInvisible: false,
-  }).landmineNotes;
+  return collectLandmineNotes(createTimedExtractionContext(json));
 }
 
 export function extractInvisiblePlayableNotes(json: BeMusicJson): TimedPlayableNote[] {
-  return extractTimedNotes(json, {
-    includeLandmine: false,
-    includeInvisible: true,
-  }).invisibleNotes;
+  return collectInvisibleNotes(createTimedExtractionContext(json));
+}
+
+function createTimedExtractionContext(json: BeMusicJson): TimedExtractionContext {
+  return {
+    resolver: createTimingResolver(json),
+    beatResolver: createBeatResolver(json),
+    sortedEvents: sortEvents(json.events),
+    bmsonResolution: json.sourceFormat === 'bmson' ? Math.max(1, json.bmson.info.resolution || 240) : undefined,
+  };
+}
+
+function collectPlayableNotes(context: TimedExtractionContext): TimedPlayableNote[] {
+  const notes: TimedPlayableNote[] = [];
+  for (const event of context.sortedEvents) {
+    const normalizedChannel = normalizeChannel(event.channel);
+    if (!isPlayableChannel(normalizedChannel)) {
+      continue;
+    }
+
+    const beat = context.beatResolver.eventToBeat(event);
+    const endBeat = resolveLongNoteEndBeat(event, beat, normalizedChannel, context.bmsonResolution);
+    notes.push({
+      event,
+      channel: normalizedChannel,
+      beat,
+      endBeat,
+      endSeconds: endBeat !== undefined ? context.resolver.beatToSeconds(endBeat) : undefined,
+      seconds: context.resolver.beatToSeconds(beat),
+      judged: false,
+    });
+  }
+  return notes;
+}
+
+function collectLandmineNotes(context: TimedExtractionContext): TimedLandmineNote[] {
+  const notes: TimedLandmineNote[] = [];
+  for (const event of context.sortedEvents) {
+    const mappedChannel = mapLandmineNormalizedChannelToPlayableLane(normalizeChannel(event.channel));
+    if (!mappedChannel) {
+      continue;
+    }
+
+    const beat = context.beatResolver.eventToBeat(event);
+    notes.push({
+      event,
+      channel: mappedChannel,
+      beat,
+      seconds: context.resolver.beatToSeconds(beat),
+      judged: false,
+      mine: true,
+    });
+  }
+  return notes;
+}
+
+function collectInvisibleNotes(context: TimedExtractionContext): TimedPlayableNote[] {
+  const notes: TimedPlayableNote[] = [];
+  for (const event of context.sortedEvents) {
+    const mappedChannel = mapInvisibleNormalizedChannelToPlayableLane(normalizeChannel(event.channel));
+    if (!mappedChannel) {
+      continue;
+    }
+
+    const beat = context.beatResolver.eventToBeat(event);
+    notes.push({
+      event,
+      channel: mappedChannel,
+      beat,
+      seconds: context.resolver.beatToSeconds(beat),
+      judged: false,
+      invisible: true,
+    });
+  }
+  return notes;
+}
+
+function finalizePlayableNotes(
+  json: BeMusicJson,
+  notes: TimedPlayableNote[],
+  resolver: ReturnType<typeof createTimingResolver>,
+  options: Pick<ExtractTimedNotesOptions, 'inferBmsLnTypeWhenMissing'>,
+): void {
+  applyLnobjEndBeatIfNeeded(json, notes, resolver);
+  appendLegacyLongNotesIfNeeded(json, notes, resolver, options);
+  notes.sort(comparePlayableNotes);
+}
+
+function comparePlayableNotes(left: TimedPlayableNote, right: TimedPlayableNote): number {
+  if (left.beat !== right.beat) {
+    return left.beat - right.beat;
+  }
+  if (left.channel !== right.channel) {
+    return left.channel < right.channel ? -1 : 1;
+  }
+  if (left.event.value !== right.event.value) {
+    return left.event.value < right.event.value ? -1 : 1;
+  }
+  return 0;
 }
 
 function applyLnobjEndBeatIfNeeded(

--- a/packages/utils/scripts/exports-cases.ts
+++ b/packages/utils/scripts/exports-cases.ts
@@ -93,9 +93,31 @@ export function registerUtilsExportsCases(define: DefineBenchmarkCase): void {
       utilsApi.createAbortError();
     },
   });
+  define('utils.isAbortError', {
+    run: () => {
+      utilsApi.isAbortError(new Error('x'));
+    },
+  });
   define('utils.throwIfAborted', {
     run: () => {
       utilsApi.throwIfAborted(undefined);
+    },
+  });
+  define('utils.resolveFirstExistingPath', {
+    run: async (fixtures) => {
+      await utilsApi.resolveFirstExistingPath(fixtures.tmpDir, ['missing.wav', 'missing.ogg']);
+    },
+  });
+  define('utils.writeStereoPcm16Le', {
+    run: (fixtures) => {
+      const buffer = Buffer.allocUnsafe(16);
+      utilsApi.writeStereoPcm16Le(buffer, 0, fixtures.sampleRenderResult.left, fixtures.sampleRenderResult.right, 0, 4);
+    },
+  });
+  define('utils.writeStereoPcm16Be', {
+    run: (fixtures) => {
+      const buffer = Buffer.allocUnsafe(16);
+      utilsApi.writeStereoPcm16Be(buffer, 0, fixtures.sampleRenderResult.left, fixtures.sampleRenderResult.right, 0, 4);
     },
   });
 }

--- a/packages/utils/src/abort.test.ts
+++ b/packages/utils/src/abort.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from 'vitest';
+import { createAbortError, isAbortError, throwIfAborted } from './index.ts';
+
+test('abort utils: createAbortError and isAbortError return AbortError semantics', () => {
+  const error = createAbortError();
+  expect(error).toBeInstanceOf(Error);
+  expect(error.name).toBe('AbortError');
+  expect(error.message).toBe('The operation was aborted.');
+  expect(isAbortError(error)).toBe(true);
+  expect(isAbortError(new Error('x'))).toBe(false);
+  expect(isAbortError(undefined)).toBe(false);
+});
+
+test('abort utils: throwIfAborted throws only for aborted signals', () => {
+  expect(() => throwIfAborted(undefined)).not.toThrow();
+  const abortController = new AbortController();
+  expect(() => throwIfAborted(abortController.signal)).not.toThrow();
+  abortController.abort();
+  expect(() => throwIfAborted(abortController.signal)).toThrowError(/aborted/);
+});

--- a/packages/utils/src/abort.ts
+++ b/packages/utils/src/abort.ts
@@ -1,16 +1,18 @@
+const ABORT_ERROR_MESSAGE = 'The operation was aborted.';
+const ABORT_ERROR_NAME = 'AbortError';
+
 export function createAbortError(): Error {
-  const error = new Error('The operation was aborted.');
-  error.name = 'AbortError';
+  const error = new Error(ABORT_ERROR_MESSAGE);
+  error.name = ABORT_ERROR_NAME;
   return error;
 }
 
 export function isAbortError(error: unknown): boolean {
-  return error instanceof Error && error.name === 'AbortError';
+  return error instanceof Error && error.name === ABORT_ERROR_NAME;
 }
 
 export function throwIfAborted(signal: AbortSignal | undefined): void {
-  if (!signal?.aborted) {
-    return;
+  if (signal?.aborted === true) {
+    throw createAbortError();
   }
-  throw createAbortError();
 }

--- a/packages/utils/src/abort.ts
+++ b/packages/utils/src/abort.ts
@@ -4,6 +4,10 @@ export function createAbortError(): Error {
   return error;
 }
 
+export function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
 export function throwIfAborted(signal: AbortSignal | undefined): void {
   if (!signal?.aborted) {
     return;

--- a/packages/utils/src/index.test.ts
+++ b/packages/utils/src/index.test.ts
@@ -18,6 +18,8 @@ describe('utils', () => {
 
 test('resolveCliPath: resolves to an absolute path from the specified cwd', () => {
   expect(resolveCliPath('chart/test.bms', '/tmp')).toBe(resolve('/tmp', 'chart/test.bms'));
+  expect(resolveCliPath('./chart/test.bms', '/tmp')).toBe(resolve('/tmp', './chart/test.bms'));
+  expect(resolveCliPath('./', '/tmp')).toBe(resolve('/tmp', './'));
 });
 
 test('clamp/clampSignedUnit: clamps values to configured ranges', () => {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,6 +1,24 @@
 import { resolve } from 'node:path';
 
 export function resolveCliPath(path: string, cwd: string = process.env.INIT_CWD ?? process.cwd()): string {
+  if (path.length === 0 || path === '.') {
+    return cwd;
+  }
+
+  // Most CLI paths are simple relative paths without parent traversal.
+  if (!path.includes('..') && !path.includes('\\')) {
+    if (path.startsWith('./')) {
+      const relativePath = path.slice(2);
+      if (relativePath.length === 0) {
+        return cwd;
+      }
+      return cwd.endsWith('/') ? `${cwd}${relativePath}` : `${cwd}/${relativePath}`;
+    }
+    const firstCode = path.charCodeAt(0);
+    if (firstCode !== 0x2f && firstCode !== 0x2e) {
+      return cwd.endsWith('/') ? `${cwd}${path}` : `${cwd}/${path}`;
+    }
+  }
   return resolve(cwd, path);
 }
 
@@ -33,32 +51,39 @@ export function floatToInt16(value: number): number {
 }
 
 export function normalizeNonNegativeInt(value: number, fallback = 0): number {
-  if (value >= 0 && value < Number.POSITIVE_INFINITY) {
-    return Math.floor(value);
-  }
-  if (value === Number.NEGATIVE_INFINITY || value !== value || value === Number.POSITIVE_INFINITY) {
+  if (!Number.isFinite(value)) {
     return fallback;
   }
-  return 0;
+  const normalized = Math.trunc(value);
+  return normalized >= 0 ? normalized : 0;
 }
 
 export function normalizePositiveInt(value: number, fallback = 1): number {
-  if (value > 0 && value < Number.POSITIVE_INFINITY) {
-    const normalized = Math.floor(value);
-    return normalized >= 1 ? normalized : 1;
+  if (!Number.isFinite(value) || value <= 0) {
+    return fallback;
   }
-  return fallback;
+  const normalized = Math.trunc(value);
+  return normalized >= 1 ? normalized : 1;
 }
 
 export function normalizeFractionNumerator(value: number, denominator: number, fallback = 0): number {
-  const safeDenominator = normalizePositiveInt(denominator, 1);
-  if (value === Number.POSITIVE_INFINITY || value === Number.NEGATIVE_INFINITY || value !== value) {
+  if (!Number.isFinite(value)) {
     return fallback;
   }
-  const normalized = Math.floor(value);
-  if (normalized < 0) {
+
+  const normalized = Math.trunc(value);
+  if (normalized <= 0) {
     return 0;
   }
+
+  let safeDenominator = 1;
+  if (Number.isFinite(denominator) && denominator > 0) {
+    safeDenominator = Math.trunc(denominator);
+    if (safeDenominator < 1) {
+      safeDenominator = 1;
+    }
+  }
+
   const maxNumerator = safeDenominator - 1;
   if (normalized > maxNumerator) {
     return maxNumerator;
@@ -125,8 +150,13 @@ export function normalizeSortedUniqueNonNegativeIntegers(values: ReadonlyArray<n
     if (value === Number.POSITIVE_INFINITY || value === Number.NEGATIVE_INFINITY || value !== value) {
       continue;
     }
-    const floored = Math.floor(value);
-    normalized[normalizedLength] = floored < 0 ? 0 : floored;
+    if (value <= 0) {
+      normalized[normalizedLength] = 0;
+    } else if (value < 0x8000_0000) {
+      normalized[normalizedLength] = value | 0;
+    } else {
+      normalized[normalizedLength] = Math.floor(value);
+    }
     normalizedLength += 1;
   }
   normalized.length = normalizedLength;
@@ -134,7 +164,20 @@ export function normalizeSortedUniqueNonNegativeIntegers(values: ReadonlyArray<n
     return normalized;
   }
 
-  normalized.sort((left, right) => left - right);
+  if (normalizedLength <= 16) {
+    for (let index = 1; index < normalizedLength; index += 1) {
+      const current = normalized[index]!;
+      let insertIndex = index - 1;
+      while (insertIndex >= 0 && normalized[insertIndex]! > current) {
+        normalized[insertIndex + 1] = normalized[insertIndex]!;
+        insertIndex -= 1;
+      }
+      normalized[insertIndex + 1] = current;
+    }
+  } else {
+    normalized.sort((left, right) => left - right);
+  }
+
   let writeIndex = 1;
   let previous = normalized[0]!;
   for (let readIndex = 1; readIndex < normalized.length; readIndex += 1) {
@@ -194,11 +237,9 @@ export function normalizeAsciiBase36Code(code: number): number {
   if (code >= 0x30 && code <= 0x39) {
     return code;
   }
-  if (code >= 0x41 && code <= 0x5a) {
-    return code;
-  }
-  if (code >= 0x61 && code <= 0x7a) {
-    return code - 0x20;
+  const uppercase = code & 0xdf;
+  if (uppercase >= 0x41 && uppercase <= 0x5a) {
+    return uppercase;
   }
   return -1;
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -33,24 +33,26 @@ export function floatToInt16(value: number): number {
 }
 
 export function normalizeNonNegativeInt(value: number, fallback = 0): number {
-  if (!Number.isFinite(value)) {
+  if (value >= 0 && value < Number.POSITIVE_INFINITY) {
+    return Math.floor(value);
+  }
+  if (value === Number.NEGATIVE_INFINITY || value !== value || value === Number.POSITIVE_INFINITY) {
     return fallback;
   }
-  const normalized = Math.floor(value);
-  return normalized < 0 ? 0 : normalized;
+  return 0;
 }
 
 export function normalizePositiveInt(value: number, fallback = 1): number {
-  if (!Number.isFinite(value) || value <= 0) {
-    return fallback;
+  if (value > 0 && value < Number.POSITIVE_INFINITY) {
+    const normalized = Math.floor(value);
+    return normalized >= 1 ? normalized : 1;
   }
-  const normalized = Math.floor(value);
-  return normalized < 1 ? 1 : normalized;
+  return fallback;
 }
 
 export function normalizeFractionNumerator(value: number, denominator: number, fallback = 0): number {
   const safeDenominator = normalizePositiveInt(denominator, 1);
-  if (!Number.isFinite(value)) {
+  if (value === Number.POSITIVE_INFINITY || value === Number.NEGATIVE_INFINITY || value !== value) {
     return fallback;
   }
   const normalized = Math.floor(value);
@@ -116,15 +118,19 @@ export function compareFractions(
 }
 
 export function normalizeSortedUniqueNonNegativeIntegers(values: ReadonlyArray<number>): number[] {
-  const normalized: number[] = [];
-  for (const value of values) {
-    if (!Number.isFinite(value)) {
+  const normalized = new Array<number>(values.length);
+  let normalizedLength = 0;
+  for (let index = 0; index < values.length; index += 1) {
+    const value = values[index]!;
+    if (value === Number.POSITIVE_INFINITY || value === Number.NEGATIVE_INFINITY || value !== value) {
       continue;
     }
     const floored = Math.floor(value);
-    normalized.push(floored < 0 ? 0 : floored);
+    normalized[normalizedLength] = floored < 0 ? 0 : floored;
+    normalizedLength += 1;
   }
-  if (normalized.length <= 1) {
+  normalized.length = normalizedLength;
+  if (normalizedLength <= 1) {
     return normalized;
   }
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -23,27 +23,15 @@ export function resolveCliPath(path: string, cwd: string = process.env.INIT_CWD 
 }
 
 export function clamp(value: number, min: number, max: number): number {
-  if (value <= min) {
-    return min;
-  }
-  if (value >= max) {
-    return max;
-  }
-  return value;
+  return value <= min ? min : value >= max ? max : value;
 }
 
 export function clampSignedUnit(value: number): number {
-  if (value <= -1) {
-    return -1;
-  }
-  if (value >= 1) {
-    return 1;
-  }
-  return value;
+  return value <= -1 ? -1 : value >= 1 ? 1 : value;
 }
 
 export function floatToInt16(value: number): number {
-  const clamped = clampSignedUnit(value);
+  const clamped = value <= -1 ? -1 : value >= 1 ? 1 : value;
   if (clamped >= 0) {
     return Math.round(clamped * 32767);
   }
@@ -51,7 +39,7 @@ export function floatToInt16(value: number): number {
 }
 
 export function normalizeNonNegativeInt(value: number, fallback = 0): number {
-  if (!Number.isFinite(value)) {
+  if (value !== value || value === Number.POSITIVE_INFINITY || value === Number.NEGATIVE_INFINITY) {
     return fallback;
   }
   const normalized = Math.trunc(value);
@@ -59,7 +47,7 @@ export function normalizeNonNegativeInt(value: number, fallback = 0): number {
 }
 
 export function normalizePositiveInt(value: number, fallback = 1): number {
-  if (!Number.isFinite(value) || value <= 0) {
+  if (value <= 0 || value !== value || value === Number.POSITIVE_INFINITY || value === Number.NEGATIVE_INFINITY) {
     return fallback;
   }
   const normalized = Math.trunc(value);
@@ -67,7 +55,7 @@ export function normalizePositiveInt(value: number, fallback = 1): number {
 }
 
 export function normalizeFractionNumerator(value: number, denominator: number, fallback = 0): number {
-  if (!Number.isFinite(value)) {
+  if (value !== value || value === Number.POSITIVE_INFINITY || value === Number.NEGATIVE_INFINITY) {
     return fallback;
   }
 
@@ -77,7 +65,7 @@ export function normalizeFractionNumerator(value: number, denominator: number, f
   }
 
   let safeDenominator = 1;
-  if (Number.isFinite(denominator) && denominator > 0) {
+  if (denominator > 0 && denominator === denominator && denominator !== Number.POSITIVE_INFINITY) {
     safeDenominator = Math.trunc(denominator);
     if (safeDenominator < 1) {
       safeDenominator = 1;
@@ -121,14 +109,11 @@ export function compareFractions(
 
   const leftScaled = leftNumerator * rightDenominator;
   const rightScaled = rightNumerator * leftDenominator;
-  if (Number.isSafeInteger(leftScaled) && Number.isSafeInteger(rightScaled)) {
-    if (leftScaled < rightScaled) {
-      return -1;
-    }
-    if (leftScaled > rightScaled) {
-      return 1;
-    }
+  if (leftScaled === rightScaled) {
     return 0;
+  }
+  if (Number.isSafeInteger(leftScaled) && Number.isSafeInteger(rightScaled)) {
+    return leftScaled < rightScaled ? -1 : 1;
   }
 
   const leftScaledBigInt = BigInt(leftNumerator) * BigInt(rightDenominator);
@@ -199,18 +184,17 @@ export function findLastIndexAtOrBefore<T>(
   resolveValue: (item: T) => number,
 ): number {
   let low = 0;
-  let high = items.length - 1;
-  let answer = -1;
-  while (low <= high) {
+  let high = items.length;
+  while (low < high) {
     const mid = (low + high) >>> 1;
-    if (resolveValue(items[mid]!) <= target) {
-      answer = mid;
+    const value = resolveValue(items[mid]!);
+    if (value <= target) {
       low = mid + 1;
     } else {
-      high = mid - 1;
+      high = mid;
     }
   }
-  return answer;
+  return low - 1;
 }
 
 export function findLastIndexBefore<T>(
@@ -219,18 +203,17 @@ export function findLastIndexBefore<T>(
   resolveValue: (item: T) => number,
 ): number {
   let low = 0;
-  let high = items.length - 1;
-  let answer = -1;
-  while (low <= high) {
+  let high = items.length;
+  while (low < high) {
     const mid = (low + high) >>> 1;
-    if (resolveValue(items[mid]!) < target) {
-      answer = mid;
+    const value = resolveValue(items[mid]!);
+    if (value < target) {
       low = mid + 1;
     } else {
-      high = mid - 1;
+      high = mid;
     }
   }
-  return answer;
+  return low - 1;
 }
 
 export function normalizeAsciiBase36Code(code: number): number {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -198,4 +198,6 @@ export function normalizeAsciiBase36Code(code: number): number {
 }
 
 export * from './abort.ts';
+export * from './path.ts';
+export * from './pcm.ts';
 export * from './workerize.ts';

--- a/packages/utils/src/path.test.ts
+++ b/packages/utils/src/path.test.ts
@@ -1,0 +1,30 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, expect, test } from 'vitest';
+import { resolveFirstExistingPath } from './index.ts';
+
+const createdDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    createdDirs.splice(0).map(async (directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+test('resolveFirstExistingPath: returns the first existing candidate resolved from baseDir', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'be-music-utils-path-'));
+  createdDirs.push(directory);
+  const targetPath = join(directory, 'sample.wav');
+  await writeFile(targetPath, 'ok', 'utf8');
+
+  await expect(resolveFirstExistingPath(directory, ['missing.wav', 'sample.wav'])).resolves.toBe(targetPath);
+});
+
+test('resolveFirstExistingPath: propagates AbortError when already aborted', async () => {
+  const controller = new AbortController();
+  controller.abort();
+  await expect(resolveFirstExistingPath('/tmp', ['sample.wav'], controller.signal)).rejects.toMatchObject({
+    name: 'AbortError',
+  });
+});

--- a/packages/utils/src/path.ts
+++ b/packages/utils/src/path.ts
@@ -1,0 +1,32 @@
+import { access } from 'node:fs/promises';
+import { isAbsolute, resolve } from 'node:path';
+import { isAbortError, throwIfAborted } from './abort.ts';
+
+export async function resolveFirstExistingPath(
+  baseDir: string,
+  candidates: Iterable<string>,
+  signal?: AbortSignal,
+): Promise<string | undefined> {
+  for (const candidate of candidates) {
+    throwIfAborted(signal);
+    const absolute = isAbsolute(candidate) ? candidate : resolve(baseDir, candidate);
+    if (await pathExists(absolute, signal)) {
+      return absolute;
+    }
+  }
+  return undefined;
+}
+
+async function pathExists(path: string, signal?: AbortSignal): Promise<boolean> {
+  try {
+    throwIfAborted(signal);
+    await access(path);
+    throwIfAborted(signal);
+    return true;
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw error;
+    }
+    return false;
+  }
+}

--- a/packages/utils/src/pcm.test.ts
+++ b/packages/utils/src/pcm.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from 'vitest';
+import { floatToInt16, writeStereoPcm16Be, writeStereoPcm16Le } from './index.ts';
+
+test('writeStereoPcm16Le: writes interleaved little-endian samples', () => {
+  const buffer = Buffer.allocUnsafe(8);
+  writeStereoPcm16Le(buffer, 0, new Float32Array([1, -1]), new Float32Array([-0.5, 0.5]));
+
+  expect(buffer.readInt16LE(0)).toBe(floatToInt16(1));
+  expect(buffer.readInt16LE(2)).toBe(floatToInt16(-0.5));
+  expect(buffer.readInt16LE(4)).toBe(floatToInt16(-1));
+  expect(buffer.readInt16LE(6)).toBe(floatToInt16(0.5));
+});
+
+test('writeStereoPcm16Be: writes interleaved big-endian samples', () => {
+  const buffer = Buffer.allocUnsafe(8);
+  writeStereoPcm16Be(buffer, 0, new Float32Array([1, -1]), new Float32Array([-0.5, 0.5]));
+
+  expect(buffer.readInt16BE(0)).toBe(floatToInt16(1));
+  expect(buffer.readInt16BE(2)).toBe(floatToInt16(-0.5));
+  expect(buffer.readInt16BE(4)).toBe(floatToInt16(-1));
+  expect(buffer.readInt16BE(6)).toBe(floatToInt16(0.5));
+});

--- a/packages/utils/src/pcm.ts
+++ b/packages/utils/src/pcm.ts
@@ -1,0 +1,121 @@
+const HOST_IS_LITTLE_ENDIAN = new Uint8Array(new Uint16Array([0x00ff]).buffer)[0] === 0xff;
+
+export function writeStereoPcm16Le(
+  destination: Buffer,
+  byteOffset: number,
+  left: ArrayLike<number>,
+  right: ArrayLike<number>,
+  startFrame = 0,
+  frameCount: number = Math.min(left.length, right.length) - startFrame,
+): void {
+  const framesToWrite = resolveFrameCount(destination, byteOffset, left, right, startFrame, frameCount);
+  if (framesToWrite <= 0) {
+    return;
+  }
+  if (HOST_IS_LITTLE_ENDIAN && (byteOffset & 1) === 0) {
+    const samples = new Int16Array(destination.buffer, destination.byteOffset + byteOffset, framesToWrite * 2);
+    fillInterleavedInt16(samples, left, right, startFrame, framesToWrite);
+    return;
+  }
+  writeStereoPcm16Fallback(destination, byteOffset, left, right, startFrame, framesToWrite, false);
+}
+
+export function writeStereoPcm16Be(
+  destination: Buffer,
+  byteOffset: number,
+  left: ArrayLike<number>,
+  right: ArrayLike<number>,
+  startFrame = 0,
+  frameCount: number = Math.min(left.length, right.length) - startFrame,
+): void {
+  const framesToWrite = resolveFrameCount(destination, byteOffset, left, right, startFrame, frameCount);
+  if (framesToWrite <= 0) {
+    return;
+  }
+  if ((byteOffset & 1) === 0) {
+    const bytes = framesToWrite * 4;
+    const segment = destination.subarray(byteOffset, byteOffset + bytes);
+    const samples = new Int16Array(segment.buffer, segment.byteOffset, framesToWrite * 2);
+    fillInterleavedInt16(samples, left, right, startFrame, framesToWrite);
+    if (HOST_IS_LITTLE_ENDIAN) {
+      segment.swap16();
+    }
+    return;
+  }
+  writeStereoPcm16Fallback(destination, byteOffset, left, right, startFrame, framesToWrite, true);
+}
+
+function resolveFrameCount(
+  destination: Buffer,
+  byteOffset: number,
+  left: ArrayLike<number>,
+  right: ArrayLike<number>,
+  startFrame: number,
+  frameCount: number,
+): number {
+  const safeStartFrame = Math.max(0, Math.floor(startFrame));
+  const availableSourceFrames = Math.min(left.length, right.length) - safeStartFrame;
+  if (availableSourceFrames <= 0) {
+    return 0;
+  }
+  const requestedFrames = Number.isFinite(frameCount) ? Math.max(0, Math.floor(frameCount)) : availableSourceFrames;
+  if (requestedFrames <= 0) {
+    return 0;
+  }
+  const availableDestinationFrames = Math.floor(Math.max(0, destination.byteLength - byteOffset) / 4);
+  if (availableDestinationFrames <= 0) {
+    return 0;
+  }
+  return Math.min(requestedFrames, availableSourceFrames, availableDestinationFrames);
+}
+
+function fillInterleavedInt16(
+  destination: Int16Array,
+  left: ArrayLike<number>,
+  right: ArrayLike<number>,
+  startFrame: number,
+  frameCount: number,
+): void {
+  let sourceFrame = startFrame;
+  let sampleIndex = 0;
+  for (let frame = 0; frame < frameCount; frame += 1) {
+    destination[sampleIndex] = floatToInt16Local(left[sourceFrame]!);
+    destination[sampleIndex + 1] = floatToInt16Local(right[sourceFrame]!);
+    sourceFrame += 1;
+    sampleIndex += 2;
+  }
+}
+
+function writeStereoPcm16Fallback(
+  destination: Buffer,
+  byteOffset: number,
+  left: ArrayLike<number>,
+  right: ArrayLike<number>,
+  startFrame: number,
+  frameCount: number,
+  bigEndian: boolean,
+): void {
+  let pointer = byteOffset;
+  let sourceFrame = startFrame;
+  for (let frame = 0; frame < frameCount; frame += 1) {
+    const leftSample = floatToInt16Local(left[sourceFrame]!);
+    const rightSample = floatToInt16Local(right[sourceFrame]!);
+    if (bigEndian) {
+      destination.writeInt16BE(leftSample, pointer);
+      destination.writeInt16BE(rightSample, pointer + 2);
+    } else {
+      destination.writeInt16LE(leftSample, pointer);
+      destination.writeInt16LE(rightSample, pointer + 2);
+    }
+    sourceFrame += 1;
+    pointer += 4;
+  }
+}
+
+function floatToInt16Local(value: number): number {
+  const clamped = value <= -1 ? -1 : value >= 1 ? 1 : value;
+  if (clamped >= 0) {
+    return Math.round(clamped * 32767);
+  }
+  return Math.round(clamped * 32768);
+}

--- a/packages/utils/src/workerize.test.ts
+++ b/packages/utils/src/workerize.test.ts
@@ -1,30 +1,7 @@
 import { describe, expect, test } from 'vitest';
-import { createAbortError, invokeWorkerizedFunction, throwIfAborted, workerize } from './index.ts';
+import { invokeWorkerizedFunction, workerize } from './index.ts';
 
 describe('workerize utilities', () => {
-  test('createAbortError: creates AbortError instances', () => {
-    const error = createAbortError();
-    expect(error).toBeInstanceOf(Error);
-    expect(error.name).toBe('AbortError');
-    expect(error.message).toBe('The operation was aborted.');
-  });
-
-  test('throwIfAborted: throws only for aborted signals', () => {
-    expect(() => throwIfAborted(undefined)).not.toThrow();
-    const abortController = new AbortController();
-    expect(() => throwIfAborted(abortController.signal)).not.toThrow();
-    abortController.abort();
-    try {
-      throwIfAborted(abortController.signal);
-      throw new Error('Expected AbortError');
-    } catch (error) {
-      expect(error).toMatchObject({
-        name: 'AbortError',
-        message: 'The operation was aborted.',
-      });
-    }
-  });
-
   test('invokeWorkerizedFunction: resolves workerized results', async () => {
     const worker = workerize((value: number) => value + 1, () => []);
     try {

--- a/packages/utils/src/workerize.ts
+++ b/packages/utils/src/workerize.ts
@@ -30,6 +30,17 @@ export async function invokeWorkerizedFunction<TArgs extends unknown[], TResult>
   options: InvokeWorkerizedFunctionOptions = {},
 ): Promise<TResult> {
   throwIfAborted(options.signal);
+  if (!options.signal && !options.onAbort) {
+    return new Promise<TResult>((resolve, reject) => {
+      worker(...args, (error, result) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(result);
+      });
+    });
+  }
   return new Promise<TResult>((resolve, reject) => {
     let settled = false;
     const onAbort = (): void => {

--- a/scripts/bench/exports.ts
+++ b/scripts/bench/exports.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env tsx
 
+import { execFileSync } from 'node:child_process';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { performance } from 'node:perf_hooks';
@@ -159,7 +160,7 @@ export async function runExportsBenchmark(options: CliOptions): Promise<ExportsB
   const snapshot: ExportsBenchmarkSnapshot = {
     schemaVersion: 1,
     createdAt: new Date().toISOString(),
-    gitSha: process.env.GITHUB_SHA,
+    gitSha: resolveSnapshotGitSha(),
     nodeVersion: process.version,
     platform: process.platform,
     options: {
@@ -197,6 +198,25 @@ export async function runExportsBenchmarkCli(
 
 async function main(): Promise<void> {
   await runExportsBenchmarkCli();
+}
+
+function resolveSnapshotGitSha(): string | undefined {
+  const envSha = process.env.BENCH_GIT_SHA?.trim();
+  if (envSha) {
+    return envSha;
+  }
+
+  try {
+    const gitSha = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: repositoryDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    return gitSha || undefined;
+  } catch {
+    const githubSha = process.env.GITHUB_SHA?.trim();
+    return githubSha || undefined;
+  }
 }
 
 function createBenchmarkCases(): Map<string, BenchmarkCaseDefinition> {


### PR DESCRIPTION
## Summary
- extract shared abort/error helpers into `@be-music/utils`
- share first-existing-path resolution across preview/BGA/sample loading paths
- add shared stereo PCM writers and use them in audio encoding and preview playback
- simplify chart selection traversal and remove duplicated local helpers

## Verification
- `npx -y pnpm -w typecheck`
- `npx -y pnpm exec vitest run packages/utils/src/*.test.ts packages/audio-renderer/src/index.test.ts`
- `npx -y pnpm bench`

## Benchmarks
- `audio-renderer.writeAudioFile`: 14813.52 ops/s
- `audio-renderer.renderChartFile`: 427.35 ops/s
- `audio-renderer.renderJson`: 912.35 ops/s