### PR TITLE
fix(player): move node TUI rendering to a worker

### DIFF
--- a/packages/player/src/cli/runner.ts
+++ b/packages/player/src/cli/runner.ts
@@ -6,15 +6,8 @@ import { isAbortError, resolveCliPath } from '@be-music/utils';
 import readline from 'node:readline';
 import { parseChartFile } from '@be-music/parser';
 import { renderJson, writeAudioFile } from '@be-music/audio-renderer';
-import {
-  autoPlay,
-  manualPlay,
-  PlayerInterruptedError,
-  type PlayerLoadProgress,
-  type PlayerSummary,
-} from '../index.ts';
-import { createNodeInputRuntime } from '../node/node-input-runtime.ts';
-import { createNodeUiRuntime } from '../node/node-ui-runtime.ts';
+import { PlayerInterruptedError, type PlayerLoadProgress, type PlayerSummary } from '../index.ts';
+import { runNodeGameplayRuntime } from '../node/node-gameplay-runtime.ts';
 import {
   HIGH_SPEED_STEP,
   MAX_HIGH_SPEED,
@@ -476,7 +469,10 @@ function resolvePersistedConfigForSongSelect(
       resolved.lastSelectedChartFileByDirectory = byDirectory;
     }
   }
-  if (resolved.lastSelectedChartFileByDirectory && Object.keys(resolved.lastSelectedChartFileByDirectory).length === 0) {
+  if (
+    resolved.lastSelectedChartFileByDirectory &&
+    Object.keys(resolved.lastSelectedChartFileByDirectory).length === 0
+  ) {
     delete resolved.lastSelectedChartFileByDirectory;
   }
   return resolved;
@@ -665,32 +661,6 @@ async function playChartOnce(chartPath: string, args: CliArgs): Promise<PlayedCh
       return extension.length > 0 ? extension : undefined;
     })(),
     tui: args.tui,
-    createUiRuntime: args.tui
-      ? async (context: Parameters<typeof createNodeUiRuntime>[0]) => {
-          const runtime = await createNodeUiRuntime(context);
-          if (!runtime.tuiEnabled && args.tui) {
-            process.stdout.write('TUI is unavailable in this environment. Falling back to text output.\n');
-          }
-          return runtime;
-        }
-      : undefined,
-    createInputRuntime: (context: Parameters<typeof createNodeInputRuntime>[0]) => createNodeInputRuntime(context),
-    writeOutput: (text: string): void => {
-      process.stdout.write(text);
-    },
-    onHighSpeedChange: (value: number): void => {
-      resolvedHighSpeed = normalizeHighSpeedValue(value);
-    },
-    onLoadProgress: reportPlayLoadingProgress
-      ? (progress: PlayerLoadProgress): void => {
-          const mappedRatio = 0.22 + Math.max(0, Math.min(1, progress.ratio)) * 0.76;
-          reportPlayLoadingProgress({
-            ratio: mappedRatio,
-            message: progress.message,
-            detail: progress.detail,
-          });
-        }
-      : undefined,
   };
 
   let summary: PlayerSummary;
@@ -701,19 +671,30 @@ async function playChartOnce(chartPath: string, args: CliArgs): Promise<PlayedCh
       playbackLoadingAbortCapture = undefined;
     };
     try {
-      summary = args.auto
-        ? await autoPlay(json, {
-            ...playOptions,
-            auto: true,
-            signal: playbackLoadingAbortCapture?.signal,
-            onLoadComplete: disposePlaybackLoadingAbortCapture,
-          })
-        : await manualPlay(json, {
-            ...playOptions,
-            autoScratch: args.autoScratch,
-            signal: playbackLoadingAbortCapture?.signal,
-            onLoadComplete: disposePlaybackLoadingAbortCapture,
-          });
+      summary = await runNodeGameplayRuntime({
+        json,
+        mode: args.auto ? 'auto' : 'manual',
+        autoScratch: args.autoScratch,
+        playOptions,
+        signal: playbackLoadingAbortCapture?.signal,
+        writeOutput: (text: string): void => {
+          process.stdout.write(text);
+        },
+        onHighSpeedChange: (value: number): void => {
+          resolvedHighSpeed = normalizeHighSpeedValue(value);
+        },
+        onLoadProgress: reportPlayLoadingProgress
+          ? (progress: PlayerLoadProgress): void => {
+              const mappedRatio = 0.22 + Math.max(0, Math.min(1, progress.ratio)) * 0.76;
+              reportPlayLoadingProgress({
+                ratio: mappedRatio,
+                message: progress.message,
+                detail: progress.detail,
+              });
+            }
+          : undefined,
+        onLoadComplete: disposePlaybackLoadingAbortCapture,
+      });
       break;
     } catch (error) {
       const cancelReason = resolveLoadingCancelReason(error, playbackLoadingAbortCapture);
@@ -747,7 +728,11 @@ async function playChartOnce(chartPath: string, args: CliArgs): Promise<PlayedCh
   };
 }
 
-async function playSingleChartUntilExit(chartPath: string, rootDir: string, args: CliArgs): Promise<ResultScreenExitAction> {
+async function playSingleChartUntilExit(
+  chartPath: string,
+  rootDir: string,
+  args: CliArgs,
+): Promise<ResultScreenExitAction> {
   while (true) {
     const played = await playChartOnce(chartPath, args);
     const action = await showResultScreen(rootDir, played, {
@@ -1470,7 +1455,6 @@ async function selectChartInteractively(
     render();
   });
 }
-
 
 function getEntryFocusKey(entry: ChartSelectionEntry | undefined): string | undefined {
   if (!entry) {

--- a/packages/player/src/core/player-engine.ts
+++ b/packages/player/src/core/player-engine.ts
@@ -30,11 +30,7 @@ import {
   resolveLaneDisplayMode,
   type LaneBinding,
 } from '../manual-input.ts';
-import {
-  extractTimedNotes,
-  type TimedLandmineNote,
-  type TimedPlayableNote,
-} from '../playable-notes.ts';
+import { extractTimedNotes, type TimedLandmineNote, type TimedPlayableNote } from '../playable-notes.ts';
 import { formatSeconds, resolveAltModifierLabel, resolveChartVolWavGain } from '../player-utils.ts';
 import { createNodeAudioSink, type AudioSink } from '../audio-sink.ts';
 import {
@@ -45,20 +41,15 @@ import {
 } from './high-speed-control.ts';
 import { createPlayerUiSignalBus, type PlayerUiSignalBus } from './player-ui-signal-bus.ts';
 import { createPlayerInputSignalBus, type PlayerInputSignalBus } from './player-input-signal-bus.ts';
-import {
-  IIDX_EX_SCORE_PER_PGREAT,
-  IIDX_SCORE_MAX,
-  applyJudgeToSummary,
-  createScoreTracker,
-} from './scoring.ts';
+import { IIDX_EX_SCORE_PER_PGREAT, IIDX_SCORE_MAX, applyJudgeToSummary, createScoreTracker } from './scoring.ts';
 import { resolveJudgeWindowsMs } from './judge-window.ts';
 import { createBeatAtSecondsResolver } from './timeline.ts';
 
 export interface PlayerUiRuntime {
   readonly tuiEnabled: boolean;
   start: () => void;
-  stop: () => void;
-  dispose: () => void;
+  stop: () => void | Promise<void>;
+  dispose: () => void | Promise<void>;
   triggerPoor: (seconds: number) => void;
   clearPoor: () => void;
 }
@@ -269,7 +260,12 @@ export function applyFastSlowForJudge(
   }
 }
 
-export { extractInvisiblePlayableNotes, extractLandmineNotes, extractPlayableNotes, extractTimedNotes } from '../playable-notes.ts';
+export {
+  extractInvisiblePlayableNotes,
+  extractLandmineNotes,
+  extractPlayableNotes,
+  extractTimedNotes,
+} from '../playable-notes.ts';
 
 function reportLoadProgress(options: PlayerOptions, ratio: number, message: string, detail?: string): void {
   const listener = options.onLoadProgress;
@@ -772,8 +768,8 @@ export async function autoPlay(json: BeMusicJson, options: PlayerOptions = {}): 
       await finalizeAudioSessionSafely(audioSession);
     }
     inputRuntime?.stop();
-    uiRuntime?.stop();
-    uiRuntime?.dispose();
+    await settleMaybeAsyncWithTimeout(uiRuntime?.stop(), 300);
+    await settleMaybeAsyncWithTimeout(uiRuntime?.dispose(), 300);
   }
 
   if (interruptedReason === 'ctrl-c') {
@@ -1460,8 +1456,8 @@ export async function manualPlay(json: BeMusicJson, options: PlayerOptions = {})
       await finalizeAudioSessionSafely(audioSession);
     }
     inputRuntime?.stop();
-    uiRuntime?.stop();
-    uiRuntime?.dispose();
+    await settleMaybeAsyncWithTimeout(uiRuntime?.stop(), 300);
+    await settleMaybeAsyncWithTimeout(uiRuntime?.dispose(), 300);
   }
 
   if (interruptedReason) {
@@ -1507,6 +1503,16 @@ async function settleWithTimeout(task: Promise<void>, timeoutMs: number): Promis
     });
   await Promise.race([guardedTask, delay(timeoutMs)]);
   return completed;
+}
+
+async function settleMaybeAsyncWithTimeout(
+  task: void | Promise<void> | undefined,
+  timeoutMs: number,
+): Promise<boolean> {
+  if (!task) {
+    return true;
+  }
+  return settleWithTimeout(Promise.resolve(task), timeoutMs);
 }
 
 async function createAudioSessionIfEnabled(
@@ -1773,7 +1779,11 @@ async function createDebugActiveAudioEstimator(
   const triggers = collectSampleTriggers(json, resolver, {
     inferBmsLnTypeWhenMissing: options.inferBmsLnTypeWhenMissing === true,
   });
-  const sampleDurationSecondsByKey = await buildDebugSampleDurationSecondsMap(triggers, options.baseDir, options.signal);
+  const sampleDurationSecondsByKey = await buildDebugSampleDurationSecondsMap(
+    triggers,
+    options.baseDir,
+    options.signal,
+  );
   throwIfAborted(options.signal);
   const windows: DebugSampleWindow[] = triggers
     .map((trigger) => {
@@ -1939,7 +1949,8 @@ async function playMixedPcmThroughOutput(params: {
   outputDynamics?: OutputDynamicsConfig;
   playbackSampleRate: number;
 }): Promise<void> {
-  const { output, background, activeVoices, shouldStop, isDraining, isPaused, mode, leadTuning, playbackSampleRate } = params;
+  const { output, background, activeVoices, shouldStop, isDraining, isPaused, mode, leadTuning, playbackSampleRate } =
+    params;
 
   const chunkFrames = mode === 'manual' ? MANUAL_AUDIO_CHUNK_FRAMES : AUTO_AUDIO_CHUNK_FRAMES;
   // Keep one reusable PCM buffer and fill through Int16Array to minimize per-sample write overhead.
@@ -2184,7 +2195,10 @@ function createOutputDynamicsConfig(options: PlayerOptions, sampleRate: number):
     resolveFiniteNumberOption(options.compressorThresholdDb, DEFAULT_COMPRESSOR_THRESHOLD_DB),
   );
   const compressorThresholdLinear = Math.max(1e-4, dbToLinear(compressorThresholdDb));
-  const compressorRatio = Math.max(1.01, resolvePositiveNumberOption(options.compressorRatio, DEFAULT_COMPRESSOR_RATIO));
+  const compressorRatio = Math.max(
+    1.01,
+    resolvePositiveNumberOption(options.compressorRatio, DEFAULT_COMPRESSOR_RATIO),
+  );
   const compressorInvRatioMinusOne = 1 / compressorRatio - 1;
   const compressorAttackMs = resolvePositiveNumberOption(options.compressorAttackMs, DEFAULT_COMPRESSOR_ATTACK_MS);
   const compressorReleaseMs = resolvePositiveNumberOption(options.compressorReleaseMs, DEFAULT_COMPRESSOR_RELEASE_MS);
@@ -2307,8 +2321,7 @@ async function renderAutoMixWithVolumeControls(
     return renderJson(json, {
       ...options,
       normalize: false,
-      resolveTriggerGain: (trigger) =>
-        isPlayLaneChannelForVolumeControl(trigger.channel) ? playVolume : bgmVolume,
+      resolveTriggerGain: (trigger) => (isPlayLaneChannelForVolumeControl(trigger.channel) ? playVolume : bgmVolume),
     });
   }
 
@@ -2434,7 +2447,9 @@ function resolveTriggerVoiceGain(channel: string, playVolume: number, bgmVolume:
 }
 
 function createSilentRenderResult(sampleRate: number): RenderResult {
-  const safeSampleRate = Number.isFinite(sampleRate) ? Math.max(8_000, Math.floor(sampleRate)) : RUNTIME_AUDIO_SAMPLE_RATE;
+  const safeSampleRate = Number.isFinite(sampleRate)
+    ? Math.max(8_000, Math.floor(sampleRate))
+    : RUNTIME_AUDIO_SAMPLE_RATE;
   const left = new Float32Array(0);
   const right = new Float32Array(0);
   return {
@@ -2756,7 +2771,7 @@ function renderSummary(summary: PlayerSummary): string {
   const exScoreRate = maxExScore > 0 ? summary.exScore / maxExScore : 0;
   const scoreRate = summary.score / IIDX_SCORE_MAX;
   return (
-      [
+    [
       '--- Result ---',
       `TOTAL  : ${summary.total}`,
       `PGREAT : ${summary.perfect}`,

--- a/packages/player/src/node/deferred-ui-flush.test.ts
+++ b/packages/player/src/node/deferred-ui-flush.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { createDeferredUiFlush } from './deferred-ui-flush.ts';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('deferred ui flush', () => {
+  test('defers flush work and coalesces repeated frame marks', async () => {
+    vi.useFakeTimers();
+    const flushSpy = vi.fn();
+    const deferred = createDeferredUiFlush(flushSpy);
+
+    deferred.markFrameDirty();
+    deferred.markFrameDirty();
+
+    expect(flushSpy).not.toHaveBeenCalled();
+
+    await vi.runAllTimersAsync();
+
+    expect(flushSpy).toHaveBeenCalledTimes(1);
+    expect(flushSpy).toHaveBeenCalledWith({ frame: true, commands: false });
+  });
+
+  test('flushes frame and command dirties together in one asynchronous pass', async () => {
+    vi.useFakeTimers();
+    const flushSpy = vi.fn();
+    const deferred = createDeferredUiFlush(flushSpy);
+
+    deferred.markFrameDirty();
+    deferred.markCommandsDirty();
+
+    await vi.runAllTimersAsync();
+
+    expect(flushSpy).toHaveBeenCalledTimes(1);
+    expect(flushSpy).toHaveBeenCalledWith({ frame: true, commands: true });
+  });
+});

--- a/packages/player/src/node/deferred-ui-flush.ts
+++ b/packages/player/src/node/deferred-ui-flush.ts
@@ -1,0 +1,68 @@
+import { clearImmediate, setImmediate } from 'node:timers';
+
+export interface DeferredUiFlushState {
+  frame: boolean;
+  commands: boolean;
+}
+
+export interface DeferredUiFlush {
+  markFrameDirty: () => void;
+  markCommandsDirty: () => void;
+  dispose: () => void;
+}
+
+export function createDeferredUiFlush(flush: (state: Readonly<DeferredUiFlushState>) => void): DeferredUiFlush {
+  let framePending = false;
+  let commandsPending = false;
+  let disposed = false;
+  let handle: ReturnType<typeof setImmediate> | undefined;
+
+  const run = (): void => {
+    handle = undefined;
+    if (disposed) {
+      return;
+    }
+
+    const pendingState: DeferredUiFlushState = {
+      frame: framePending,
+      commands: commandsPending,
+    };
+    framePending = false;
+    commandsPending = false;
+
+    if (!pendingState.frame && !pendingState.commands) {
+      return;
+    }
+
+    flush(pendingState);
+
+    if (!disposed && (framePending || commandsPending) && handle === undefined) {
+      handle = setImmediate(run);
+    }
+  };
+
+  const schedule = (): void => {
+    if (disposed || handle !== undefined) {
+      return;
+    }
+    handle = setImmediate(run);
+  };
+
+  return {
+    markFrameDirty: () => {
+      framePending = true;
+      schedule();
+    },
+    markCommandsDirty: () => {
+      commandsPending = true;
+      schedule();
+    },
+    dispose: () => {
+      disposed = true;
+      if (handle !== undefined) {
+        clearImmediate(handle);
+        handle = undefined;
+      }
+    },
+  };
+}

--- a/packages/player/src/node/node-gameplay-runtime.test.ts
+++ b/packages/player/src/node/node-gameplay-runtime.test.ts
@@ -1,0 +1,278 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import type { WorkerOptions } from 'node:worker_threads';
+import { isAbortError } from '@be-music/utils';
+import { createEmptyJson } from '../../../json/src/index.ts';
+import type { NodeInputRuntime } from './node-input-runtime.ts';
+import type { NodeUiRuntime } from './node-ui-runtime.ts';
+
+type MockWorker = EventEmitter & {
+  postMessage: ReturnType<typeof vi.fn>;
+  terminate: ReturnType<typeof vi.fn>;
+};
+
+const workerState = vi.hoisted(() => ({
+  lastWorker: undefined as MockWorker | undefined,
+  lastWorkerOptions: undefined as WorkerOptions | undefined,
+}));
+
+const inputRuntimeState = vi.hoisted(() => ({
+  context: undefined as Parameters<(typeof import('./node-input-runtime.ts'))['createNodeInputRuntime']>[0] | undefined,
+  runtime: undefined as NodeInputRuntime | undefined,
+  start: vi.fn(),
+  stop: vi.fn(),
+}));
+
+const uiRuntimeState = vi.hoisted(() => ({
+  context: undefined as Parameters<(typeof import('./node-ui-runtime.ts'))['createNodeUiRuntime']>[0] | undefined,
+  runtime: undefined as NodeUiRuntime | undefined,
+  start: vi.fn(),
+  stop: vi.fn(async () => undefined),
+  dispose: vi.fn(async () => undefined),
+  triggerPoor: vi.fn(),
+  clearPoor: vi.fn(),
+  tuiEnabled: true,
+}));
+
+vi.mock('node:worker_threads', () => ({
+  Worker: class MockWorker extends EventEmitter {
+    readonly postMessage = vi.fn();
+
+    readonly terminate = vi.fn(async () => 0);
+
+    constructor(...args: unknown[]) {
+      super();
+      workerState.lastWorker = this;
+      workerState.lastWorkerOptions = args[1] as WorkerOptions | undefined;
+    }
+  },
+}));
+
+vi.mock('./node-input-runtime.ts', () => ({
+  createNodeInputRuntime: vi.fn((context) => {
+    inputRuntimeState.context = context;
+    inputRuntimeState.runtime = {
+      start: inputRuntimeState.start,
+      stop: inputRuntimeState.stop,
+    };
+    return inputRuntimeState.runtime;
+  }),
+}));
+
+vi.mock('./node-ui-runtime.ts', () => ({
+  createNodeUiRuntime: vi.fn(async (context) => {
+    uiRuntimeState.context = context;
+    uiRuntimeState.runtime = {
+      tuiEnabled: uiRuntimeState.tuiEnabled,
+      start: uiRuntimeState.start,
+      stop: uiRuntimeState.stop,
+      dispose: uiRuntimeState.dispose,
+      triggerPoor: uiRuntimeState.triggerPoor,
+      clearPoor: uiRuntimeState.clearPoor,
+    };
+    return uiRuntimeState.runtime;
+  }),
+}));
+
+import { runNodeGameplayRuntime } from './node-gameplay-runtime.ts';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  workerState.lastWorker = undefined;
+  workerState.lastWorkerOptions = undefined;
+  inputRuntimeState.context = undefined;
+  inputRuntimeState.runtime = undefined;
+  inputRuntimeState.start.mockReset();
+  inputRuntimeState.stop.mockReset();
+  uiRuntimeState.context = undefined;
+  uiRuntimeState.runtime = undefined;
+  uiRuntimeState.start.mockReset();
+  uiRuntimeState.stop.mockReset();
+  uiRuntimeState.dispose.mockReset();
+  uiRuntimeState.triggerPoor.mockReset();
+  uiRuntimeState.clearPoor.mockReset();
+  uiRuntimeState.tuiEnabled = true;
+});
+
+describe('node gameplay runtime', () => {
+  test('creates input runtime and forwards input commands to the gameplay worker', async () => {
+    const promise = runNodeGameplayRuntime(createOptions());
+    const worker = getLastWorker();
+
+    worker.emit('message', {
+      kind: 'input-init',
+      runtime: {
+        mode: 'manual',
+        inputTokenToChannelsEntries: [['a', ['11']]],
+      },
+    });
+
+    expect(inputRuntimeState.context?.mode).toBe('manual');
+    expect(inputRuntimeState.context?.inputTokenToChannels.get('a')).toEqual(['11']);
+
+    inputRuntimeState.context?.inputSignals.pushCommand({
+      kind: 'lane-input',
+      tokens: ['a'],
+    });
+
+    expect(messagesOfKind(worker, 'input-commands')).toEqual([
+      {
+        kind: 'input-commands',
+        commands: [{ kind: 'lane-input', tokens: ['a'] }],
+      },
+    ]);
+
+    worker.emit('message', { kind: 'result', summary: createSummary() });
+    await expect(promise).resolves.toEqual(createSummary());
+    expect(inputRuntimeState.stop).toHaveBeenCalled();
+  });
+
+  test('bridges UI lifecycle and updates through the main thread runtime', async () => {
+    const promise = runNodeGameplayRuntime(createOptions());
+    const worker = getLastWorker();
+
+    worker.emit('message', {
+      kind: 'ui-init',
+      requestId: 3,
+      runtime: createUiInit(),
+    });
+    await Promise.resolve();
+
+    expect(uiRuntimeState.context?.laneDisplayMode).toBe('7 KEY');
+    expect(messagesOfKind(worker, 'ui-init-result')).toEqual([{ kind: 'ui-init-result', requestId: 3, enabled: true }]);
+
+    worker.emit('message', { kind: 'ui-start' });
+    expect(uiRuntimeState.start).toHaveBeenCalled();
+
+    worker.emit('message', {
+      kind: 'ui-frame',
+      frame: {
+        ...createUiInit().initialFrame,
+        currentBeat: 8,
+        currentSeconds: 4,
+      },
+    });
+    expect(uiRuntimeState.context?.uiSignals.getFrame()).toMatchObject({
+      currentBeat: 8,
+      currentSeconds: 4,
+    });
+
+    worker.emit('message', {
+      kind: 'ui-set-judge-combo',
+      state: {
+        judge: 'GREAT',
+        combo: 12,
+        channel: '11',
+        updatedAtMs: 1234,
+      },
+    });
+    expect(uiRuntimeState.context?.stateSignals.getJudgeCombo()).toMatchObject({
+      judge: 'GREAT',
+      combo: 12,
+      channel: '11',
+      updatedAtMs: 1234,
+    });
+
+    worker.emit('message', { kind: 'ui-trigger-poor', seconds: 1.25 });
+    worker.emit('message', { kind: 'ui-clear-poor' });
+    expect(uiRuntimeState.triggerPoor).toHaveBeenCalledWith(1.25);
+    expect(uiRuntimeState.clearPoor).toHaveBeenCalled();
+
+    worker.emit('message', { kind: 'ui-stop', requestId: 4 });
+    await Promise.resolve();
+    expect(uiRuntimeState.stop).toHaveBeenCalled();
+    expect(messagesOfKind(worker, 'ui-stop-result')).toEqual([{ kind: 'ui-stop-result', requestId: 4 }]);
+
+    worker.emit('message', { kind: 'ui-dispose', requestId: 5 });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(uiRuntimeState.dispose).toHaveBeenCalled();
+    expect(messagesOfKind(worker, 'ui-dispose-result')).toEqual([{ kind: 'ui-dispose-result', requestId: 5 }]);
+
+    worker.emit('message', { kind: 'result', summary: createSummary() });
+    await promise;
+  });
+
+  test('maps worker abort errors back to AbortError', async () => {
+    const promise = runNodeGameplayRuntime(createOptions());
+    const worker = getLastWorker();
+
+    worker.emit('message', {
+      kind: 'error',
+      name: 'AbortError',
+      message: 'The operation was aborted.',
+    });
+
+    await expect(promise).rejects.toSatisfy((error: unknown) => isAbortError(error));
+  });
+});
+
+function createOptions(): Parameters<typeof runNodeGameplayRuntime>[0] {
+  return {
+    json: createEmptyJson('bms'),
+    mode: 'manual',
+    playOptions: {
+      tui: true,
+      speed: 1,
+      audioBaseDir: process.cwd(),
+    },
+  };
+}
+
+function createUiInit() {
+  return {
+    json: createEmptyJson('bms'),
+    mode: 'MANUAL' as const,
+    laneDisplayMode: '7 KEY',
+    laneBindings: [{ channel: '11', keyLabel: 'A', inputTokens: ['a'], isScratch: false, side: '1P' as const }],
+    speed: 1,
+    judgeWindowMs: 16.67,
+    highSpeed: 1,
+    showLaneChannels: false,
+    baseDir: process.cwd(),
+    initialFrame: {
+      currentBeat: 0,
+      currentSeconds: 0,
+      totalSeconds: 120,
+      summary: createSummary(),
+      notes: [],
+    },
+    initialPaused: false,
+    initialJudgeCombo: {
+      judge: 'READY',
+      combo: 0,
+      updatedAtMs: 0,
+    },
+  };
+}
+
+function createSummary() {
+  return {
+    total: 100,
+    perfect: 0,
+    fast: 0,
+    slow: 0,
+    great: 0,
+    good: 0,
+    bad: 0,
+    poor: 0,
+    exScore: 0,
+    score: 0,
+  };
+}
+
+function getLastWorker(): MockWorker {
+  if (!workerState.lastWorker) {
+    throw new Error('worker was not created');
+  }
+  return workerState.lastWorker;
+}
+
+function messagesOfKind(worker: MockWorker, kind: string): unknown[] {
+  return worker.postMessage.mock.calls
+    .map((call) => call[0])
+    .filter(
+      (message): message is { kind: string } => typeof message === 'object' && message !== null && 'kind' in message,
+    )
+    .filter((message) => message.kind === kind);
+}

--- a/packages/player/src/node/node-gameplay-runtime.test.ts
+++ b/packages/player/src/node/node-gameplay-runtime.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'node:events';
 import { afterEach, describe, expect, test, vi } from 'vitest';
-import type { WorkerOptions } from 'node:worker_threads';
+import { MessageChannel, type MessagePort, type WorkerOptions } from 'node:worker_threads';
 import { isAbortError } from '@be-music/utils';
 import { createEmptyJson } from '../../../json/src/index.ts';
 import type { NodeInputRuntime } from './node-input-runtime.ts';
@@ -26,6 +26,7 @@ const inputRuntimeState = vi.hoisted(() => ({
 const uiRuntimeState = vi.hoisted(() => ({
   context: undefined as Parameters<(typeof import('./node-ui-runtime.ts'))['createNodeUiRuntime']>[0] | undefined,
   runtime: undefined as NodeUiRuntime | undefined,
+  bridgePort: undefined as MessagePort | undefined,
   start: vi.fn(),
   stop: vi.fn(async () => undefined),
   dispose: vi.fn(async () => undefined),
@@ -34,19 +35,23 @@ const uiRuntimeState = vi.hoisted(() => ({
   tuiEnabled: true,
 }));
 
-vi.mock('node:worker_threads', () => ({
-  Worker: class MockWorker extends EventEmitter {
-    readonly postMessage = vi.fn();
+vi.mock('node:worker_threads', async () => {
+  const actual = await vi.importActual<typeof import('node:worker_threads')>('node:worker_threads');
+  return {
+    ...actual,
+    Worker: class MockWorker extends EventEmitter {
+      readonly postMessage = vi.fn();
 
-    readonly terminate = vi.fn(async () => 0);
+      readonly terminate = vi.fn(async () => 0);
 
-    constructor(...args: unknown[]) {
-      super();
-      workerState.lastWorker = this;
-      workerState.lastWorkerOptions = args[1] as WorkerOptions | undefined;
-    }
-  },
-}));
+      constructor(...args: unknown[]) {
+        super();
+        workerState.lastWorker = this;
+        workerState.lastWorkerOptions = args[1] as WorkerOptions | undefined;
+      }
+    },
+  };
+});
 
 vi.mock('./node-input-runtime.ts', () => ({
   createNodeInputRuntime: vi.fn((context) => {
@@ -62,6 +67,7 @@ vi.mock('./node-input-runtime.ts', () => ({
 vi.mock('./node-ui-runtime.ts', () => ({
   createNodeUiRuntime: vi.fn(async (context) => {
     uiRuntimeState.context = context;
+    uiRuntimeState.bridgePort = new MessageChannel().port1;
     uiRuntimeState.runtime = {
       tuiEnabled: uiRuntimeState.tuiEnabled,
       start: uiRuntimeState.start,
@@ -69,6 +75,12 @@ vi.mock('./node-ui-runtime.ts', () => ({
       dispose: uiRuntimeState.dispose,
       triggerPoor: uiRuntimeState.triggerPoor,
       clearPoor: uiRuntimeState.clearPoor,
+      createBridgePort: () => {
+        if (!uiRuntimeState.bridgePort) {
+          throw new Error('bridge port missing');
+        }
+        return uiRuntimeState.bridgePort;
+      },
     };
     return uiRuntimeState.runtime;
   }),
@@ -86,6 +98,7 @@ afterEach(() => {
   inputRuntimeState.stop.mockReset();
   uiRuntimeState.context = undefined;
   uiRuntimeState.runtime = undefined;
+  uiRuntimeState.bridgePort = undefined;
   uiRuntimeState.start.mockReset();
   uiRuntimeState.stop.mockReset();
   uiRuntimeState.dispose.mockReset();
@@ -127,7 +140,7 @@ describe('node gameplay runtime', () => {
     expect(inputRuntimeState.stop).toHaveBeenCalled();
   });
 
-  test('bridges UI lifecycle and updates through the main thread runtime', async () => {
+  test('passes a direct bridge port to the gameplay worker and keeps lifecycle acks on the main thread', async () => {
     const promise = runNodeGameplayRuntime(createOptions());
     const worker = getLastWorker();
 
@@ -139,44 +152,10 @@ describe('node gameplay runtime', () => {
     await Promise.resolve();
 
     expect(uiRuntimeState.context?.laneDisplayMode).toBe('7 KEY');
-    expect(messagesOfKind(worker, 'ui-init-result')).toEqual([{ kind: 'ui-init-result', requestId: 3, enabled: true }]);
-
-    worker.emit('message', { kind: 'ui-start' });
-    expect(uiRuntimeState.start).toHaveBeenCalled();
-
-    worker.emit('message', {
-      kind: 'ui-frame',
-      frame: {
-        ...createUiInit().initialFrame,
-        currentBeat: 8,
-        currentSeconds: 4,
-      },
-    });
-    expect(uiRuntimeState.context?.uiSignals.getFrame()).toMatchObject({
-      currentBeat: 8,
-      currentSeconds: 4,
-    });
-
-    worker.emit('message', {
-      kind: 'ui-set-judge-combo',
-      state: {
-        judge: 'GREAT',
-        combo: 12,
-        channel: '11',
-        updatedAtMs: 1234,
-      },
-    });
-    expect(uiRuntimeState.context?.stateSignals.getJudgeCombo()).toMatchObject({
-      judge: 'GREAT',
-      combo: 12,
-      channel: '11',
-      updatedAtMs: 1234,
-    });
-
-    worker.emit('message', { kind: 'ui-trigger-poor', seconds: 1.25 });
-    worker.emit('message', { kind: 'ui-clear-poor' });
-    expect(uiRuntimeState.triggerPoor).toHaveBeenCalledWith(1.25);
-    expect(uiRuntimeState.clearPoor).toHaveBeenCalled();
+    const uiInitResults = messagesOfKind(worker, 'ui-init-result');
+    expect(uiInitResults).toHaveLength(1);
+    expect(uiInitResults[0]).toMatchObject({ kind: 'ui-init-result', requestId: 3, enabled: true });
+    expect((uiInitResults[0] as { port?: MessagePort }).port).toBe(uiRuntimeState.bridgePort);
 
     worker.emit('message', { kind: 'ui-stop', requestId: 4 });
     await Promise.resolve();

--- a/packages/player/src/node/node-gameplay-runtime.ts
+++ b/packages/player/src/node/node-gameplay-runtime.ts
@@ -2,12 +2,10 @@ import { effect } from 'alien-signals';
 import { createAbortError } from '@be-music/utils';
 import type { BeMusicJson } from '@be-music/json';
 import { fileURLToPath } from 'node:url';
-import { Worker } from 'node:worker_threads';
+import { Worker, type TransferListItem } from 'node:worker_threads';
 import { createPlayerInputSignalBus } from '../core/player-input-signal-bus.ts';
 import type { PlayerLoadProgress, PlayerSummary } from '../core/player-engine.ts';
 import { PlayerInterruptedError } from '../core/player-engine.ts';
-import { createPlayerUiSignalBus } from '../core/player-ui-signal-bus.ts';
-import { createPlayerStateSignals, type PlayerStateSignals } from '../player-state-signals.ts';
 import { createNodeInputRuntime, type NodeInputRuntime } from './node-input-runtime.ts';
 import { createNodeUiRuntime, type NodeUiRuntime } from './node-ui-runtime.ts';
 import type {
@@ -44,8 +42,6 @@ export async function runNodeGameplayRuntime(options: NodeGameplayRuntimeOptions
   let inputRuntime: NodeInputRuntime | undefined;
   let stopInputEffect = (): void => undefined;
   let uiRuntime: NodeUiRuntime | undefined;
-  let uiSignals: ReturnType<typeof createPlayerUiSignalBus> | undefined;
-  let stateSignals: PlayerStateSignals | undefined;
   let settled = false;
 
   const cleanup = async (): Promise<void> => {
@@ -56,8 +52,6 @@ export async function runNodeGameplayRuntime(options: NodeGameplayRuntimeOptions
     await settleMaybeAsyncWithTimeout(uiRuntime?.stop(), 200);
     await settleMaybeAsyncWithTimeout(uiRuntime?.dispose(), 300);
     uiRuntime = undefined;
-    uiSignals = undefined;
-    stateSignals = undefined;
   };
 
   return await new Promise<PlayerSummary>((resolve, reject) => {
@@ -129,51 +123,10 @@ export async function runNodeGameplayRuntime(options: NodeGameplayRuntimeOptions
       }
       if (message.kind === 'ui-init') {
         void handleUiInit(worker, message, {
-          setRuntime: (runtime, nextUiSignals, nextStateSignals) => {
+          setRuntime: (runtime) => {
             uiRuntime = runtime;
-            uiSignals = nextUiSignals;
-            stateSignals = nextStateSignals;
           },
         });
-        return;
-      }
-      if (message.kind === 'ui-start') {
-        uiRuntime?.start();
-        return;
-      }
-      if (message.kind === 'ui-frame') {
-        uiSignals?.publishFrame(message.frame);
-        return;
-      }
-      if (message.kind === 'ui-commands') {
-        for (const command of message.commands) {
-          uiSignals?.pushCommand(command);
-        }
-        return;
-      }
-      if (message.kind === 'ui-set-paused') {
-        stateSignals?.setPaused(message.value);
-        return;
-      }
-      if (message.kind === 'ui-set-high-speed') {
-        stateSignals?.setHighSpeed(message.value);
-        return;
-      }
-      if (message.kind === 'ui-set-judge-combo') {
-        stateSignals?.publishJudgeCombo(
-          message.state.judge,
-          message.state.combo,
-          message.state.channel,
-          message.state.updatedAtMs,
-        );
-        return;
-      }
-      if (message.kind === 'ui-trigger-poor') {
-        uiRuntime?.triggerPoor(message.seconds);
-        return;
-      }
-      if (message.kind === 'ui-clear-poor') {
-        uiRuntime?.clearPoor();
         return;
       }
       if (message.kind === 'ui-stop') {
@@ -184,8 +137,6 @@ export async function runNodeGameplayRuntime(options: NodeGameplayRuntimeOptions
         void handleUiLifecycleAck(worker, message.requestId, 'ui-dispose-result', async () => {
           await uiRuntime?.dispose();
           uiRuntime = undefined;
-          uiSignals = undefined;
-          stateSignals = undefined;
         });
         return;
       }
@@ -225,23 +176,9 @@ async function handleUiInit(
   worker: Worker,
   message: Extract<NodeGameplayWorkerOutboundMessage, { kind: 'ui-init' }>,
   runtimeStore: {
-    setRuntime: (
-      runtime: NodeUiRuntime | undefined,
-      uiSignals: ReturnType<typeof createPlayerUiSignalBus> | undefined,
-      stateSignals: PlayerStateSignals | undefined,
-    ) => void;
+    setRuntime: (runtime: NodeUiRuntime | undefined) => void;
   },
 ): Promise<void> {
-  const localUiSignals = createPlayerUiSignalBus(message.runtime.initialFrame);
-  const localStateSignals = createPlayerStateSignals(message.runtime.highSpeed);
-  localStateSignals.setPaused(message.runtime.initialPaused);
-  localStateSignals.publishJudgeCombo(
-    message.runtime.initialJudgeCombo.judge,
-    message.runtime.initialJudgeCombo.combo,
-    message.runtime.initialJudgeCombo.channel,
-    message.runtime.initialJudgeCombo.updatedAtMs,
-  );
-
   try {
     const runtime = await createNodeUiRuntime({
       json: message.runtime.json,
@@ -253,9 +190,9 @@ async function handleUiInit(
       highSpeed: message.runtime.highSpeed,
       showLaneChannels: message.runtime.showLaneChannels,
       randomPatternSummary: message.runtime.randomPatternSummary,
-      stateSignals: localStateSignals,
-      uiSignals: localUiSignals,
       baseDir: message.runtime.baseDir,
+      initialPaused: message.runtime.initialPaused,
+      initialJudgeCombo: message.runtime.initialJudgeCombo,
       onBgaLoadProgress: (progress) => {
         postWorkerMessage(worker, {
           kind: 'ui-bga-load-progress',
@@ -264,18 +201,20 @@ async function handleUiInit(
         });
       },
     });
-    runtimeStore.setRuntime(
-      runtime.tuiEnabled ? runtime : undefined,
-      runtime.tuiEnabled ? localUiSignals : undefined,
-      runtime.tuiEnabled ? localStateSignals : undefined,
-    );
-    postWorkerMessage(worker, {
+    runtimeStore.setRuntime(runtime.tuiEnabled ? runtime : undefined);
+    const transferList: TransferListItem[] = [];
+    const response: NodeGameplayWorkerInboundMessage = {
       kind: 'ui-init-result',
       requestId: message.requestId,
       enabled: runtime.tuiEnabled,
-    });
+    };
+    if (runtime.tuiEnabled) {
+      response.port = runtime.createBridgePort();
+      transferList.push(response.port);
+    }
+    postWorkerMessage(worker, response, transferList);
   } catch (error) {
-    runtimeStore.setRuntime(undefined, undefined, undefined);
+    runtimeStore.setRuntime(undefined);
     postWorkerMessage(worker, {
       kind: 'ui-init-result',
       requestId: message.requestId,
@@ -331,8 +270,12 @@ function resolveNodeGameplayWorkerEnv(): NodeJS.ProcessEnv {
   };
 }
 
-function postWorkerMessage(worker: Worker, message: NodeGameplayWorkerInboundMessage): void {
-  worker.postMessage(message);
+function postWorkerMessage(
+  worker: Worker,
+  message: NodeGameplayWorkerInboundMessage,
+  transferList?: TransferListItem[],
+): void {
+  worker.postMessage(message, transferList ?? []);
 }
 
 async function settleMaybeAsyncWithTimeout(

--- a/packages/player/src/node/node-gameplay-runtime.ts
+++ b/packages/player/src/node/node-gameplay-runtime.ts
@@ -1,0 +1,357 @@
+import { effect } from 'alien-signals';
+import { createAbortError } from '@be-music/utils';
+import type { BeMusicJson } from '@be-music/json';
+import { fileURLToPath } from 'node:url';
+import { Worker } from 'node:worker_threads';
+import { createPlayerInputSignalBus } from '../core/player-input-signal-bus.ts';
+import type { PlayerLoadProgress, PlayerSummary } from '../core/player-engine.ts';
+import { PlayerInterruptedError } from '../core/player-engine.ts';
+import { createPlayerUiSignalBus } from '../core/player-ui-signal-bus.ts';
+import { createPlayerStateSignals, type PlayerStateSignals } from '../player-state-signals.ts';
+import { createNodeInputRuntime, type NodeInputRuntime } from './node-input-runtime.ts';
+import { createNodeUiRuntime, type NodeUiRuntime } from './node-ui-runtime.ts';
+import type {
+  NodeGameplayWorkerInboundMessage,
+  NodeGameplayWorkerInitData,
+  NodeGameplayWorkerOutboundMessage,
+  NodeGameplayWorkerPlayOptions,
+} from './node-gameplay-worker-protocol.ts';
+
+export interface NodeGameplayRuntimeOptions {
+  json: BeMusicJson;
+  mode: 'auto' | 'manual';
+  autoScratch?: boolean;
+  playOptions: NodeGameplayWorkerPlayOptions;
+  signal?: AbortSignal;
+  onLoadProgress?: (progress: PlayerLoadProgress) => void;
+  onLoadComplete?: () => void;
+  onHighSpeedChange?: (value: number) => void;
+  writeOutput?: (text: string) => void;
+}
+
+export async function runNodeGameplayRuntime(options: NodeGameplayRuntimeOptions): Promise<PlayerSummary> {
+  if (options.signal?.aborted) {
+    throw createAbortError();
+  }
+
+  const worker = new Worker(resolveNodeGameplayWorkerUrl(), {
+    workerData: createWorkerInitData(options),
+    execArgv: process.execArgv,
+    env: resolveNodeGameplayWorkerEnv(),
+  });
+  const writeOutput = options.writeOutput ?? ((text: string) => process.stdout.write(text));
+
+  let inputRuntime: NodeInputRuntime | undefined;
+  let stopInputEffect = (): void => undefined;
+  let uiRuntime: NodeUiRuntime | undefined;
+  let uiSignals: ReturnType<typeof createPlayerUiSignalBus> | undefined;
+  let stateSignals: PlayerStateSignals | undefined;
+  let settled = false;
+
+  const cleanup = async (): Promise<void> => {
+    inputRuntime?.stop();
+    inputRuntime = undefined;
+    stopInputEffect();
+    stopInputEffect = () => undefined;
+    await settleMaybeAsyncWithTimeout(uiRuntime?.stop(), 200);
+    await settleMaybeAsyncWithTimeout(uiRuntime?.dispose(), 300);
+    uiRuntime = undefined;
+    uiSignals = undefined;
+    stateSignals = undefined;
+  };
+
+  return await new Promise<PlayerSummary>((resolve, reject) => {
+    const signal = options.signal;
+
+    const settle = (callback: () => void): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup()
+        .catch(() => undefined)
+        .finally(() => {
+          worker.off('message', onMessage);
+          worker.off('error', onError);
+          worker.off('exit', onExit);
+          signal?.removeEventListener('abort', onAbort);
+          callback();
+        });
+    };
+
+    const onMessage = (message: NodeGameplayWorkerOutboundMessage): void => {
+      if (message.kind === 'load-progress') {
+        options.onLoadProgress?.(message.progress);
+        return;
+      }
+      if (message.kind === 'load-complete') {
+        options.onLoadComplete?.();
+        return;
+      }
+      if (message.kind === 'output') {
+        writeOutput(message.text);
+        return;
+      }
+      if (message.kind === 'high-speed') {
+        options.onHighSpeedChange?.(message.value);
+        return;
+      }
+      if (message.kind === 'input-init') {
+        inputRuntime?.stop();
+        stopInputEffect();
+        const inputSignals = createPlayerInputSignalBus();
+        inputRuntime = createNodeInputRuntime({
+          mode: message.runtime.mode,
+          inputSignals,
+          inputTokenToChannels: new Map(
+            message.runtime.inputTokenToChannelsEntries.map(([token, channels]) => [token, [...channels]]),
+          ),
+        });
+        stopInputEffect = effect(() => {
+          inputSignals.tick();
+          const commands = inputSignals.drainCommands();
+          if (commands.length > 0) {
+            postWorkerMessage(worker, {
+              kind: 'input-commands',
+              commands,
+            });
+          }
+        });
+        return;
+      }
+      if (message.kind === 'input-start') {
+        inputRuntime?.start();
+        return;
+      }
+      if (message.kind === 'input-stop') {
+        inputRuntime?.stop();
+        return;
+      }
+      if (message.kind === 'ui-init') {
+        void handleUiInit(worker, message, {
+          setRuntime: (runtime, nextUiSignals, nextStateSignals) => {
+            uiRuntime = runtime;
+            uiSignals = nextUiSignals;
+            stateSignals = nextStateSignals;
+          },
+        });
+        return;
+      }
+      if (message.kind === 'ui-start') {
+        uiRuntime?.start();
+        return;
+      }
+      if (message.kind === 'ui-frame') {
+        uiSignals?.publishFrame(message.frame);
+        return;
+      }
+      if (message.kind === 'ui-commands') {
+        for (const command of message.commands) {
+          uiSignals?.pushCommand(command);
+        }
+        return;
+      }
+      if (message.kind === 'ui-set-paused') {
+        stateSignals?.setPaused(message.value);
+        return;
+      }
+      if (message.kind === 'ui-set-high-speed') {
+        stateSignals?.setHighSpeed(message.value);
+        return;
+      }
+      if (message.kind === 'ui-set-judge-combo') {
+        stateSignals?.publishJudgeCombo(
+          message.state.judge,
+          message.state.combo,
+          message.state.channel,
+          message.state.updatedAtMs,
+        );
+        return;
+      }
+      if (message.kind === 'ui-trigger-poor') {
+        uiRuntime?.triggerPoor(message.seconds);
+        return;
+      }
+      if (message.kind === 'ui-clear-poor') {
+        uiRuntime?.clearPoor();
+        return;
+      }
+      if (message.kind === 'ui-stop') {
+        void handleUiLifecycleAck(worker, message.requestId, 'ui-stop-result', () => uiRuntime?.stop());
+        return;
+      }
+      if (message.kind === 'ui-dispose') {
+        void handleUiLifecycleAck(worker, message.requestId, 'ui-dispose-result', async () => {
+          await uiRuntime?.dispose();
+          uiRuntime = undefined;
+          uiSignals = undefined;
+          stateSignals = undefined;
+        });
+        return;
+      }
+      if (message.kind === 'result') {
+        settle(() => resolve(message.summary));
+        return;
+      }
+      if (message.kind === 'interrupted') {
+        settle(() => reject(new PlayerInterruptedError(message.reason)));
+        return;
+      }
+      if (message.kind === 'error') {
+        settle(() => reject(message.name === 'AbortError' ? createAbortError() : new Error(message.message)));
+      }
+    };
+
+    const onError = (error: Error): void => {
+      settle(() => reject(error));
+    };
+
+    const onExit = (code: number): void => {
+      settle(() => reject(new Error(`Gameplay worker exited unexpectedly (code ${code})`)));
+    };
+
+    const onAbort = (): void => {
+      postWorkerMessage(worker, { kind: 'abort' });
+    };
+
+    worker.on('message', onMessage);
+    worker.on('error', onError);
+    worker.on('exit', onExit);
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+async function handleUiInit(
+  worker: Worker,
+  message: Extract<NodeGameplayWorkerOutboundMessage, { kind: 'ui-init' }>,
+  runtimeStore: {
+    setRuntime: (
+      runtime: NodeUiRuntime | undefined,
+      uiSignals: ReturnType<typeof createPlayerUiSignalBus> | undefined,
+      stateSignals: PlayerStateSignals | undefined,
+    ) => void;
+  },
+): Promise<void> {
+  const localUiSignals = createPlayerUiSignalBus(message.runtime.initialFrame);
+  const localStateSignals = createPlayerStateSignals(message.runtime.highSpeed);
+  localStateSignals.setPaused(message.runtime.initialPaused);
+  localStateSignals.publishJudgeCombo(
+    message.runtime.initialJudgeCombo.judge,
+    message.runtime.initialJudgeCombo.combo,
+    message.runtime.initialJudgeCombo.channel,
+    message.runtime.initialJudgeCombo.updatedAtMs,
+  );
+
+  try {
+    const runtime = await createNodeUiRuntime({
+      json: message.runtime.json,
+      mode: message.runtime.mode,
+      laneDisplayMode: message.runtime.laneDisplayMode,
+      laneBindings: message.runtime.laneBindings,
+      speed: message.runtime.speed,
+      judgeWindowMs: message.runtime.judgeWindowMs,
+      highSpeed: message.runtime.highSpeed,
+      showLaneChannels: message.runtime.showLaneChannels,
+      randomPatternSummary: message.runtime.randomPatternSummary,
+      stateSignals: localStateSignals,
+      uiSignals: localUiSignals,
+      baseDir: message.runtime.baseDir,
+      onBgaLoadProgress: (progress) => {
+        postWorkerMessage(worker, {
+          kind: 'ui-bga-load-progress',
+          requestId: message.requestId,
+          progress,
+        });
+      },
+    });
+    runtimeStore.setRuntime(
+      runtime.tuiEnabled ? runtime : undefined,
+      runtime.tuiEnabled ? localUiSignals : undefined,
+      runtime.tuiEnabled ? localStateSignals : undefined,
+    );
+    postWorkerMessage(worker, {
+      kind: 'ui-init-result',
+      requestId: message.requestId,
+      enabled: runtime.tuiEnabled,
+    });
+  } catch (error) {
+    runtimeStore.setRuntime(undefined, undefined, undefined);
+    postWorkerMessage(worker, {
+      kind: 'ui-init-result',
+      requestId: message.requestId,
+      enabled: false,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function handleUiLifecycleAck(
+  worker: Worker,
+  requestId: number,
+  kind: 'ui-stop-result' | 'ui-dispose-result',
+  action: () => void | Promise<void>,
+): Promise<void> {
+  try {
+    await Promise.resolve(action());
+    postWorkerMessage(worker, { kind, requestId });
+  } catch (error) {
+    postWorkerMessage(worker, {
+      kind,
+      requestId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+function createWorkerInitData(options: NodeGameplayRuntimeOptions): NodeGameplayWorkerInitData {
+  return {
+    json: options.json,
+    mode: options.mode,
+    autoScratch: options.autoScratch,
+    playOptions: options.playOptions,
+  };
+}
+
+function resolveNodeGameplayWorkerUrl(): URL {
+  return new URL(
+    import.meta.url.endsWith('.ts') ? './node-gameplay-worker.ts' : './node-gameplay-worker.js',
+    import.meta.url,
+  );
+}
+
+function resolveNodeGameplayWorkerEnv(): NodeJS.ProcessEnv {
+  if (!import.meta.url.endsWith('.ts')) {
+    return process.env;
+  }
+
+  return {
+    ...process.env,
+    TSX_TSCONFIG_PATH:
+      process.env.TSX_TSCONFIG_PATH ?? fileURLToPath(new URL('../../../../tsconfig.typecheck.json', import.meta.url)),
+  };
+}
+
+function postWorkerMessage(worker: Worker, message: NodeGameplayWorkerInboundMessage): void {
+  worker.postMessage(message);
+}
+
+async function settleMaybeAsyncWithTimeout(
+  task: void | Promise<void> | undefined,
+  timeoutMs: number,
+): Promise<boolean> {
+  if (!task) {
+    return true;
+  }
+  return await settleWithTimeout(Promise.resolve(task), timeoutMs);
+}
+
+async function settleWithTimeout(task: Promise<void>, timeoutMs: number): Promise<boolean> {
+  let completed = false;
+  const guardedTask = task
+    .catch(() => undefined)
+    .then(() => {
+      completed = true;
+    });
+  await Promise.race([guardedTask, new Promise((resolve) => setTimeout(resolve, timeoutMs))]);
+  return completed;
+}

--- a/packages/player/src/node/node-gameplay-worker-protocol.ts
+++ b/packages/player/src/node/node-gameplay-worker-protocol.ts
@@ -1,3 +1,4 @@
+import type { MessagePort } from 'node:worker_threads';
 import type { BeMusicJson } from '@be-music/json';
 import type { PlayerInputCommand } from '../core/player-input-signal-bus.ts';
 import type { PlayerInterruptReason, PlayerLoadProgress, PlayerSummary } from '../core/player-engine.ts';
@@ -68,7 +69,7 @@ export interface NodeGameplayInputRuntimeInit {
 export type NodeGameplayWorkerInboundMessage =
   | { kind: 'abort'; reason?: string }
   | { kind: 'input-commands'; commands: PlayerInputCommand[] }
-  | { kind: 'ui-init-result'; requestId: number; enabled: boolean; error?: string }
+  | { kind: 'ui-init-result'; requestId: number; enabled: boolean; port?: MessagePort; error?: string }
   | { kind: 'ui-bga-load-progress'; requestId: number; progress: { ratio: number; detail?: string } }
   | { kind: 'ui-stop-result'; requestId: number; error?: string }
   | { kind: 'ui-dispose-result'; requestId: number; error?: string };

--- a/packages/player/src/node/node-gameplay-worker-protocol.ts
+++ b/packages/player/src/node/node-gameplay-worker-protocol.ts
@@ -1,0 +1,97 @@
+import type { BeMusicJson } from '@be-music/json';
+import type { PlayerInputCommand } from '../core/player-input-signal-bus.ts';
+import type { PlayerInterruptReason, PlayerLoadProgress, PlayerSummary } from '../core/player-engine.ts';
+import type { PlayerUiCommand, PlayerUiFramePayload } from '../core/player-ui-signal-bus.ts';
+import type { LaneBinding } from '../manual-input.ts';
+import type { PlayerJudgeComboSignalState } from '../player-state-signals.ts';
+
+export interface NodeGameplayWorkerPlayOptions {
+  inferBmsLnTypeWhenMissing?: boolean;
+  showInvisibleNotes?: boolean;
+  compressor?: boolean;
+  compressorThresholdDb?: number;
+  compressorRatio?: number;
+  compressorAttackMs?: number;
+  compressorReleaseMs?: number;
+  compressorMakeupDb?: number;
+  limiter?: boolean;
+  limiterCeilingDb?: number;
+  limiterReleaseMs?: number;
+  speed?: number;
+  highSpeed?: number;
+  judgeWindowMs?: number;
+  debugActiveAudio?: boolean;
+  leadInMs?: number;
+  audio?: boolean;
+  bgmVolume?: number;
+  playVolume?: number;
+  audioBaseDir?: string;
+  audioTailSeconds?: number;
+  audioOffsetMs?: number;
+  audioHeadPaddingMs?: number;
+  audioLeadMs?: number;
+  audioLeadMaxMs?: number;
+  audioLeadStepUpMs?: number;
+  audioLeadStepDownMs?: number;
+  laneModeExtension?: string;
+  tui?: boolean;
+}
+
+export interface NodeGameplayWorkerInitData {
+  json: BeMusicJson;
+  mode: 'auto' | 'manual';
+  autoScratch?: boolean;
+  playOptions: NodeGameplayWorkerPlayOptions;
+}
+
+export interface NodeGameplayUiRuntimeInit {
+  json: BeMusicJson;
+  mode: 'AUTO' | 'MANUAL' | 'AUTO SCRATCH';
+  laneDisplayMode: string;
+  laneBindings: LaneBinding[];
+  speed: number;
+  judgeWindowMs: number;
+  highSpeed: number;
+  showLaneChannels: boolean;
+  randomPatternSummary?: string;
+  baseDir: string;
+  initialFrame: PlayerUiFramePayload;
+  initialPaused: boolean;
+  initialJudgeCombo: PlayerJudgeComboSignalState;
+}
+
+export interface NodeGameplayInputRuntimeInit {
+  mode: 'auto' | 'manual';
+  inputTokenToChannelsEntries: Array<[string, string[]]>;
+}
+
+export type NodeGameplayWorkerInboundMessage =
+  | { kind: 'abort'; reason?: string }
+  | { kind: 'input-commands'; commands: PlayerInputCommand[] }
+  | { kind: 'ui-init-result'; requestId: number; enabled: boolean; error?: string }
+  | { kind: 'ui-bga-load-progress'; requestId: number; progress: { ratio: number; detail?: string } }
+  | { kind: 'ui-stop-result'; requestId: number; error?: string }
+  | { kind: 'ui-dispose-result'; requestId: number; error?: string };
+
+export type NodeGameplayWorkerOutboundMessage =
+  | { kind: 'load-progress'; progress: PlayerLoadProgress }
+  | { kind: 'load-complete' }
+  | { kind: 'output'; text: string }
+  | { kind: 'high-speed'; value: number }
+  | { kind: 'input-init'; runtime: NodeGameplayInputRuntimeInit }
+  | { kind: 'input-start' }
+  | { kind: 'input-stop' }
+  | { kind: 'ui-init'; requestId: number; runtime: NodeGameplayUiRuntimeInit }
+  | { kind: 'ui-start' }
+  | { kind: 'ui-frame'; frame: PlayerUiFramePayload }
+  | { kind: 'ui-commands'; commands: PlayerUiCommand[] }
+  | { kind: 'ui-set-paused'; value: boolean }
+  | { kind: 'ui-set-high-speed'; value: number }
+  | { kind: 'ui-set-judge-combo'; state: PlayerJudgeComboSignalState }
+  | { kind: 'ui-trigger-poor'; seconds: number }
+  | { kind: 'ui-clear-poor' }
+  | { kind: 'ui-stop'; requestId: number }
+  | { kind: 'ui-dispose'; requestId: number }
+  | { kind: 'result'; summary: PlayerSummary }
+  | { kind: 'interrupted'; reason: PlayerInterruptReason }
+  | { kind: 'error'; name?: string; message: string; stack?: string };

--- a/packages/player/src/node/node-gameplay-worker.ts
+++ b/packages/player/src/node/node-gameplay-worker.ts
@@ -1,0 +1,350 @@
+import { effect } from 'alien-signals';
+import { createAbortError } from '@be-music/utils';
+import { parentPort, workerData } from 'node:worker_threads';
+import type {
+  CreatePlayerInputRuntimeContext,
+  CreatePlayerUiRuntimeContext,
+  PlayerInputRuntime,
+} from '../core/player-engine.ts';
+import { autoPlay, manualPlay, PlayerInterruptedError } from '../core/player-engine.ts';
+import type { PlayerLoadProgress } from '../core/player-engine.ts';
+import { createDeferredUiFlush } from './deferred-ui-flush.ts';
+import type {
+  NodeGameplayWorkerInboundMessage,
+  NodeGameplayWorkerInitData,
+  NodeGameplayWorkerOutboundMessage,
+  NodeGameplayUiRuntimeInit,
+} from './node-gameplay-worker-protocol.ts';
+
+const port = parentPort;
+const initData = workerData as NodeGameplayWorkerInitData;
+
+void bootstrap().catch((error) => {
+  postWorkerMessage({
+    kind: 'error',
+    name: error instanceof Error ? error.name : undefined,
+    message: error instanceof Error ? error.message : String(error),
+    stack: error instanceof Error ? error.stack : undefined,
+  });
+  throw error;
+});
+
+async function bootstrap(): Promise<void> {
+  if (!port) {
+    throw new Error('Gameplay worker parent port is unavailable');
+  }
+
+  const abortController = new AbortController();
+  let bridgedInputContext: CreatePlayerInputRuntimeContext | undefined;
+  let nextUiRequestId = 0;
+
+  const pendingUiInit = new Map<
+    number,
+    {
+      resolve: (enabled: boolean) => void;
+      reject: (error: Error) => void;
+      onProgress: CreatePlayerUiRuntimeContext['onBgaLoadProgress'];
+    }
+  >();
+  const pendingUiStop = new Map<number, { resolve: () => void; reject: (error: Error) => void }>();
+  const pendingUiDispose = new Map<number, { resolve: () => void; reject: (error: Error) => void }>();
+
+  port.on('message', (message: NodeGameplayWorkerInboundMessage) => {
+    if (message.kind === 'abort') {
+      if (!abortController.signal.aborted) {
+        abortController.abort(resolveAbortReason(message.reason));
+      }
+      return;
+    }
+    if (message.kind === 'input-commands') {
+      for (const command of message.commands) {
+        bridgedInputContext?.inputSignals.pushCommand(command);
+      }
+      return;
+    }
+    if (message.kind === 'ui-init-result') {
+      const pending = pendingUiInit.get(message.requestId);
+      if (!pending) {
+        return;
+      }
+      pendingUiInit.delete(message.requestId);
+      if (typeof message.error === 'string' && message.error.length > 0) {
+        pending.reject(new Error(message.error));
+        return;
+      }
+      pending.resolve(message.enabled);
+      return;
+    }
+    if (message.kind === 'ui-bga-load-progress') {
+      const pending = pendingUiInit.get(message.requestId);
+      pending?.onProgress(message.progress);
+      return;
+    }
+    const pendingAcks = message.kind === 'ui-stop-result' ? pendingUiStop : pendingUiDispose;
+    const pending = pendingAcks.get(message.requestId);
+    if (!pending) {
+      return;
+    }
+    pendingAcks.delete(message.requestId);
+    if (typeof message.error === 'string' && message.error.length > 0) {
+      pending.reject(new Error(message.error));
+      return;
+    }
+    pending.resolve();
+  });
+
+  const createInputRuntime = (context: CreatePlayerInputRuntimeContext): PlayerInputRuntime => {
+    bridgedInputContext = context;
+    postWorkerMessage({
+      kind: 'input-init',
+      runtime: {
+        mode: context.mode,
+        inputTokenToChannelsEntries: [...context.inputTokenToChannels.entries()].map(([token, channels]) => [
+          token,
+          [...channels],
+        ]),
+      },
+    });
+    let started = false;
+    let stopped = false;
+
+    return {
+      start: () => {
+        if (started || stopped) {
+          return;
+        }
+        started = true;
+        postWorkerMessage({ kind: 'input-start' });
+      },
+      stop: () => {
+        if (stopped) {
+          return;
+        }
+        stopped = true;
+        postWorkerMessage({ kind: 'input-stop' });
+      },
+    };
+  };
+
+  const createUiRuntime = async (context: CreatePlayerUiRuntimeContext) => {
+    const initRequestId = nextUiRequestId;
+    nextUiRequestId += 1;
+    const tuiEnabled = await requestUiInit(initRequestId, context, pendingUiInit);
+    if (!tuiEnabled) {
+      postWorkerMessage({
+        kind: 'output',
+        text: 'TUI is unavailable in this environment. Falling back to text output.\n',
+      });
+      return {
+        tuiEnabled: false,
+        start: () => undefined,
+        stop: () => Promise.resolve(),
+        dispose: () => Promise.resolve(),
+        triggerPoor: () => undefined,
+        clearPoor: () => undefined,
+      };
+    }
+
+    let disposed = false;
+    let stopPromise: Promise<void> | undefined;
+    let disposePromise: Promise<void> | undefined;
+
+    const deferredUiFlush = createDeferredUiFlush(({ commands, frame }) => {
+      if (commands) {
+        const queuedCommands = context.uiSignals.drainCommands();
+        if (queuedCommands.length > 0) {
+          postWorkerMessage({ kind: 'ui-commands', commands: queuedCommands });
+        }
+      }
+      if (frame) {
+        postWorkerMessage({ kind: 'ui-frame', frame: context.uiSignals.getFrame() });
+      }
+    });
+
+    const stopFrameEffect = effect(() => {
+      context.uiSignals.frameTick();
+      deferredUiFlush.markFrameDirty();
+    });
+
+    const stopCommandEffect = effect(() => {
+      context.uiSignals.commandTick();
+      deferredUiFlush.markCommandsDirty();
+    });
+
+    const stopPausedEffect = effect(() => {
+      postWorkerMessage({ kind: 'ui-set-paused', value: context.stateSignals.paused() });
+    });
+
+    const stopHighSpeedEffect = effect(() => {
+      postWorkerMessage({ kind: 'ui-set-high-speed', value: context.stateSignals.highSpeed() });
+    });
+
+    const stopJudgeComboEffect = effect(() => {
+      context.stateSignals.judgeComboTick();
+      postWorkerMessage({ kind: 'ui-set-judge-combo', state: context.stateSignals.getJudgeCombo() });
+    });
+
+    return {
+      tuiEnabled: true,
+      start: () => {
+        if (disposed) {
+          return;
+        }
+        postWorkerMessage({ kind: 'ui-start' });
+      },
+      stop: () => {
+        if (disposed) {
+          return Promise.resolve();
+        }
+        if (stopPromise) {
+          return stopPromise;
+        }
+        const requestId = nextUiRequestId;
+        nextUiRequestId += 1;
+        stopPromise = requestUiLifecycleAck('ui-stop', requestId, pendingUiStop);
+        return stopPromise;
+      },
+      dispose: () => {
+        if (disposePromise) {
+          return disposePromise;
+        }
+        disposed = true;
+        deferredUiFlush.dispose();
+        stopFrameEffect();
+        stopCommandEffect();
+        stopPausedEffect();
+        stopHighSpeedEffect();
+        stopJudgeComboEffect();
+        const requestId = nextUiRequestId;
+        nextUiRequestId += 1;
+        disposePromise = requestUiLifecycleAck('ui-dispose', requestId, pendingUiDispose);
+        return disposePromise;
+      },
+      triggerPoor: (seconds: number) => {
+        if (disposed) {
+          return;
+        }
+        postWorkerMessage({ kind: 'ui-trigger-poor', seconds });
+      },
+      clearPoor: () => {
+        if (disposed) {
+          return;
+        }
+        postWorkerMessage({ kind: 'ui-clear-poor' });
+      },
+    };
+  };
+
+  try {
+    const playOptions = {
+      ...initData.playOptions,
+      signal: abortController.signal,
+      createInputRuntime,
+      createUiRuntime: initData.playOptions.tui === true ? createUiRuntime : undefined,
+      writeOutput: (text: string): void => {
+        postWorkerMessage({ kind: 'output', text });
+      },
+      onHighSpeedChange: (value: number): void => {
+        postWorkerMessage({ kind: 'high-speed', value });
+      },
+      onLoadProgress: (progress: PlayerLoadProgress): void => {
+        postWorkerMessage({ kind: 'load-progress', progress });
+      },
+      onLoadComplete: (): void => {
+        postWorkerMessage({ kind: 'load-complete' });
+      },
+    };
+
+    const summary =
+      initData.mode === 'auto'
+        ? await autoPlay(initData.json, {
+            ...playOptions,
+            auto: true,
+          })
+        : await manualPlay(initData.json, {
+            ...playOptions,
+            autoScratch: initData.autoScratch === true,
+          });
+    postWorkerMessage({ kind: 'result', summary });
+  } catch (error) {
+    if (error instanceof PlayerInterruptedError) {
+      postWorkerMessage({ kind: 'interrupted', reason: error.reason });
+    } else {
+      postWorkerMessage({
+        kind: 'error',
+        name: error instanceof Error ? error.name : undefined,
+        message: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+    }
+  } finally {
+    port.close();
+  }
+}
+
+function requestUiInit(
+  requestId: number,
+  context: CreatePlayerUiRuntimeContext,
+  pendingUiInit: Map<
+    number,
+    {
+      resolve: (enabled: boolean) => void;
+      reject: (error: Error) => void;
+      onProgress: CreatePlayerUiRuntimeContext['onBgaLoadProgress'];
+    }
+  >,
+): Promise<boolean> {
+  return new Promise<boolean>((resolve, reject) => {
+    pendingUiInit.set(requestId, {
+      resolve,
+      reject,
+      onProgress: context.onBgaLoadProgress,
+    });
+    postWorkerMessage({
+      kind: 'ui-init',
+      requestId,
+      runtime: serializeUiRuntimeInit(context),
+    });
+  });
+}
+
+function requestUiLifecycleAck(
+  kind: 'ui-stop' | 'ui-dispose',
+  requestId: number,
+  pending: Map<number, { resolve: () => void; reject: (error: Error) => void }>,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    pending.set(requestId, { resolve, reject });
+    postWorkerMessage({ kind, requestId });
+  });
+}
+
+function serializeUiRuntimeInit(context: CreatePlayerUiRuntimeContext): NodeGameplayUiRuntimeInit {
+  return {
+    json: context.json,
+    mode: context.mode,
+    laneDisplayMode: context.laneDisplayMode,
+    laneBindings: [...context.laneBindings],
+    speed: context.speed,
+    judgeWindowMs: context.judgeWindowMs,
+    highSpeed: context.highSpeed,
+    showLaneChannels: context.showLaneChannels,
+    randomPatternSummary: context.randomPatternSummary,
+    baseDir: context.baseDir,
+    initialFrame: context.uiSignals.getFrame(),
+    initialPaused: context.stateSignals.paused(),
+    initialJudgeCombo: context.stateSignals.getJudgeCombo(),
+  };
+}
+
+function resolveAbortReason(reason?: string): Error {
+  const error = createAbortError();
+  if (typeof reason === 'string' && reason.length > 0) {
+    error.message = reason;
+  }
+  return error;
+}
+
+function postWorkerMessage(message: NodeGameplayWorkerOutboundMessage): void {
+  port?.postMessage(message);
+}

--- a/packages/player/src/node/node-gameplay-worker.ts
+++ b/packages/player/src/node/node-gameplay-worker.ts
@@ -1,6 +1,6 @@
 import { effect } from 'alien-signals';
 import { createAbortError } from '@be-music/utils';
-import { parentPort, workerData } from 'node:worker_threads';
+import { parentPort, workerData, type MessagePort } from 'node:worker_threads';
 import type {
   CreatePlayerInputRuntimeContext,
   CreatePlayerUiRuntimeContext,
@@ -41,7 +41,7 @@ async function bootstrap(): Promise<void> {
   const pendingUiInit = new Map<
     number,
     {
-      resolve: (enabled: boolean) => void;
+      resolve: (result: { enabled: boolean; port?: MessagePort }) => void;
       reject: (error: Error) => void;
       onProgress: CreatePlayerUiRuntimeContext['onBgaLoadProgress'];
     }
@@ -72,7 +72,10 @@ async function bootstrap(): Promise<void> {
         pending.reject(new Error(message.error));
         return;
       }
-      pending.resolve(message.enabled);
+      pending.resolve({
+        enabled: message.enabled,
+        port: message.port,
+      });
       return;
     }
     if (message.kind === 'ui-bga-load-progress') {
@@ -129,8 +132,8 @@ async function bootstrap(): Promise<void> {
   const createUiRuntime = async (context: CreatePlayerUiRuntimeContext) => {
     const initRequestId = nextUiRequestId;
     nextUiRequestId += 1;
-    const tuiEnabled = await requestUiInit(initRequestId, context, pendingUiInit);
-    if (!tuiEnabled) {
+    const uiInitResult = await requestUiInit(initRequestId, context, pendingUiInit);
+    if (!uiInitResult.enabled) {
       postWorkerMessage({
         kind: 'output',
         text: 'TUI is unavailable in this environment. Falling back to text output.\n',
@@ -144,6 +147,24 @@ async function bootstrap(): Promise<void> {
         clearPoor: () => undefined,
       };
     }
+    if (!uiInitResult.port) {
+      throw new Error('UI bridge port is unavailable');
+    }
+    const bridgePort = uiInitResult.port;
+
+    const postUiMessage = (
+      message:
+        | { kind: 'start' }
+        | { kind: 'frame'; frame: ReturnType<CreatePlayerUiRuntimeContext['uiSignals']['getFrame']> }
+        | { kind: 'commands'; commands: ReturnType<CreatePlayerUiRuntimeContext['uiSignals']['drainCommands']> }
+        | { kind: 'set-paused'; value: boolean }
+        | { kind: 'set-high-speed'; value: number }
+        | { kind: 'set-judge-combo'; state: ReturnType<CreatePlayerUiRuntimeContext['stateSignals']['getJudgeCombo']> }
+        | { kind: 'trigger-poor'; seconds: number }
+        | { kind: 'clear-poor' },
+    ): void => {
+      bridgePort.postMessage(message);
+    };
 
     let disposed = false;
     let stopPromise: Promise<void> | undefined;
@@ -153,11 +174,11 @@ async function bootstrap(): Promise<void> {
       if (commands) {
         const queuedCommands = context.uiSignals.drainCommands();
         if (queuedCommands.length > 0) {
-          postWorkerMessage({ kind: 'ui-commands', commands: queuedCommands });
+          postUiMessage({ kind: 'commands', commands: queuedCommands });
         }
       }
       if (frame) {
-        postWorkerMessage({ kind: 'ui-frame', frame: context.uiSignals.getFrame() });
+        postUiMessage({ kind: 'frame', frame: context.uiSignals.getFrame() });
       }
     });
 
@@ -172,16 +193,16 @@ async function bootstrap(): Promise<void> {
     });
 
     const stopPausedEffect = effect(() => {
-      postWorkerMessage({ kind: 'ui-set-paused', value: context.stateSignals.paused() });
+      postUiMessage({ kind: 'set-paused', value: context.stateSignals.paused() });
     });
 
     const stopHighSpeedEffect = effect(() => {
-      postWorkerMessage({ kind: 'ui-set-high-speed', value: context.stateSignals.highSpeed() });
+      postUiMessage({ kind: 'set-high-speed', value: context.stateSignals.highSpeed() });
     });
 
     const stopJudgeComboEffect = effect(() => {
       context.stateSignals.judgeComboTick();
-      postWorkerMessage({ kind: 'ui-set-judge-combo', state: context.stateSignals.getJudgeCombo() });
+      postUiMessage({ kind: 'set-judge-combo', state: context.stateSignals.getJudgeCombo() });
     });
 
     return {
@@ -190,7 +211,7 @@ async function bootstrap(): Promise<void> {
         if (disposed) {
           return;
         }
-        postWorkerMessage({ kind: 'ui-start' });
+        postUiMessage({ kind: 'start' });
       },
       stop: () => {
         if (disposed) {
@@ -209,6 +230,7 @@ async function bootstrap(): Promise<void> {
           return disposePromise;
         }
         disposed = true;
+        bridgePort.close();
         deferredUiFlush.dispose();
         stopFrameEffect();
         stopCommandEffect();
@@ -224,13 +246,13 @@ async function bootstrap(): Promise<void> {
         if (disposed) {
           return;
         }
-        postWorkerMessage({ kind: 'ui-trigger-poor', seconds });
+        postUiMessage({ kind: 'trigger-poor', seconds });
       },
       clearPoor: () => {
         if (disposed) {
           return;
         }
-        postWorkerMessage({ kind: 'ui-clear-poor' });
+        postUiMessage({ kind: 'clear-poor' });
       },
     };
   };
@@ -288,13 +310,13 @@ function requestUiInit(
   pendingUiInit: Map<
     number,
     {
-      resolve: (enabled: boolean) => void;
+      resolve: (result: { enabled: boolean; port?: MessagePort }) => void;
       reject: (error: Error) => void;
       onProgress: CreatePlayerUiRuntimeContext['onBgaLoadProgress'];
     }
   >,
-): Promise<boolean> {
-  return new Promise<boolean>((resolve, reject) => {
+): Promise<{ enabled: boolean; port?: MessagePort }> {
+  return new Promise<{ enabled: boolean; port?: MessagePort }>((resolve, reject) => {
     pendingUiInit.set(requestId, {
       resolve,
       reject,

--- a/packages/player/src/node/node-ui-runtime.test.ts
+++ b/packages/player/src/node/node-ui-runtime.test.ts
@@ -1,0 +1,232 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import type { WorkerOptions } from 'node:worker_threads';
+import { createEmptyJson } from '../../../json/src/index.ts';
+import { createPlayerUiSignalBus } from '../core/player-ui-signal-bus.ts';
+import { createPlayerStateSignals } from '../player-state-signals.ts';
+
+type MockWorker = EventEmitter & {
+  postMessage: ReturnType<typeof vi.fn>;
+  terminate: ReturnType<typeof vi.fn>;
+};
+
+const workerState = vi.hoisted(() => ({
+  lastWorker: undefined as MockWorker | undefined,
+  lastWorkerOptions: undefined as WorkerOptions | undefined,
+  autoAckLifecycle: true,
+}));
+
+vi.mock('node:worker_threads', () => ({
+  Worker: class MockWorker extends EventEmitter {
+    readonly postMessage = vi.fn((message: unknown) => {
+      if (!workerState.autoAckLifecycle || typeof message !== 'object' || message === null || !('kind' in message)) {
+        return;
+      }
+      if (message.kind === 'stop') {
+        queueMicrotask(() => {
+          this.emit('message', { kind: 'stopped' });
+        });
+        return;
+      }
+      if (message.kind === 'dispose') {
+        queueMicrotask(() => {
+          this.emit('message', { kind: 'disposed' });
+        });
+      }
+    });
+
+    readonly terminate = vi.fn(async () => 0);
+
+    constructor(..._args: unknown[]) {
+      super();
+      workerState.lastWorkerOptions = _args[1] as WorkerOptions | undefined;
+      workerState.lastWorker = this;
+      queueMicrotask(() => {
+        this.emit('message', { kind: 'ready' });
+      });
+    }
+  },
+}));
+
+import { createNodeUiRuntime } from './node-ui-runtime.ts';
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  workerState.lastWorker = undefined;
+  workerState.lastWorkerOptions = undefined;
+  workerState.autoAckLifecycle = true;
+});
+
+describe('node ui runtime', () => {
+  test('coalesces frames before posting them to the UI worker', async () => {
+    vi.useFakeTimers();
+    const uiSignals = createPlayerUiSignalBus(createFrame());
+    const runtime = await createNodeUiRuntime(createContext(uiSignals));
+    const worker = getLastWorker();
+
+    worker.postMessage.mockClear();
+    uiSignals.publishFrame(createFrame({ currentBeat: 1, currentSeconds: 1 }));
+    uiSignals.publishFrame(createFrame({ currentBeat: 2, currentSeconds: 2 }));
+
+    expect(messagesOfKind(worker, 'frame')).toHaveLength(0);
+
+    await vi.runAllTimersAsync();
+
+    const frameMessages = messagesOfKind(worker, 'frame');
+    expect(frameMessages).toHaveLength(1);
+    expect(frameMessages[0]).toMatchObject({
+      kind: 'frame',
+      frame: {
+        currentBeat: 2,
+        currentSeconds: 2,
+      },
+    });
+
+    runtime.dispose();
+  });
+
+  test('posts lifecycle and state updates to the UI worker', async () => {
+    vi.useFakeTimers();
+    const stateSignals = createPlayerStateSignals(1);
+    const uiSignals = createPlayerUiSignalBus(createFrame());
+    const runtime = await createNodeUiRuntime(createContext(uiSignals, stateSignals));
+    const worker = getLastWorker();
+
+    worker.postMessage.mockClear();
+
+    runtime.start();
+    expect(messagesOfKind(worker, 'start')).toHaveLength(1);
+
+    stateSignals.setPaused(true);
+    expect(messagesOfKind(worker, 'set-paused')).toHaveLength(1);
+
+    stateSignals.setHighSpeed(1.5);
+    expect(messagesOfKind(worker, 'set-high-speed')).toHaveLength(1);
+
+    stateSignals.publishJudgeCombo('GREAT', 12, '11', 1_234);
+    const judgeMessages = messagesOfKind(worker, 'set-judge-combo');
+    expect(judgeMessages).toHaveLength(1);
+    expect(judgeMessages[0]).toMatchObject({
+      kind: 'set-judge-combo',
+      state: {
+        judge: 'GREAT',
+        combo: 12,
+        channel: '11',
+        updatedAtMs: 1_234,
+      },
+    });
+
+    await runtime.stop();
+    expect(messagesOfKind(worker, 'stop')).toHaveLength(1);
+
+    await runtime.dispose();
+    expect(messagesOfKind(worker, 'dispose')).toHaveLength(1);
+  });
+
+  test('passes tsx tsconfig path to the UI worker in source runs', async () => {
+    const uiSignals = createPlayerUiSignalBus(createFrame());
+    const runtime = await createNodeUiRuntime(createContext(uiSignals));
+    const workerEnv = workerState.lastWorkerOptions?.env;
+    const workerEnvObject = typeof workerEnv === 'object' ? (workerEnv as NodeJS.ProcessEnv) : undefined;
+    const workerData = workerState.lastWorkerOptions?.workerData as
+      | { stdinIsTTY?: boolean; stdoutIsTTY?: boolean }
+      | undefined;
+
+    expect(typeof workerEnv).toBe('object');
+    expect(workerEnvObject?.TSX_TSCONFIG_PATH).toContain('tsconfig.typecheck.json');
+    expect(workerData).toMatchObject({
+      stdinIsTTY: Boolean(process.stdin.isTTY),
+      stdoutIsTTY: Boolean(process.stdout.isTTY),
+    });
+
+    await runtime.dispose();
+  });
+
+  test('waits for stop acknowledgement before resolving lifecycle cleanup', async () => {
+    workerState.autoAckLifecycle = false;
+    const uiSignals = createPlayerUiSignalBus(createFrame());
+    const runtime = await createNodeUiRuntime(createContext(uiSignals));
+    const worker = getLastWorker();
+
+    let resolved = false;
+    const stopPromise = runtime.stop().then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+    expect(messagesOfKind(worker, 'stop')).toHaveLength(1);
+
+    worker.emit('message', { kind: 'stopped' });
+    await stopPromise;
+    expect(resolved).toBe(true);
+
+    const disposePromise = runtime.dispose();
+    worker.emit('message', { kind: 'disposed' });
+    await disposePromise;
+  });
+});
+
+function createContext(
+  uiSignals: ReturnType<typeof createPlayerUiSignalBus>,
+  stateSignals = createPlayerStateSignals(1),
+): Parameters<typeof createNodeUiRuntime>[0] {
+  return {
+    json: createEmptyJson('bms'),
+    mode: 'MANUAL',
+    laneDisplayMode: '7 KEY',
+    laneBindings: [
+      { channel: '16', keyLabel: 'A', inputTokens: ['a'], isScratch: true, side: '1P' },
+      { channel: '11', keyLabel: 'S', inputTokens: ['s'], isScratch: false, side: '1P' },
+      { channel: '12', keyLabel: 'D', inputTokens: ['d'], isScratch: false, side: '1P' },
+    ],
+    speed: 1,
+    judgeWindowMs: 16.67,
+    highSpeed: 1,
+    stateSignals,
+    uiSignals,
+    baseDir: process.cwd(),
+    onBgaLoadProgress: () => undefined,
+  };
+}
+
+function createFrame(
+  overrides: Partial<Parameters<ReturnType<typeof createPlayerUiSignalBus>['publishFrame']>[0]> = {},
+): Parameters<ReturnType<typeof createPlayerUiSignalBus>['publishFrame']>[0] {
+  return {
+    currentBeat: 0,
+    currentSeconds: 0,
+    totalSeconds: 120,
+    summary: {
+      total: 100,
+      perfect: 0,
+      fast: 0,
+      slow: 0,
+      great: 0,
+      good: 0,
+      bad: 0,
+      poor: 0,
+      exScore: 0,
+      score: 0,
+    },
+    notes: [],
+    ...overrides,
+  };
+}
+
+function getLastWorker(): MockWorker {
+  if (!workerState.lastWorker) {
+    throw new Error('worker was not created');
+  }
+  return workerState.lastWorker;
+}
+
+function messagesOfKind(worker: MockWorker, kind: string): unknown[] {
+  return worker.postMessage.mock.calls
+    .map((call) => call[0])
+    .filter(
+      (message): message is { kind: string } => typeof message === 'object' && message !== null && 'kind' in message,
+    )
+    .filter((message) => message.kind === kind);
+}

--- a/packages/player/src/node/node-ui-runtime.test.ts
+++ b/packages/player/src/node/node-ui-runtime.test.ts
@@ -16,37 +16,41 @@ const workerState = vi.hoisted(() => ({
   autoAckLifecycle: true,
 }));
 
-vi.mock('node:worker_threads', () => ({
-  Worker: class MockWorker extends EventEmitter {
-    readonly postMessage = vi.fn((message: unknown) => {
-      if (!workerState.autoAckLifecycle || typeof message !== 'object' || message === null || !('kind' in message)) {
-        return;
-      }
-      if (message.kind === 'stop') {
-        queueMicrotask(() => {
-          this.emit('message', { kind: 'stopped' });
-        });
-        return;
-      }
-      if (message.kind === 'dispose') {
-        queueMicrotask(() => {
-          this.emit('message', { kind: 'disposed' });
-        });
-      }
-    });
-
-    readonly terminate = vi.fn(async () => 0);
-
-    constructor(..._args: unknown[]) {
-      super();
-      workerState.lastWorkerOptions = _args[1] as WorkerOptions | undefined;
-      workerState.lastWorker = this;
-      queueMicrotask(() => {
-        this.emit('message', { kind: 'ready' });
+vi.mock('node:worker_threads', async () => {
+  const actual = await vi.importActual<typeof import('node:worker_threads')>('node:worker_threads');
+  return {
+    ...actual,
+    Worker: class MockWorker extends EventEmitter {
+      readonly postMessage = vi.fn((message: unknown) => {
+        if (!workerState.autoAckLifecycle || typeof message !== 'object' || message === null || !('kind' in message)) {
+          return;
+        }
+        if (message.kind === 'stop') {
+          queueMicrotask(() => {
+            this.emit('message', { kind: 'stopped' });
+          });
+          return;
+        }
+        if (message.kind === 'dispose') {
+          queueMicrotask(() => {
+            this.emit('message', { kind: 'disposed' });
+          });
+        }
       });
-    }
-  },
-}));
+
+      readonly terminate = vi.fn(async () => 0);
+
+      constructor(..._args: unknown[]) {
+        super();
+        workerState.lastWorkerOptions = _args[1] as WorkerOptions | undefined;
+        workerState.lastWorker = this;
+        queueMicrotask(() => {
+          this.emit('message', { kind: 'ready' });
+        });
+      }
+    },
+  };
+});
 
 import { createNodeUiRuntime } from './node-ui-runtime.ts';
 
@@ -165,6 +169,20 @@ describe('node ui runtime', () => {
     const disposePromise = runtime.dispose();
     worker.emit('message', { kind: 'disposed' });
     await disposePromise;
+  });
+
+  test('creates a dedicated bridge port for direct UI IPC', async () => {
+    const uiSignals = createPlayerUiSignalBus(createFrame());
+    const runtime = await createNodeUiRuntime(createContext(uiSignals));
+    const worker = getLastWorker();
+
+    worker.postMessage.mockClear();
+
+    const bridgePort = runtime.createBridgePort();
+    expect(bridgePort).toBeDefined();
+    expect(messagesOfKind(worker, 'attach-bridge-port')).toHaveLength(1);
+
+    await runtime.dispose();
   });
 });
 

--- a/packages/player/src/node/node-ui-runtime.ts
+++ b/packages/player/src/node/node-ui-runtime.ts
@@ -1,6 +1,6 @@
 import { effect } from 'alien-signals';
 import { fileURLToPath } from 'node:url';
-import { Worker } from 'node:worker_threads';
+import { MessageChannel, type MessagePort, Worker } from 'node:worker_threads';
 import type { LaneBinding } from '../manual-input.ts';
 import type { PlayerStateSignals } from '../player-state-signals.ts';
 import type { PlayerUiSignalBus } from '../core/player-ui-signal-bus.ts';
@@ -22,11 +22,13 @@ export interface NodeUiRuntimeOptions {
   highSpeed: number;
   showLaneChannels?: boolean;
   randomPatternSummary?: string;
-  stateSignals: PlayerStateSignals;
-  uiSignals: PlayerUiSignalBus;
+  stateSignals?: PlayerStateSignals;
+  uiSignals?: PlayerUiSignalBus;
   baseDir: string;
   loadSignal?: AbortSignal;
   onBgaLoadProgress?: (progress: { ratio: number; detail?: string }) => void;
+  initialPaused?: boolean;
+  initialJudgeCombo?: ReturnType<PlayerStateSignals['getJudgeCombo']>;
 }
 
 export interface NodeUiRuntime {
@@ -36,6 +38,7 @@ export interface NodeUiRuntime {
   dispose: () => Promise<void>;
   triggerPoor: (seconds: number) => void;
   clearPoor: () => void;
+  createBridgePort: () => MessagePort;
 }
 
 export async function createNodeUiRuntime(options: NodeUiRuntimeOptions): Promise<NodeUiRuntime> {
@@ -53,12 +56,16 @@ export async function createNodeUiRuntime(options: NodeUiRuntimeOptions): Promis
       dispose: () => Promise.resolve(),
       triggerPoor: () => undefined,
       clearPoor: () => undefined,
+      createBridgePort: () => {
+        throw new Error('TUI bridge port is unavailable');
+      },
     };
   }
 
   let disposed = false;
   let stopPromise: Promise<void> | undefined;
   let disposePromise: Promise<void> | undefined;
+  let bridgePortAttached = false;
   const postWorkerMessage = (message: NodeUiWorkerInboundMessage): void => {
     if (disposed) {
       return;
@@ -66,40 +73,64 @@ export async function createNodeUiRuntime(options: NodeUiRuntimeOptions): Promis
     worker.postMessage(message);
   };
 
-  const deferredUiFlush = createDeferredUiFlush(({ commands, frame }) => {
-    if (commands) {
-      const queuedCommands = options.uiSignals.drainCommands();
-      if (queuedCommands.length > 0) {
-        postWorkerMessage({ kind: 'commands', commands: queuedCommands });
-      }
-    }
-    if (frame) {
-      postWorkerMessage({ kind: 'frame', frame: options.uiSignals.getFrame() });
-    }
-  });
+  const deferredUiFlush =
+    options.uiSignals && options.stateSignals
+      ? createDeferredUiFlush(({ commands, frame }) => {
+          if (commands) {
+            const queuedCommands = options.uiSignals?.drainCommands() ?? [];
+            if (queuedCommands.length > 0) {
+              postWorkerMessage({ kind: 'commands', commands: queuedCommands });
+            }
+          }
+          if (frame) {
+            const frameState = options.uiSignals?.getFrame();
+            if (frameState) {
+              postWorkerMessage({ kind: 'frame', frame: frameState });
+            }
+          }
+        })
+      : undefined;
 
-  const stopFrameEffect = effect(() => {
-    options.uiSignals.frameTick();
-    deferredUiFlush.markFrameDirty();
-  });
+  const stopFrameEffect =
+    options.uiSignals && deferredUiFlush
+      ? effect(() => {
+          options.uiSignals?.frameTick();
+          deferredUiFlush.markFrameDirty();
+        })
+      : () => undefined;
 
-  const stopCommandEffect = effect(() => {
-    options.uiSignals.commandTick();
-    deferredUiFlush.markCommandsDirty();
-  });
+  const stopCommandEffect =
+    options.uiSignals && deferredUiFlush
+      ? effect(() => {
+          options.uiSignals?.commandTick();
+          deferredUiFlush.markCommandsDirty();
+        })
+      : () => undefined;
 
-  const stopPausedEffect = effect(() => {
-    postWorkerMessage({ kind: 'set-paused', value: options.stateSignals.paused() });
-  });
+  const stopPausedEffect =
+    options.stateSignals && options.uiSignals
+      ? effect(() => {
+          postWorkerMessage({ kind: 'set-paused', value: options.stateSignals?.paused() ?? false });
+        })
+      : () => undefined;
 
-  const stopHighSpeedEffect = effect(() => {
-    postWorkerMessage({ kind: 'set-high-speed', value: options.stateSignals.highSpeed() });
-  });
+  const stopHighSpeedEffect =
+    options.stateSignals && options.uiSignals
+      ? effect(() => {
+          postWorkerMessage({ kind: 'set-high-speed', value: options.stateSignals?.highSpeed() ?? options.highSpeed });
+        })
+      : () => undefined;
 
-  const stopJudgeComboEffect = effect(() => {
-    options.stateSignals.judgeComboTick();
-    postWorkerMessage({ kind: 'set-judge-combo', state: options.stateSignals.getJudgeCombo() });
-  });
+  const stopJudgeComboEffect =
+    options.stateSignals && options.uiSignals
+      ? effect(() => {
+          options.stateSignals?.judgeComboTick();
+          const state = options.stateSignals?.getJudgeCombo();
+          if (state) {
+            postWorkerMessage({ kind: 'set-judge-combo', state });
+          }
+        })
+      : () => undefined;
 
   const detachResizeHandler = attachResizeHandler((columns, rows) => {
     postWorkerMessage({ kind: 'resize', columns, rows });
@@ -125,7 +156,7 @@ export async function createNodeUiRuntime(options: NodeUiRuntimeOptions): Promis
         return disposePromise;
       }
       disposed = true;
-      deferredUiFlush.dispose();
+      deferredUiFlush?.dispose();
       stopFrameEffect();
       stopCommandEffect();
       stopPausedEffect();
@@ -140,6 +171,18 @@ export async function createNodeUiRuntime(options: NodeUiRuntimeOptions): Promis
     },
     clearPoor: () => {
       postWorkerMessage({ kind: 'clear-poor' });
+    },
+    createBridgePort: () => {
+      if (disposed) {
+        throw new Error('TUI bridge port is unavailable');
+      }
+      if (bridgePortAttached) {
+        throw new Error('TUI bridge port is already attached');
+      }
+      const channel = new MessageChannel();
+      bridgePortAttached = true;
+      worker.postMessage({ kind: 'attach-bridge-port', port: channel.port1 }, [channel.port1]);
+      return channel.port2;
     },
   };
 }
@@ -211,6 +254,13 @@ function createWorkerInitData(options: NodeUiRuntimeOptions): NodeUiWorkerInitDa
     baseDir: options.baseDir,
     stdinIsTTY: Boolean(process.stdin.isTTY),
     stdoutIsTTY: Boolean(process.stdout.isTTY),
+    initialPaused: options.initialPaused ?? options.stateSignals?.paused() ?? false,
+    initialJudgeCombo: options.initialJudgeCombo ??
+      options.stateSignals?.getJudgeCombo() ?? {
+        judge: 'READY',
+        combo: 0,
+        updatedAtMs: 0,
+      },
   };
 }
 

--- a/packages/player/src/node/node-ui-runtime.ts
+++ b/packages/player/src/node/node-ui-runtime.ts
@@ -1,34 +1,20 @@
 import { effect } from 'alien-signals';
-import { createTimingResolver } from '@be-music/audio-renderer';
-import { createBeatResolver, type BeMusicJson } from '@be-music/json';
-import {
-  createBeatAtSecondsResolver,
-  createBpmTimeline,
-  createMeasureBoundariesBeats,
-  createMeasureTimeline,
-  createScrollTimeline,
-  createStopBeatWindows,
-} from '../core/timeline.ts';
+import { fileURLToPath } from 'node:url';
+import { Worker } from 'node:worker_threads';
 import type { LaneBinding } from '../manual-input.ts';
-import { PlayerTui } from '../tui.ts';
-import { createBgaAnsiRenderer, type BgaAnsiRenderer } from '../bga.ts';
 import type { PlayerStateSignals } from '../player-state-signals.ts';
 import type { PlayerUiSignalBus } from '../core/player-ui-signal-bus.ts';
 import { resolveHighSpeedMultiplier } from '../core/high-speed-control.ts';
-
-const DEFAULT_LANE_WIDTH = 3;
-const WIDE_SCRATCH_LANE_WIDTH = DEFAULT_LANE_WIDTH * 2;
-const DEFAULT_GRID_ROWS = 14;
-const MIN_GRID_ROWS = 4;
-const STATIC_TUI_LINES = 15;
-const BGA_LANE_GAP = 3;
-const MIN_BGA_ASCII_WIDTH = 8;
-const MIN_BGA_ASCII_HEIGHT = 6;
-const DEFAULT_TERMINAL_COLUMNS = 120;
+import { createDeferredUiFlush } from './deferred-ui-flush.ts';
+import type {
+  NodeUiWorkerInboundMessage,
+  NodeUiWorkerInitData,
+  NodeUiWorkerOutboundMessage,
+} from './node-ui-worker-protocol.ts';
 
 export interface NodeUiRuntimeOptions {
-  json: BeMusicJson;
-  mode: 'AUTO' | 'MANUAL' | 'AUTO SCRATCH';
+  json: NodeUiWorkerInitData['json'];
+  mode: NodeUiWorkerInitData['mode'];
   laneDisplayMode: string;
   laneBindings: LaneBinding[];
   speed: number;
@@ -46,196 +32,294 @@ export interface NodeUiRuntimeOptions {
 export interface NodeUiRuntime {
   readonly tuiEnabled: boolean;
   start: () => void;
-  stop: () => void;
-  dispose: () => void;
+  stop: () => Promise<void>;
+  dispose: () => Promise<void>;
   triggerPoor: (seconds: number) => void;
   clearPoor: () => void;
 }
 
 export async function createNodeUiRuntime(options: NodeUiRuntimeOptions): Promise<NodeUiRuntime> {
-  const splitAfterIndex = resolveSplitAfterIndex(options.laneBindings);
-  const lanes = options.laneBindings.map((binding) => ({
-    channel: binding.channel,
-    key: binding.keyLabel,
-    isScratch: binding.isScratch,
-  }));
-  const timingResolver = createTimingResolver(options.json);
-  const beatResolver = createBeatResolver(options.json);
-  const measureLengths = new Map<number, number>();
-  for (const measure of options.json.measures) {
-    const measureIndex = Math.max(0, Math.floor(measure.index));
-    if (typeof measure.length !== 'number' || !Number.isFinite(measure.length) || measure.length <= 0) {
-      continue;
-    }
-    measureLengths.set(measureIndex, measure.length);
-  }
-  const measureTimeline = createMeasureTimeline(options.json, timingResolver, beatResolver);
-  const bpmTimeline = createBpmTimeline(options.json, timingResolver);
-  const scrollTimeline = createScrollTimeline(options.json, beatResolver);
-  const stopWindows = createStopBeatWindows(timingResolver).map((window) => ({
-    startSeconds: window.startSeconds,
-    endSeconds: window.endSeconds,
-  }));
-  const measureBoundariesBeats = createMeasureBoundariesBeats(options.json, beatResolver);
-
-  const tui = new PlayerTui({
-    mode: options.mode,
-    laneDisplayMode: options.laneDisplayMode,
-    title: options.json.metadata.title ?? 'Untitled',
-    artist: options.json.metadata.artist,
-    genre: options.json.metadata.genre,
-    player: options.json.bms.player,
-    rank: options.json.metadata.rank,
-    playLevel: options.json.metadata.playLevel,
-    lanes,
-    speed: options.speed,
-    highSpeed: resolveHighSpeedMultiplier(options.highSpeed),
-    judgeWindowMs: options.judgeWindowMs,
-    showLaneChannels: options.showLaneChannels,
-    randomPatternSummary: options.randomPatternSummary,
-    bpmTimeline,
-    scrollTimeline,
-    stopWindows,
-    measureTimeline,
-    measureLengths,
-    measureBoundariesBeats,
-    splitAfterIndex,
-    stateSignals: options.stateSignals,
+  const worker = new Worker(resolveNodeUiWorkerUrl(), {
+    workerData: createWorkerInitData(options),
+    execArgv: process.execArgv,
+    env: resolveNodeUiWorkerEnv(),
   });
-
-  if (!tui.isSupported()) {
+  const workerReady = await waitForWorkerReady(worker, options.loadSignal, options.onBgaLoadProgress);
+  if (!workerReady) {
     return {
       tuiEnabled: false,
       start: () => undefined,
-      stop: () => undefined,
-      dispose: () => undefined,
+      stop: () => Promise.resolve(),
+      dispose: () => Promise.resolve(),
       triggerPoor: () => undefined,
       clearPoor: () => undefined,
     };
   }
 
-  const bgaDisplay = estimateBgaAnsiDisplaySize(options.laneBindings);
-  const bgaRenderer = await createBgaAnsiRenderer(options.json, {
-    baseDir: options.baseDir,
-    width: bgaDisplay.width,
-    height: bgaDisplay.height,
-    signal: options.loadSignal,
-    onLoadProgress: (progress) => {
-      options.onBgaLoadProgress?.({
-        ratio: progress.ratio,
-        detail: progress.detail,
-      });
-    },
+  let disposed = false;
+  let stopPromise: Promise<void> | undefined;
+  let disposePromise: Promise<void> | undefined;
+  const postWorkerMessage = (message: NodeUiWorkerInboundMessage): void => {
+    if (disposed) {
+      return;
+    }
+    worker.postMessage(message);
+  };
+
+  const deferredUiFlush = createDeferredUiFlush(({ commands, frame }) => {
+    if (commands) {
+      const queuedCommands = options.uiSignals.drainCommands();
+      if (queuedCommands.length > 0) {
+        postWorkerMessage({ kind: 'commands', commands: queuedCommands });
+      }
+    }
+    if (frame) {
+      postWorkerMessage({ kind: 'frame', frame: options.uiSignals.getFrame() });
+    }
   });
 
   const stopFrameEffect = effect(() => {
     options.uiSignals.frameTick();
-    const frame = options.uiSignals.getFrame();
-    tui.render({
-      ...frame,
-      bgaAnsiLines: bgaRenderer?.getAnsiLines(frame.currentSeconds),
-    });
+    deferredUiFlush.markFrameDirty();
   });
 
   const stopCommandEffect = effect(() => {
     options.uiSignals.commandTick();
-    const commands = options.uiSignals.drainCommands();
-    for (const command of commands) {
-      if (command.kind === 'flash-lane') {
-        tui.flashLane(command.channel);
-        continue;
-      }
-      if (command.kind === 'hold-lane-until-beat') {
-        tui.holdLaneUntilBeat(command.channel, command.beat);
-        continue;
-      }
-      if (command.kind === 'press-lane') {
-        tui.pressLane(command.channel);
-        continue;
-      }
-      if (command.kind === 'release-lane') {
-        tui.releaseLane(command.channel);
-        continue;
-      }
-      if (command.kind === 'trigger-poor-bga') {
-        bgaRenderer?.triggerPoor(command.seconds);
-        continue;
-      }
-      bgaRenderer?.clearPoor();
-    }
+    deferredUiFlush.markCommandsDirty();
   });
 
-  const detachBgaResizeHandler = attachBgaResizeHandler(tui, bgaRenderer, options.laneBindings);
+  const stopPausedEffect = effect(() => {
+    postWorkerMessage({ kind: 'set-paused', value: options.stateSignals.paused() });
+  });
+
+  const stopHighSpeedEffect = effect(() => {
+    postWorkerMessage({ kind: 'set-high-speed', value: options.stateSignals.highSpeed() });
+  });
+
+  const stopJudgeComboEffect = effect(() => {
+    options.stateSignals.judgeComboTick();
+    postWorkerMessage({ kind: 'set-judge-combo', state: options.stateSignals.getJudgeCombo() });
+  });
+
+  const detachResizeHandler = attachResizeHandler((columns, rows) => {
+    postWorkerMessage({ kind: 'resize', columns, rows });
+  });
 
   return {
     tuiEnabled: true,
     start: () => {
-      tui.start();
+      postWorkerMessage({ kind: 'start' });
     },
     stop: () => {
-      tui.stop();
+      if (disposed) {
+        return Promise.resolve();
+      }
+      if (stopPromise) {
+        return stopPromise;
+      }
+      stopPromise = postWorkerMessageAndWaitForAck(worker, { kind: 'stop' }, 'stopped');
+      return stopPromise;
     },
     dispose: () => {
+      if (disposePromise) {
+        return disposePromise;
+      }
+      disposed = true;
+      deferredUiFlush.dispose();
       stopFrameEffect();
       stopCommandEffect();
-      detachBgaResizeHandler();
+      stopPausedEffect();
+      stopHighSpeedEffect();
+      stopJudgeComboEffect();
+      detachResizeHandler();
+      disposePromise = postWorkerMessageAndWaitForAck(worker, { kind: 'dispose' }, 'disposed', true);
+      return disposePromise;
     },
     triggerPoor: (seconds: number) => {
-      bgaRenderer?.triggerPoor(seconds);
+      postWorkerMessage({ kind: 'trigger-poor', seconds });
     },
     clearPoor: () => {
-      bgaRenderer?.clearPoor();
+      postWorkerMessage({ kind: 'clear-poor' });
     },
   };
 }
 
-function resolveSplitAfterIndex(bindings: LaneBinding[]): number {
-  const has2P = bindings.some((binding) => binding.side === '2P');
-  if (!has2P) {
-    return -1;
-  }
-  for (let index = bindings.length - 1; index >= 0; index -= 1) {
-    if (bindings[index]?.side === '1P') {
-      return index;
-    }
-  }
-  return -1;
+function postWorkerMessageAndWaitForAck(
+  worker: Worker,
+  message: NodeUiWorkerInboundMessage,
+  expectedKind: Extract<NodeUiWorkerOutboundMessage, { kind: string }>['kind'],
+  resolveOnExit = false,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+
+    const cleanup = (): void => {
+      worker.off('message', onMessage);
+      worker.off('error', onError);
+      worker.off('exit', onExit);
+    };
+
+    const settle = (cb: () => void): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      cb();
+    };
+
+    const onMessage = (workerMessage: NodeUiWorkerOutboundMessage): void => {
+      if (workerMessage.kind === expectedKind) {
+        settle(resolve);
+        return;
+      }
+      if (workerMessage.kind === 'error') {
+        settle(() => reject(new Error(workerMessage.message)));
+      }
+    };
+
+    const onError = (error: Error): void => {
+      settle(() => reject(error));
+    };
+
+    const onExit = (code: number): void => {
+      if (resolveOnExit && code === 0) {
+        settle(resolve);
+        return;
+      }
+      settle(() => reject(new Error(`UI worker exited before ${expectedKind} (code ${code})`)));
+    };
+
+    worker.on('message', onMessage);
+    worker.on('error', onError);
+    worker.on('exit', onExit);
+    worker.postMessage(message);
+  });
 }
 
-function estimateBgaAnsiDisplaySize(bindings: LaneBinding[]): { width: number; height: number } {
-  const laneWidths = bindings.map((binding) => (binding.isScratch ? WIDE_SCRATCH_LANE_WIDTH : DEFAULT_LANE_WIDTH));
-  const laneCount = laneWidths.length;
-  const splitAfterIndex = resolveSplitAfterIndex(bindings);
-  const laneTextWidth = laneWidths.reduce((sum, width) => sum + width, 0);
-  const laneSpacingWidth = laneCount > 0 ? laneCount - 1 : 0;
-  const splitExtraWidth = splitAfterIndex >= 0 && splitAfterIndex < laneCount - 1 ? 2 : 0;
-  const laneBlockWidth = laneTextWidth + laneSpacingWidth + splitExtraWidth;
-
-  const columns = process.stdout.columns ?? DEFAULT_TERMINAL_COLUMNS;
-  const width = Math.max(MIN_BGA_ASCII_WIDTH, columns - laneBlockWidth - BGA_LANE_GAP);
-
-  const terminalRows = process.stdout.rows ?? DEFAULT_GRID_ROWS + STATIC_TUI_LINES;
-  const rowCount = Math.max(MIN_GRID_ROWS, terminalRows - STATIC_TUI_LINES);
-  const laneBlockHeight = rowCount + 4;
-  const height = Math.max(MIN_BGA_ASCII_HEIGHT, laneBlockHeight);
-  return { width, height };
+function createWorkerInitData(options: NodeUiRuntimeOptions): NodeUiWorkerInitData {
+  return {
+    json: options.json,
+    mode: options.mode,
+    laneDisplayMode: options.laneDisplayMode,
+    laneBindings: options.laneBindings,
+    speed: options.speed,
+    judgeWindowMs: options.judgeWindowMs,
+    highSpeed: resolveHighSpeedMultiplier(options.highSpeed),
+    showLaneChannels: options.showLaneChannels,
+    randomPatternSummary: options.randomPatternSummary,
+    baseDir: options.baseDir,
+    stdinIsTTY: Boolean(process.stdin.isTTY),
+    stdoutIsTTY: Boolean(process.stdout.isTTY),
+  };
 }
 
-function attachBgaResizeHandler(
-  tui: PlayerTui,
-  bgaRenderer: BgaAnsiRenderer | undefined,
-  bindings: LaneBinding[],
-): () => void {
-  if (!bgaRenderer || !process.stdout.isTTY) {
+function resolveNodeUiWorkerUrl(): URL {
+  return new URL(import.meta.url.endsWith('.ts') ? './node-ui-worker.ts' : './node-ui-worker.js', import.meta.url);
+}
+
+function resolveNodeUiWorkerEnv(): NodeJS.ProcessEnv {
+  if (!import.meta.url.endsWith('.ts')) {
+    return process.env;
+  }
+
+  return {
+    ...process.env,
+    TSX_TSCONFIG_PATH:
+      process.env.TSX_TSCONFIG_PATH ?? fileURLToPath(new URL('../../../../tsconfig.typecheck.json', import.meta.url)),
+  };
+}
+
+async function waitForWorkerReady(
+  worker: Worker,
+  signal: AbortSignal | undefined,
+  onBgaLoadProgress: NodeUiRuntimeOptions['onBgaLoadProgress'],
+): Promise<boolean> {
+  if (signal?.aborted) {
+    await worker.terminate();
+    throw resolveAbortReason(signal);
+  }
+
+  return await new Promise<boolean>((resolve, reject) => {
+    let settled = false;
+
+    const cleanup = (): void => {
+      worker.off('message', onMessage);
+      worker.off('error', onError);
+      worker.off('exit', onExit);
+      signal?.removeEventListener('abort', onAbort);
+    };
+
+    const settle = (cb: () => void): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      cb();
+    };
+
+    const onMessage = (message: NodeUiWorkerOutboundMessage): void => {
+      if (message.kind === 'bga-load-progress') {
+        onBgaLoadProgress?.(message.progress);
+        return;
+      }
+      if (message.kind === 'ready') {
+        settle(() => resolve(true));
+        return;
+      }
+      if (message.kind === 'unsupported') {
+        settle(() => {
+          void worker.terminate();
+          resolve(false);
+        });
+        return;
+      }
+      if (message.kind === 'error') {
+        settle(() => reject(new Error(message.message)));
+      }
+    };
+
+    const onError = (error: Error): void => {
+      settle(() => reject(error));
+    };
+
+    const onExit = (code: number): void => {
+      settle(() => reject(new Error(`UI worker exited before ready (code ${code})`)));
+    };
+
+    const onAbort = (): void => {
+      settle(() => {
+        void worker.terminate();
+        reject(resolveAbortReason(signal));
+      });
+    };
+
+    worker.on('message', onMessage);
+    worker.on('error', onError);
+    worker.on('exit', onExit);
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+function attachResizeHandler(onResize: (columns: number | undefined, rows: number | undefined) => void): () => void {
+  if (!process.stdout.isTTY) {
     return () => undefined;
   }
-  const onResize = (): void => {
-    const size = estimateBgaAnsiDisplaySize(bindings);
-    bgaRenderer.setDisplaySize(size.width, size.height);
+  const handleResize = (): void => {
+    onResize(process.stdout.columns, process.stdout.rows);
   };
-  process.stdout.on('resize', onResize);
-  onResize();
+  process.stdout.on('resize', handleResize);
+  handleResize();
   return () => {
-    process.stdout.off('resize', onResize);
+    process.stdout.off('resize', handleResize);
   };
+}
+
+function resolveAbortReason(signal: AbortSignal | undefined): Error {
+  const reason = signal?.reason;
+  if (reason instanceof Error) {
+    return reason;
+  }
+  return new Error(typeof reason === 'string' && reason.length > 0 ? reason : 'UI worker initialization aborted');
 }

--- a/packages/player/src/node/node-ui-worker-protocol.ts
+++ b/packages/player/src/node/node-ui-worker-protocol.ts
@@ -1,0 +1,40 @@
+import type { BeMusicJson } from '@be-music/json';
+import type { PlayerUiCommand, PlayerUiFramePayload } from '../core/player-ui-signal-bus.ts';
+import type { LaneBinding } from '../manual-input.ts';
+import type { PlayerJudgeComboSignalState } from '../player-state-signals.ts';
+
+export interface NodeUiWorkerInitData {
+  json: BeMusicJson;
+  mode: 'AUTO' | 'MANUAL' | 'AUTO SCRATCH';
+  laneDisplayMode: string;
+  laneBindings: LaneBinding[];
+  speed: number;
+  judgeWindowMs: number;
+  highSpeed: number;
+  showLaneChannels?: boolean;
+  randomPatternSummary?: string;
+  baseDir: string;
+  stdinIsTTY: boolean;
+  stdoutIsTTY: boolean;
+}
+
+export type NodeUiWorkerInboundMessage =
+  | { kind: 'start' }
+  | { kind: 'stop' }
+  | { kind: 'dispose' }
+  | { kind: 'frame'; frame: PlayerUiFramePayload }
+  | { kind: 'commands'; commands: PlayerUiCommand[] }
+  | { kind: 'set-paused'; value: boolean }
+  | { kind: 'set-high-speed'; value: number }
+  | { kind: 'set-judge-combo'; state: PlayerJudgeComboSignalState }
+  | { kind: 'trigger-poor'; seconds: number }
+  | { kind: 'clear-poor' }
+  | { kind: 'resize'; columns?: number; rows?: number };
+
+export type NodeUiWorkerOutboundMessage =
+  | { kind: 'ready' }
+  | { kind: 'unsupported' }
+  | { kind: 'stopped' }
+  | { kind: 'disposed' }
+  | { kind: 'bga-load-progress'; progress: { ratio: number; detail?: string } }
+  | { kind: 'error'; message: string };

--- a/packages/player/src/node/node-ui-worker-protocol.ts
+++ b/packages/player/src/node/node-ui-worker-protocol.ts
@@ -1,3 +1,4 @@
+import type { MessagePort } from 'node:worker_threads';
 import type { BeMusicJson } from '@be-music/json';
 import type { PlayerUiCommand, PlayerUiFramePayload } from '../core/player-ui-signal-bus.ts';
 import type { LaneBinding } from '../manual-input.ts';
@@ -16,9 +17,12 @@ export interface NodeUiWorkerInitData {
   baseDir: string;
   stdinIsTTY: boolean;
   stdoutIsTTY: boolean;
+  initialPaused: boolean;
+  initialJudgeCombo: PlayerJudgeComboSignalState;
 }
 
 export type NodeUiWorkerInboundMessage =
+  | { kind: 'attach-bridge-port'; port: MessagePort }
   | { kind: 'start' }
   | { kind: 'stop' }
   | { kind: 'dispose' }

--- a/packages/player/src/node/node-ui-worker.ts
+++ b/packages/player/src/node/node-ui-worker.ts
@@ -1,0 +1,273 @@
+import { parentPort, workerData } from 'node:worker_threads';
+import { createTimingResolver } from '@be-music/audio-renderer';
+import { createBeatResolver } from '@be-music/json';
+import {
+  createBpmTimeline,
+  createMeasureBoundariesBeats,
+  createMeasureTimeline,
+  createScrollTimeline,
+  createStopBeatWindows,
+} from '../core/timeline.ts';
+import { createBgaAnsiRenderer } from '../bga.ts';
+import type { PlayerUiCommand, PlayerUiFramePayload } from '../core/player-ui-signal-bus.ts';
+import { PlayerTui } from '../tui.ts';
+import { createDeferredUiFlush } from './deferred-ui-flush.ts';
+import type {
+  NodeUiWorkerInboundMessage,
+  NodeUiWorkerInitData,
+  NodeUiWorkerOutboundMessage,
+} from './node-ui-worker-protocol.ts';
+
+const DEFAULT_LANE_WIDTH = 3;
+const WIDE_SCRATCH_LANE_WIDTH = DEFAULT_LANE_WIDTH * 2;
+const DEFAULT_GRID_ROWS = 14;
+const MIN_GRID_ROWS = 4;
+const STATIC_TUI_LINES = 15;
+const BGA_LANE_GAP = 3;
+const MIN_BGA_ASCII_WIDTH = 8;
+const MIN_BGA_ASCII_HEIGHT = 6;
+const DEFAULT_TERMINAL_COLUMNS = 120;
+
+const port = parentPort;
+const initData = workerData as NodeUiWorkerInitData;
+
+void bootstrap().catch((error) => {
+  postWorkerMessage({
+    kind: 'error',
+    message: error instanceof Error ? error.message : String(error),
+  });
+  throw error;
+});
+
+async function bootstrap(): Promise<void> {
+  if (!port) {
+    throw new Error('UI worker parent port is unavailable');
+  }
+
+  const splitAfterIndex = resolveSplitAfterIndex(initData.laneBindings);
+  const lanes = initData.laneBindings.map((binding) => ({
+    channel: binding.channel,
+    key: binding.keyLabel,
+    isScratch: binding.isScratch,
+  }));
+  const timingResolver = createTimingResolver(initData.json);
+  const beatResolver = createBeatResolver(initData.json);
+  const measureLengths = new Map<number, number>();
+  for (const measure of initData.json.measures) {
+    const measureIndex = Math.max(0, Math.floor(measure.index));
+    if (typeof measure.length !== 'number' || !Number.isFinite(measure.length) || measure.length <= 0) {
+      continue;
+    }
+    measureLengths.set(measureIndex, measure.length);
+  }
+  const measureTimeline = createMeasureTimeline(initData.json, timingResolver, beatResolver);
+  const bpmTimeline = createBpmTimeline(initData.json, timingResolver);
+  const scrollTimeline = createScrollTimeline(initData.json, beatResolver);
+  const stopWindows = createStopBeatWindows(timingResolver).map((window) => ({
+    startSeconds: window.startSeconds,
+    endSeconds: window.endSeconds,
+  }));
+  const measureBoundariesBeats = createMeasureBoundariesBeats(initData.json, beatResolver);
+
+  const tui = new PlayerTui({
+    mode: initData.mode,
+    laneDisplayMode: initData.laneDisplayMode,
+    title: initData.json.metadata.title ?? 'Untitled',
+    artist: initData.json.metadata.artist,
+    genre: initData.json.metadata.genre,
+    player: initData.json.bms.player,
+    rank: initData.json.metadata.rank,
+    playLevel: initData.json.metadata.playLevel,
+    lanes,
+    speed: initData.speed,
+    highSpeed: initData.highSpeed,
+    judgeWindowMs: initData.judgeWindowMs,
+    showLaneChannels: initData.showLaneChannels,
+    randomPatternSummary: initData.randomPatternSummary,
+    bpmTimeline,
+    scrollTimeline,
+    stopWindows,
+    measureTimeline,
+    measureLengths,
+    measureBoundariesBeats,
+    splitAfterIndex,
+    stdinIsTTY: initData.stdinIsTTY,
+    stdoutIsTTY: initData.stdoutIsTTY,
+  });
+
+  if (!tui.isSupported()) {
+    postWorkerMessage({ kind: 'unsupported' });
+    process.exit(0);
+    return;
+  }
+
+  const initialBgaSize = estimateBgaAnsiDisplaySize(initData.laneBindings);
+  const bgaRenderer = await createBgaAnsiRenderer(initData.json, {
+    baseDir: initData.baseDir,
+    width: initialBgaSize.width,
+    height: initialBgaSize.height,
+    onLoadProgress: (progress) => {
+      postWorkerMessage({
+        kind: 'bga-load-progress',
+        progress: {
+          ratio: progress.ratio,
+          detail: progress.detail,
+        },
+      });
+    },
+  });
+
+  let latestFrame: PlayerUiFramePayload | undefined;
+  const queuedCommands: PlayerUiCommand[] = [];
+
+  const deferredUiFlush = createDeferredUiFlush(({ commands, frame }) => {
+    if (commands) {
+      while (queuedCommands.length > 0) {
+        const command = queuedCommands.shift();
+        if (!command) {
+          continue;
+        }
+        if (command.kind === 'flash-lane') {
+          tui.flashLane(command.channel);
+          continue;
+        }
+        if (command.kind === 'hold-lane-until-beat') {
+          tui.holdLaneUntilBeat(command.channel, command.beat);
+          continue;
+        }
+        if (command.kind === 'press-lane') {
+          tui.pressLane(command.channel);
+          continue;
+        }
+        if (command.kind === 'release-lane') {
+          tui.releaseLane(command.channel);
+          continue;
+        }
+        if (command.kind === 'trigger-poor-bga') {
+          bgaRenderer?.triggerPoor(command.seconds);
+          continue;
+        }
+        bgaRenderer?.clearPoor();
+      }
+    }
+
+    if (frame && latestFrame) {
+      tui.render({
+        ...latestFrame,
+        bgaAnsiLines: bgaRenderer?.getAnsiLines(latestFrame.currentSeconds),
+      });
+    }
+  });
+
+  port.on('message', (message: NodeUiWorkerInboundMessage) => {
+    if (message.kind === 'start') {
+      tui.start();
+      return;
+    }
+    if (message.kind === 'stop') {
+      tui.stop();
+      postWorkerMessage({ kind: 'stopped' });
+      return;
+    }
+    if (message.kind === 'dispose') {
+      deferredUiFlush.dispose();
+      tui.stop();
+      postWorkerMessage({ kind: 'disposed' });
+      port.close();
+      process.exit(0);
+      return;
+    }
+    if (message.kind === 'frame') {
+      latestFrame = message.frame;
+      deferredUiFlush.markFrameDirty();
+      return;
+    }
+    if (message.kind === 'commands') {
+      queuedCommands.push(...message.commands);
+      deferredUiFlush.markCommandsDirty();
+      return;
+    }
+    if (message.kind === 'set-paused') {
+      tui.setPaused(message.value);
+      if (latestFrame) {
+        deferredUiFlush.markFrameDirty();
+      }
+      return;
+    }
+    if (message.kind === 'set-high-speed') {
+      tui.setHighSpeed(message.value);
+      if (latestFrame) {
+        deferredUiFlush.markFrameDirty();
+      }
+      return;
+    }
+    if (message.kind === 'set-judge-combo') {
+      tui.setLatestJudge(message.state.judge, message.state.channel);
+      tui.setCombo(message.state.combo, message.state.channel);
+      if (latestFrame) {
+        deferredUiFlush.markFrameDirty();
+      }
+      return;
+    }
+    if (message.kind === 'trigger-poor') {
+      bgaRenderer?.triggerPoor(message.seconds);
+      if (latestFrame) {
+        deferredUiFlush.markFrameDirty();
+      }
+      return;
+    }
+    if (message.kind === 'clear-poor') {
+      bgaRenderer?.clearPoor();
+      if (latestFrame) {
+        deferredUiFlush.markFrameDirty();
+      }
+      return;
+    }
+
+    tui.setTerminalSize(message.columns, message.rows);
+    const size = estimateBgaAnsiDisplaySize(initData.laneBindings, message.columns, message.rows);
+    bgaRenderer?.setDisplaySize(size.width, size.height);
+    if (latestFrame) {
+      deferredUiFlush.markFrameDirty();
+    }
+  });
+
+  postWorkerMessage({ kind: 'ready' });
+}
+
+function resolveSplitAfterIndex(bindings: NodeUiWorkerInitData['laneBindings']): number {
+  const has2P = bindings.some((binding) => binding.side === '2P');
+  if (!has2P) {
+    return -1;
+  }
+  for (let index = bindings.length - 1; index >= 0; index -= 1) {
+    if (bindings[index]?.side === '1P') {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function estimateBgaAnsiDisplaySize(
+  bindings: NodeUiWorkerInitData['laneBindings'],
+  columns = process.stdout.columns ?? DEFAULT_TERMINAL_COLUMNS,
+  rows = process.stdout.rows ?? DEFAULT_GRID_ROWS + STATIC_TUI_LINES,
+): { width: number; height: number } {
+  const laneWidths = bindings.map((binding) => (binding.isScratch ? WIDE_SCRATCH_LANE_WIDTH : DEFAULT_LANE_WIDTH));
+  const laneCount = laneWidths.length;
+  const splitAfterIndex = resolveSplitAfterIndex(bindings);
+  const laneTextWidth = laneWidths.reduce((sum, width) => sum + width, 0);
+  const laneSpacingWidth = laneCount > 0 ? laneCount - 1 : 0;
+  const splitExtraWidth = splitAfterIndex >= 0 && splitAfterIndex < laneCount - 1 ? 2 : 0;
+  const laneBlockWidth = laneTextWidth + laneSpacingWidth + splitExtraWidth;
+
+  const width = Math.max(MIN_BGA_ASCII_WIDTH, columns - laneBlockWidth - BGA_LANE_GAP);
+  const rowCount = Math.max(MIN_GRID_ROWS, rows - STATIC_TUI_LINES);
+  const laneBlockHeight = rowCount + 4;
+  const height = Math.max(MIN_BGA_ASCII_HEIGHT, laneBlockHeight);
+  return { width, height };
+}
+
+function postWorkerMessage(message: NodeUiWorkerOutboundMessage): void {
+  port?.postMessage(message);
+}

--- a/packages/player/src/node/node-ui-worker.ts
+++ b/packages/player/src/node/node-ui-worker.ts
@@ -1,4 +1,4 @@
-import { parentPort, workerData } from 'node:worker_threads';
+import { parentPort, workerData, type MessagePort } from 'node:worker_threads';
 import { createTimingResolver } from '@be-music/audio-renderer';
 import { createBeatResolver } from '@be-music/json';
 import {
@@ -94,6 +94,9 @@ async function bootstrap(): Promise<void> {
     stdinIsTTY: initData.stdinIsTTY,
     stdoutIsTTY: initData.stdoutIsTTY,
   });
+  tui.setPaused(initData.initialPaused);
+  tui.setLatestJudge(initData.initialJudgeCombo.judge, initData.initialJudgeCombo.channel);
+  tui.setCombo(initData.initialJudgeCombo.combo, initData.initialJudgeCombo.channel);
 
   if (!tui.isSupported()) {
     postWorkerMessage({ kind: 'unsupported' });
@@ -119,6 +122,7 @@ async function bootstrap(): Promise<void> {
 
   let latestFrame: PlayerUiFramePayload | undefined;
   const queuedCommands: PlayerUiCommand[] = [];
+  let bridgePort: MessagePort | undefined;
 
   const deferredUiFlush = createDeferredUiFlush(({ commands, frame }) => {
     if (commands) {
@@ -159,9 +163,68 @@ async function bootstrap(): Promise<void> {
     }
   });
 
-  port.on('message', (message: NodeUiWorkerInboundMessage) => {
+  const handleRenderMessage = (message: NodeUiWorkerInboundMessage): boolean => {
     if (message.kind === 'start') {
       tui.start();
+      return true;
+    }
+    if (message.kind === 'frame') {
+      latestFrame = message.frame;
+      deferredUiFlush.markFrameDirty();
+      return true;
+    }
+    if (message.kind === 'commands') {
+      queuedCommands.push(...message.commands);
+      deferredUiFlush.markCommandsDirty();
+      return true;
+    }
+    if (message.kind === 'set-paused') {
+      tui.setPaused(message.value);
+      if (latestFrame) {
+        deferredUiFlush.markFrameDirty();
+      }
+      return true;
+    }
+    if (message.kind === 'set-high-speed') {
+      tui.setHighSpeed(message.value);
+      if (latestFrame) {
+        deferredUiFlush.markFrameDirty();
+      }
+      return true;
+    }
+    if (message.kind === 'set-judge-combo') {
+      tui.setLatestJudge(message.state.judge, message.state.channel);
+      tui.setCombo(message.state.combo, message.state.channel);
+      if (latestFrame) {
+        deferredUiFlush.markFrameDirty();
+      }
+      return true;
+    }
+    if (message.kind === 'trigger-poor') {
+      bgaRenderer?.triggerPoor(message.seconds);
+      if (latestFrame) {
+        deferredUiFlush.markFrameDirty();
+      }
+      return true;
+    }
+    if (message.kind === 'clear-poor') {
+      bgaRenderer?.clearPoor();
+      if (latestFrame) {
+        deferredUiFlush.markFrameDirty();
+      }
+      return true;
+    }
+    return false;
+  };
+
+  const handleControlMessage = (message: NodeUiWorkerInboundMessage): void => {
+    if (message.kind === 'attach-bridge-port') {
+      bridgePort?.off('message', handleControlMessage);
+      bridgePort = message.port;
+      bridgePort.on('message', handleControlMessage);
+      return;
+    }
+    if (handleRenderMessage(message)) {
       return;
     }
     if (message.kind === 'stop') {
@@ -171,56 +234,14 @@ async function bootstrap(): Promise<void> {
     }
     if (message.kind === 'dispose') {
       deferredUiFlush.dispose();
+      bridgePort?.close();
       tui.stop();
       postWorkerMessage({ kind: 'disposed' });
       port.close();
       process.exit(0);
       return;
     }
-    if (message.kind === 'frame') {
-      latestFrame = message.frame;
-      deferredUiFlush.markFrameDirty();
-      return;
-    }
-    if (message.kind === 'commands') {
-      queuedCommands.push(...message.commands);
-      deferredUiFlush.markCommandsDirty();
-      return;
-    }
-    if (message.kind === 'set-paused') {
-      tui.setPaused(message.value);
-      if (latestFrame) {
-        deferredUiFlush.markFrameDirty();
-      }
-      return;
-    }
-    if (message.kind === 'set-high-speed') {
-      tui.setHighSpeed(message.value);
-      if (latestFrame) {
-        deferredUiFlush.markFrameDirty();
-      }
-      return;
-    }
-    if (message.kind === 'set-judge-combo') {
-      tui.setLatestJudge(message.state.judge, message.state.channel);
-      tui.setCombo(message.state.combo, message.state.channel);
-      if (latestFrame) {
-        deferredUiFlush.markFrameDirty();
-      }
-      return;
-    }
-    if (message.kind === 'trigger-poor') {
-      bgaRenderer?.triggerPoor(message.seconds);
-      if (latestFrame) {
-        deferredUiFlush.markFrameDirty();
-      }
-      return;
-    }
-    if (message.kind === 'clear-poor') {
-      bgaRenderer?.clearPoor();
-      if (latestFrame) {
-        deferredUiFlush.markFrameDirty();
-      }
+    if (message.kind !== 'resize') {
       return;
     }
 
@@ -230,7 +251,9 @@ async function bootstrap(): Promise<void> {
     if (latestFrame) {
       deferredUiFlush.markFrameDirty();
     }
-  });
+  };
+
+  port.on('message', handleControlMessage);
 
   postWorkerMessage({ kind: 'ready' });
 }

--- a/packages/player/src/tui.test.ts
+++ b/packages/player/src/tui.test.ts
@@ -1,5 +1,19 @@
-import { describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { formatMeasureSignature, resolveAnimatedHighSpeedValue, resolveVisibleBeatsForTuiGrid } from './tui.ts';
+import { PlayerTui } from './tui.ts';
+
+const STDOUT_IS_TTY_DESCRIPTOR = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+const STDIN_IS_TTY_DESCRIPTOR = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
+const STDOUT_COLUMNS_DESCRIPTOR = Object.getOwnPropertyDescriptor(process.stdout, 'columns');
+const STDOUT_ROWS_DESCRIPTOR = Object.getOwnPropertyDescriptor(process.stdout, 'rows');
+
+afterEach(() => {
+  restoreDescriptor(process.stdout, 'isTTY', STDOUT_IS_TTY_DESCRIPTOR);
+  restoreDescriptor(process.stdin, 'isTTY', STDIN_IS_TTY_DESCRIPTOR);
+  restoreDescriptor(process.stdout, 'columns', STDOUT_COLUMNS_DESCRIPTOR);
+  restoreDescriptor(process.stdout, 'rows', STDOUT_ROWS_DESCRIPTOR);
+  vi.restoreAllMocks();
+});
 
 describe('player tui', () => {
   test('tui: keeps rows-per-beat constant across different terminal heights', () => {
@@ -51,4 +65,106 @@ describe('player tui', () => {
   test('tui: falls back to decimal meter when fraction conversion is not stable', () => {
     expect(formatMeasureSignature(0.123456789)).toBe('0.493827/4');
   });
+
+  test('tui: can use explicit tty support overrides for worker rendering', () => {
+    Object.defineProperty(process.stdout, 'isTTY', {
+      configurable: true,
+      value: false,
+    });
+    Object.defineProperty(process.stdin, 'isTTY', {
+      configurable: true,
+      value: false,
+    });
+
+    const tui = new PlayerTui({
+      mode: 'MANUAL',
+      laneDisplayMode: '7 KEY',
+      title: 'Test Song',
+      lanes: [
+        { channel: '16', key: 'A', isScratch: true },
+        { channel: '11', key: 'S' },
+        { channel: '12', key: 'D' },
+      ],
+      speed: 1,
+      highSpeed: 1,
+      judgeWindowMs: 16.67,
+      stdinIsTTY: true,
+      stdoutIsTTY: true,
+    });
+
+    expect(tui.isSupported()).toBe(true);
+  });
+
+  test('tui: clears and relayouts the frame after terminal resize', () => {
+    mockTerminal({ columns: 120, rows: 32 });
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((() => true) as typeof process.stdout.write);
+    const tui = new PlayerTui({
+      mode: 'MANUAL',
+      laneDisplayMode: '7 KEY',
+      title: 'Test Song',
+      lanes: [
+        { channel: '16', key: 'A', isScratch: true },
+        { channel: '11', key: 'S' },
+        { channel: '12', key: 'D' },
+      ],
+      speed: 1,
+      highSpeed: 1,
+      judgeWindowMs: 16.67,
+      stdinIsTTY: true,
+      stdoutIsTTY: true,
+    });
+    const frame: Parameters<PlayerTui['render']>[0] = {
+      currentBeat: 0,
+      currentSeconds: 0,
+      totalSeconds: 120,
+      summary: {
+        total: 100,
+        perfect: 0,
+        fast: 0,
+        slow: 0,
+        great: 0,
+        good: 0,
+        bad: 0,
+        poor: 0,
+        exScore: 0,
+        score: 0,
+      },
+      notes: [],
+    };
+
+    tui.start();
+    writeSpy.mockClear();
+
+    tui.render(frame);
+    const initialRender = writeSpy.mock.calls.at(-1)?.[0];
+    expect(initialRender).toContain('\u001b[H');
+    expect(initialRender).not.toContain('\u001b[2J\u001b[H');
+
+    tui.setTerminalSize(80, 24);
+    tui.render(frame);
+
+    const resizedRender = writeSpy.mock.calls.at(-1)?.[0];
+    expect(resizedRender).toContain('\u001b[2J\u001b[H');
+
+    tui.stop();
+  });
 });
+
+function mockTerminal({ columns, rows }: { columns: number; rows: number }): void {
+  Object.defineProperty(process.stdout, 'columns', {
+    configurable: true,
+    value: columns,
+  });
+  Object.defineProperty(process.stdout, 'rows', {
+    configurable: true,
+    value: rows,
+  });
+}
+
+function restoreDescriptor(target: object, key: PropertyKey, descriptor: PropertyDescriptor | undefined): void {
+  if (descriptor) {
+    Object.defineProperty(target, key, descriptor);
+    return;
+  }
+  Reflect.deleteProperty(target, key);
+}

--- a/packages/player/src/tui/player-tui.ts
+++ b/packages/player/src/tui/player-tui.ts
@@ -3,11 +3,7 @@ import type { PlayerSummary } from '../index.ts';
 import { formatSeconds, resolveAltModifierLabel } from '../player-utils.ts';
 import type { PlayerStateSignals } from '../player-state-signals.ts';
 import { findStackableRowIndex } from './lane-stacking.ts';
-import {
-  normalizeHighSpeed,
-  resolveAnimatedHighSpeedValue,
-  resolveVisibleBeatsForTuiGrid,
-} from './high-speed.ts';
+import { normalizeHighSpeed, resolveAnimatedHighSpeedValue, resolveVisibleBeatsForTuiGrid } from './high-speed.ts';
 export { resolveAnimatedHighSpeedValue, resolveVisibleBeatsForTuiGrid } from './high-speed.ts';
 
 interface TuiLane {
@@ -39,6 +35,8 @@ interface TuiOptions {
   measureBoundariesBeats?: number[];
   splitAfterIndex?: number;
   stateSignals?: PlayerStateSignals;
+  stdinIsTTY?: boolean;
+  stdoutIsTTY?: boolean;
 }
 
 interface TuiNote {
@@ -129,7 +127,6 @@ const HIGH_SPEED_TRANSITION_MS = 180;
 const JUDGE_COMBO_VISIBILITY_TIMEOUT_MS = 1000;
 const JUDGE_COMBO_BLINK_INTERVAL_MS = 80;
 const FPS_SMOOTHING_FACTOR = 0.2;
-const INPUT_KEY_ACTIVE_STYLE = '1;30;48;5;208';
 const MEASURE_SIGNATURE_MAX_DENOMINATOR = 32;
 const HIGH_SPEED_MODIFIER_LABEL = resolveAltModifierLabel();
 const MEASURE_SIGNATURE_TOLERANCE = 1e-8;
@@ -150,6 +147,42 @@ const BLACK_RGB: RgbColor = { r: 0, g: 0, b: 0 };
 const WHITE_KEY_LANE_BG_RGB: RgbColor = { r: 24, g: 36, b: 56 };
 const BLACK_KEY_LANE_BG_RGB: RgbColor = { r: 2, g: 4, b: 8 };
 const SCRATCH_LANE_BG_RGB: RgbColor = { r: 5, g: 8, b: 12 };
+const SPLIT_PANEL_BACKGROUND_RGB: RgbColor = { r: 18, g: 18, b: 18 };
+const LANE_DIVIDER_RGB: RgbColor = { r: 148, g: 148, b: 148 };
+const LANE_OUTER_BORDER_RGB: RgbColor = { r: 218, g: 218, b: 218 };
+const LANE_CEILING_RGB: RgbColor = { r: 88, g: 88, b: 88 };
+const JUDGE_LINE_RGB: RgbColor = { r: 255, g: 48, b: 48 };
+const LANE_LABEL_RGB: RgbColor = { r: 198, g: 198, b: 198 };
+const RED_NOTE_RGB: RgbColor = { r: 255, g: 95, b: 95 };
+const BLUE_NOTE_RGB: RgbColor = { r: 95, g: 135, b: 255 };
+const WHITE_NOTE_RGB: RgbColor = { r: 255, g: 255, b: 255 };
+const INVISIBLE_NOTE_RGB: RgbColor = { r: 102, g: 224, b: 161 };
+const MEASURE_LINE_RGB: RgbColor = { r: 158, g: 158, b: 158 };
+const MINE_FOREGROUND_RGB: RgbColor = { r: 255, g: 255, b: 255 };
+const MINE_BACKGROUND_RGB: RgbColor = { r: 205, g: 64, b: 64 };
+const INPUT_KEY_LIGHT_FOREGROUND_RGB: RgbColor = { r: 24, g: 24, b: 24 };
+const INPUT_KEY_LIGHT_BACKGROUND_RGB: RgbColor = { r: 238, g: 238, b: 238 };
+const INPUT_KEY_DARK_FOREGROUND_RGB: RgbColor = { r: 250, g: 250, b: 250 };
+const INPUT_KEY_DARK_BACKGROUND_RGB: RgbColor = { r: 16, g: 16, b: 16 };
+const INPUT_KEY_SCRATCH_BACKGROUND_RGB: RgbColor = { r: 138, g: 138, b: 138 };
+const INPUT_KEY_ACTIVE_BACKGROUND_RGB: RgbColor = { r: 255, g: 135, b: 0 };
+const PAUSE_FOREGROUND_RGB: RgbColor = { r: 255, g: 255, b: 255 };
+const PAUSE_BACKGROUND_RGB: RgbColor = { r: 200, g: 59, b: 59 };
+const GREAT_JUDGE_RGB: RgbColor = { r: 255, g: 215, b: 95 };
+const GOOD_JUDGE_RGB: RgbColor = { r: 135, g: 255, b: 118 };
+const BAD_JUDGE_RGB: RgbColor = { r: 255, g: 159, b: 74 };
+const POOR_JUDGE_RGB: RgbColor = { r: 255, g: 107, b: 107 };
+const READY_JUDGE_RGB: RgbColor = { r: 95, g: 215, b: 255 };
+const IDLE_JUDGE_RGB: RgbColor = { r: 154, g: 161, b: 170 };
+const RAINBOW_RGB_STEPS: RgbColor[] = [
+  { r: 255, g: 0, b: 0 },
+  { r: 255, g: 135, b: 0 },
+  { r: 255, g: 255, b: 0 },
+  { r: 135, g: 255, b: 0 },
+  { r: 0, g: 255, b: 255 },
+  { r: 0, g: 175, b: 255 },
+  { r: 255, g: 0, b: 255 },
+];
 
 export class PlayerTui {
   private readonly options: TuiOptions;
@@ -179,6 +212,12 @@ export class PlayerTui {
   private readonly supported: boolean;
 
   private active = false;
+
+  private terminalColumns?: number;
+
+  private terminalRows?: number;
+
+  private needsFullRefresh = false;
 
   private readonly leftJudgeComboDisplay = createJudgeComboDisplayState();
 
@@ -234,7 +273,9 @@ export class PlayerTui {
     this.highSpeedTransitionFrom = initialHighSpeed;
     this.laneChannels = options.lanes.map((lane) => lane.channel);
     this.scrollDistanceMapper = new ScrollDistanceMapper(options.scrollTimeline);
-    this.supported = Boolean(process.stdout.isTTY && process.stdin.isTTY);
+    this.supported = Boolean(
+      (options.stdoutIsTTY ?? process.stdout.isTTY) && (options.stdinIsTTY ?? process.stdin.isTTY),
+    );
     options.lanes.forEach((lane, index) => {
       this.laneIndex.set(lane.channel, index);
       this.laneWidths[index] = lane.isScratch ? DEFAULT_LANE_WIDTH * 2 : DEFAULT_LANE_WIDTH;
@@ -263,6 +304,7 @@ export class PlayerTui {
       return;
     }
     this.active = true;
+    this.needsFullRefresh = false;
     process.stdout.write('\u001b[?1049h\u001b[2J\u001b[H\u001b[?25l');
   }
 
@@ -285,6 +327,7 @@ export class PlayerTui {
     this.noteWindowBeat = Number.NEGATIVE_INFINITY;
     this.visibleNoteIndices.clear();
     this.visibleNoteRows.clear();
+    this.needsFullRefresh = false;
     this.displayedHighSpeed = normalizeHighSpeed(this.options.highSpeed);
     this.targetHighSpeed = this.displayedHighSpeed;
     this.highSpeedTransitionFrom = this.displayedHighSpeed;
@@ -354,6 +397,18 @@ export class PlayerTui {
     this.pressedLaneChannels.delete(this.resolveRenderLaneChannel(channel));
   }
 
+  setTerminalSize(columns: number | undefined, rows: number | undefined): void {
+    const nextColumns = normalizeTerminalDimension(columns);
+    const nextRows = normalizeTerminalDimension(rows);
+    if (this.terminalColumns === nextColumns && this.terminalRows === nextRows) {
+      return;
+    }
+    this.terminalColumns = nextColumns;
+    this.terminalRows = nextRows;
+    this.previousFrameLineCount = 0;
+    this.needsFullRefresh = true;
+  }
+
   private syncStateSignals(): void {
     const stateSignals = this.stateSignals;
     if (!stateSignals) {
@@ -380,7 +435,9 @@ export class PlayerTui {
     this.applyJudgeComboSignalState(stateSignals.getJudgeCombo());
   }
 
-  private applyJudgeComboSignalState(state: Readonly<{ judge: string; combo: number; channel?: string; updatedAtMs: number }>): void {
+  private applyJudgeComboSignalState(
+    state: Readonly<{ judge: string; combo: number; channel?: string; updatedAtMs: number }>,
+  ): void {
     for (const display of this.resolveJudgeComboTargets(state.channel)) {
       display.latestJudge = state.judge;
       display.combo = state.combo;
@@ -394,7 +451,7 @@ export class PlayerTui {
     }
     this.syncStateSignals();
 
-    const terminalRows = process.stdout.rows ?? DEFAULT_GRID_ROWS + STATIC_TUI_LINES;
+    const terminalRows = this.terminalRows ?? process.stdout.rows ?? DEFAULT_GRID_ROWS + STATIC_TUI_LINES;
     const debugLineCount = frame.activeAudioFiles === undefined && frame.activeAudioVoiceCount === undefined ? 0 : 1;
     const rowCount = Math.max(MIN_GRID_ROWS, terminalRows - STATIC_TUI_LINES - debugLineCount);
     const laneCount = Math.max(1, this.options.lanes.length);
@@ -434,7 +491,6 @@ export class PlayerTui {
 
     for (let noteIndex = noteStartIndex; noteIndex < noteEndIndex; noteIndex += 1) {
       const note = frame.notes[noteIndex];
-      const wasVisible = this.visibleNoteIndices.has(noteIndex);
       const previousRow = this.visibleNoteRows.get(noteIndex);
       let visibleThisFrame = false;
       const keepVisible =
@@ -504,15 +560,7 @@ export class PlayerTui {
             if (row < 0 || row >= rowCount) {
               continue;
             }
-            setLaneCell(
-              grid,
-              gridSourceChannels,
-              row,
-              lane,
-              longBodySymbol,
-              note.channel,
-              this.freeZoneSourceChannels,
-            );
+            setLaneCell(grid, gridSourceChannels, row, lane, longBodySymbol, note.channel, this.freeZoneSourceChannels);
           }
           visibleThisFrame = true;
         }
@@ -717,7 +765,7 @@ export class PlayerTui {
       `Space: pause/resume  Shift+R: restart  ${HIGH_SPEED_MODIFIER_LABEL}+odd/even lane: HS -/+  Ctrl+C/Esc: quit`,
     );
 
-    const columns = process.stdout.columns ?? 120;
+    const columns = this.terminalColumns ?? process.stdout.columns ?? 120;
     const paddedLines = lines.map((line) => padVisibleWidth(line, columns));
     if (this.previousFrameLineCount > paddedLines.length) {
       const diff = this.previousFrameLineCount - paddedLines.length;
@@ -725,12 +773,17 @@ export class PlayerTui {
         paddedLines.push(' '.repeat(columns));
       }
     }
-    process.stdout.write(`\u001b[H${paddedLines.join('\n')}`);
+    process.stdout.write(`${this.needsFullRefresh ? '\u001b[2J' : ''}\u001b[H${paddedLines.join('\n')}`);
     this.previousFrameLineCount = lines.length;
+    this.needsFullRefresh = false;
     this.lastRenderedBeat = frame.currentBeat;
   }
 
-  private resolveNoteWindow(notes: TuiNote[], currentBeat: number, scrollWindowBeats: number): { start: number; end: number } {
+  private resolveNoteWindow(
+    notes: TuiNote[],
+    currentBeat: number,
+    scrollWindowBeats: number,
+  ): { start: number; end: number } {
     if (this.noteWindowSource !== notes || currentBeat < this.noteWindowBeat) {
       this.noteWindowSource = notes;
       this.noteWindowStartIndex = 0;
@@ -1135,7 +1188,7 @@ function renderLaneSection(cells: string[]): string {
 }
 
 function renderLaneSplitPanel(): string {
-  const fill = `\u001b[48;5;233m${' '.repeat(SPLIT_PANEL_INNER_WIDTH)}${ANSI_RESET}`;
+  const fill = `\u001b[48;2;${SPLIT_PANEL_BACKGROUND_RGB.r};${SPLIT_PANEL_BACKGROUND_RGB.g};${SPLIT_PANEL_BACKGROUND_RGB.b}m${' '.repeat(SPLIT_PANEL_INNER_WIDTH)}${ANSI_RESET}`;
   return `${colorizeLaneOuterBorder(LANE_OUTER_BORDER_SYMBOL)}${fill}${colorizeLaneOuterBorder(LANE_OUTER_BORDER_SYMBOL)}`;
 }
 
@@ -1157,9 +1210,7 @@ function renderInputKeyRows(
       ? laneNumber > 0 && laneNumber % 2 === 0
       : resolveInputKeyLaneGroup(lane) === 'black';
     const laneChannel = lane.channel.toUpperCase();
-    const labelStyle = useOddEvenRows
-      ? (isUpperRowLane ? 'black' : 'white')
-      : resolveInputKeyLaneStyle(lane);
+    const labelStyle = useOddEvenRows ? (isUpperRowLane ? 'black' : 'white') : resolveInputKeyLaneStyle(lane);
     const styledLabel = activeChannels.has(laneChannel)
       ? colorizeActiveInputKeyLabel(center(lane.key, laneWidth))
       : colorizeInputKeyLabel(center(lane.key, laneWidth), labelStyle);
@@ -1495,48 +1546,47 @@ function renderLaneBackdropCell(width: number): string {
 }
 
 function colorizeLaneDivider(symbol: string): string {
-  return `\u001b[38;5;246m${symbol}${ANSI_RESET}`;
+  return colorizeText(symbol, LANE_DIVIDER_RGB);
 }
 
 function colorizeLaneOuterBorder(symbol: string): string {
-  return `\u001b[1;38;5;253m${symbol}${ANSI_RESET}`;
+  return colorizeText(symbol, LANE_OUTER_BORDER_RGB);
 }
 
 function colorizeLaneCeiling(symbol: string): string {
-  return `\u001b[38;5;240m${symbol}${ANSI_RESET}`;
+  return colorizeText(symbol, LANE_CEILING_RGB);
 }
 
 function colorizeJudgeLine(symbol: string): string {
-  return `\u001b[1;38;5;196m${symbol}${ANSI_RESET}`;
+  return colorizeText(symbol, JUDGE_LINE_RGB);
 }
 
 function colorizeLaneLabel(symbol: string): string {
-  return `\u001b[1;38;5;251m${symbol}${ANSI_RESET}`;
+  return colorizeText(symbol, LANE_LABEL_RGB);
 }
 
 function colorizeNote(symbol: string, channel: string, invisible = false, underline = false): string {
-  const suffix = underline ? ';4' : '';
   if (invisible) {
-    return `\u001b[32${suffix}m${symbol}\u001b[0m`;
+    return colorizeText(symbol, INVISIBLE_NOTE_RGB, undefined, underline);
   }
   if (RED_NOTE_CHANNELS.has(channel)) {
-    return `\u001b[31${suffix}m${symbol}\u001b[0m`;
+    return colorizeText(symbol, RED_NOTE_RGB, undefined, underline);
   }
   if (BLUE_NOTE_CHANNELS.has(channel)) {
-    return `\u001b[34${suffix}m${symbol}\u001b[0m`;
+    return colorizeText(symbol, BLUE_NOTE_RGB, undefined, underline);
   }
   if (WHITE_NOTE_CHANNELS.has(channel)) {
-    return `\u001b[1;97${suffix}m${symbol}\u001b[0m`;
+    return colorizeText(symbol, WHITE_NOTE_RGB, undefined, underline);
   }
   return symbol;
 }
 
 function colorizeMeasureLine(symbol: string): string {
-  return `\u001b[38;5;247m${symbol}\u001b[0m`;
+  return colorizeText(symbol, MEASURE_LINE_RGB);
 }
 
 function colorizeMine(symbol: string): string {
-  return `\u001b[1;97;41m${symbol}\u001b[0m`;
+  return colorizeText(symbol, MINE_FOREGROUND_RGB, MINE_BACKGROUND_RGB);
 }
 
 function colorizeLaneBackground(value: string, channel: string): string {
@@ -1577,16 +1627,16 @@ function mixColorByte(from: number, to: number, ratio: number): number {
 
 function colorizeInputKeyLabel(value: string, style: 'white' | 'black' | 'scratch'): string {
   if (style === 'white') {
-    return `\u001b[1;30;48;5;255m${value}${ANSI_RESET}`;
+    return colorizeText(value, INPUT_KEY_LIGHT_FOREGROUND_RGB, INPUT_KEY_LIGHT_BACKGROUND_RGB);
   }
   if (style === 'black') {
-    return `\u001b[1;97;48;5;232m${value}${ANSI_RESET}`;
+    return colorizeText(value, INPUT_KEY_DARK_FOREGROUND_RGB, INPUT_KEY_DARK_BACKGROUND_RGB);
   }
-  return `\u001b[1;30;48;5;245m${value}${ANSI_RESET}`;
+  return colorizeText(value, INPUT_KEY_LIGHT_FOREGROUND_RGB, INPUT_KEY_SCRATCH_BACKGROUND_RGB);
 }
 
 function colorizeActiveInputKeyLabel(value: string): string {
-  return `\u001b[${INPUT_KEY_ACTIVE_STYLE}m${value}${ANSI_RESET}`;
+  return colorizeText(value, INPUT_KEY_LIGHT_FOREGROUND_RGB, INPUT_KEY_ACTIVE_BACKGROUND_RGB);
 }
 
 function resolveInputKeyLaneGroup(lane: TuiLane): 'white' | 'black' {
@@ -1642,7 +1692,7 @@ function resolveVisibleJudgeComboLabel(state: JudgeComboDisplayState, nowMs: num
 
 function formatJudgeComboDisplay(latestJudge: string, combo: number, nowMs: number, paused: boolean): string {
   if (paused) {
-    return colorizeText('PAUSE', '1;97;41');
+    return colorizeText('PAUSE', PAUSE_FOREGROUND_RGB, PAUSE_BACKGROUND_RGB);
   }
   const normalizedJudge = latestJudge === 'PERFECT' ? 'GREAT' : latestJudge;
   const safeCombo = Math.max(0, Math.floor(combo));
@@ -1652,30 +1702,30 @@ function formatJudgeComboDisplay(latestJudge: string, combo: number, nowMs: numb
     return colorizeBlinkingRainbow(baseText, nowMs);
   }
   if (latestJudge === 'GREAT') {
-    return colorizeBlinkingText(baseText, '1;38;5;220', '2;38;5;220', nowMs);
+    return colorizeBlinkingText(baseText, GREAT_JUDGE_RGB, dimRgb(GREAT_JUDGE_RGB, 0.5), nowMs);
   }
   if (latestJudge === 'GOOD') {
-    return colorizeBlinkingText(baseText, '1;38;5;118', '2;38;5;118', nowMs);
+    return colorizeBlinkingText(baseText, GOOD_JUDGE_RGB, dimRgb(GOOD_JUDGE_RGB, 0.5), nowMs);
   }
   if (latestJudge === 'BAD') {
-    return colorizeBlinkingText(baseText, '1;38;5;208', '2;38;5;208', nowMs);
+    return colorizeBlinkingText(baseText, BAD_JUDGE_RGB, dimRgb(BAD_JUDGE_RGB, 0.5), nowMs);
   }
   if (latestJudge === 'POOR') {
-    return colorizeBlinkingText(baseText, '1;38;5;203', '2;38;5;203', nowMs);
+    return colorizeBlinkingText(baseText, POOR_JUDGE_RGB, dimRgb(POOR_JUDGE_RGB, 0.5), nowMs);
   }
   if (latestJudge === 'READY') {
-    return colorizeText(baseText, '1;38;5;81');
+    return colorizeText(baseText, READY_JUDGE_RGB);
   }
   if (latestJudge === '-') {
-    return colorizeText(baseText, '2;37');
+    return colorizeText(baseText, IDLE_JUDGE_RGB);
   }
   return baseText;
 }
 
-function colorizeBlinkingText(value: string, onSgr: string, offSgr: string, nowMs: number): string {
+function colorizeBlinkingText(value: string, onColor: RgbColor, offColor: RgbColor, nowMs: number): string {
   // ANSI blink is not consistently supported, so emulate blink with a time-based pulse.
   const blinkOn = Math.floor(nowMs / JUDGE_COMBO_BLINK_INTERVAL_MS) % 2 === 0;
-  return colorizeText(value, blinkOn ? onSgr : offSgr);
+  return colorizeText(value, blinkOn ? onColor : offColor);
 }
 
 function colorizeBlinkingRainbow(value: string, nowMs: number): string {
@@ -1683,17 +1733,34 @@ function colorizeBlinkingRainbow(value: string, nowMs: number): string {
   return colorizeRainbow(value, blinkOn);
 }
 
-function colorizeText(value: string, sgr: string): string {
-  return `\u001b[${sgr}m${value}${ANSI_RESET}`;
+function colorizeText(value: string, foreground: RgbColor, background?: RgbColor, underline = false): string {
+  const sgr = [`38;2;${foreground.r};${foreground.g};${foreground.b}`];
+  if (background) {
+    sgr.push(`48;2;${background.r};${background.g};${background.b}`);
+  }
+  if (underline) {
+    sgr.push('4');
+  }
+  return `\u001b[${sgr.join(';')}m${value}${ANSI_RESET}`;
 }
 
 function colorizeRainbow(value: string, bright = true): string {
-  const steps = [196, 208, 226, 118, 51, 39, 201];
-  const intensity = bright ? '1' : '2';
+  const brightness = bright ? 1 : 0.5;
   const characters = [...value];
   return characters
-    .map((character, index) => `\u001b[${intensity};38;5;${steps[index % steps.length]}m${character}${ANSI_RESET}`)
+    .map((character, index) =>
+      colorizeText(character, dimRgb(RAINBOW_RGB_STEPS[index % RAINBOW_RGB_STEPS.length]!, brightness)),
+    )
     .join('');
+}
+
+function dimRgb(color: RgbColor, factor: number): RgbColor {
+  const safeFactor = clamp(factor, 0, 1);
+  return {
+    r: clampColorByte(color.r * safeFactor),
+    g: clampColorByte(color.g * safeFactor),
+    b: clampColorByte(color.b * safeFactor),
+  };
 }
 
 function renderLaneBlockWithBga(laneLines: string[], bgaAnsiLines?: string[]): string[] {
@@ -1735,6 +1802,13 @@ function padVisibleWidth(line: string, width: number): string {
     return clipped;
   }
   return `${clipped}${' '.repeat(width - currentWidth)}`;
+}
+
+function normalizeTerminalDimension(value: number | undefined): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return undefined;
+  }
+  return Math.max(1, Math.floor(value));
 }
 
 function renderBgaLineWithScopedBlackBackground(line: string, width: number): string {
@@ -1791,9 +1865,7 @@ function parseAnsiSgrParams(value: string, start: number, end: number): number[]
   if (parts.length === 0) {
     return [0];
   }
-  const params = parts
-    .map((part) => Number.parseInt(part, 10))
-    .filter((param) => Number.isFinite(param));
+  const params = parts.map((part) => Number.parseInt(part, 10)).filter((param) => Number.isFinite(param));
   return params.length > 0 ? params : [0];
 }
 
@@ -2175,11 +2247,7 @@ function resolveMeasureLength(measureLengths: ReadonlyMap<number, number> | unde
 export function formatMeasureSignature(length: number | undefined): string {
   const safeLength = typeof length === 'number' && Number.isFinite(length) && length > 0 ? length : 1;
   const quarterBeats = safeLength * IIDX_MEASURE_BEATS;
-  const fraction = approximateFraction(
-    quarterBeats,
-    MEASURE_SIGNATURE_MAX_DENOMINATOR,
-    MEASURE_SIGNATURE_TOLERANCE,
-  );
+  const fraction = approximateFraction(quarterBeats, MEASURE_SIGNATURE_MAX_DENOMINATOR, MEASURE_SIGNATURE_TOLERANCE);
   if (fraction) {
     return `${fraction.numerator}/${fraction.denominator * IIDX_MEASURE_BEATS}`;
   }

--- a/packages/player/vite.config.ts
+++ b/packages/player/vite.config.ts
@@ -9,6 +9,7 @@ export default createPackageViteConfig({
   entries: {
     index: 'src/index.ts',
     cli: 'src/cli.ts',
+    'node-gameplay-worker': 'src/node/node-gameplay-worker.ts',
     'node-ui-worker': 'src/node/node-ui-worker.ts',
   },
 });

--- a/packages/player/vite.config.ts
+++ b/packages/player/vite.config.ts
@@ -9,5 +9,6 @@ export default createPackageViteConfig({
   entries: {
     index: 'src/index.ts',
     cli: 'src/cli.ts',
+    'node-ui-worker': 'src/node/node-ui-worker.ts',
   },
 });


### PR DESCRIPTION
## Summary
- move Node TUI and BGA rendering into a dedicated worker so terminal stalls do not block the playback and judgement loop
- restore the TUI rendering path to the devel-style full-frame baseline, while keeping worker-safe TTY handling and terminal resize propagation
- wait for UI worker shutdown before returning to the result screen, and switch the TUI palette to truecolor for more consistent colors across terminals

## Testing
- npx pnpm@10.30.3 --filter @be-music/player exec vitest run src/tui.test.ts src/node/deferred-ui-flush.test.ts src/node/node-ui-runtime.test.ts
- npx pnpm@10.30.3 --filter @be-music/player run typecheck
- npx pnpm@10.30.3 --filter @be-music/player exec oxlint src/core/player-engine.ts src/node/deferred-ui-flush.ts src/node/deferred-ui-flush.test.ts src/node/node-ui-runtime.ts src/node/node-ui-runtime.test.ts src/node/node-ui-worker.ts src/node/node-ui-worker-protocol.ts src/tui.test.ts src/tui/player-tui.ts
- npx pnpm@10.30.3 --filter @be-music/player exec oxfmt --check src/core/player-engine.ts src/node/deferred-ui-flush.ts src/node/deferred-ui-flush.test.ts src/node/node-ui-runtime.ts src/node/node-ui-runtime.test.ts src/node/node-ui-worker.ts src/node/node-ui-worker-protocol.ts src/tui.test.ts src/tui/player-tui.ts