### PR TITLE
fix(player): align BGA sizing with TUI layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -199,7 +200,15 @@ jobs:
         id: detect-bench
         shell: bash
         run: |
-          if node -e "const fs=require('node:fs'); const pkg=JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.exit(pkg.scripts && pkg.scripts['bench'] ? 0 : 1);" package.json; then
+          set -euo pipefail
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          BASE_PKG_JSON="$(mktemp)"
+          trap 'rm -f "$BASE_PKG_JSON"' EXIT
+          if ! git show "${BASE_SHA}:package.json" > "$BASE_PKG_JSON" 2>/dev/null; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if node -e "const fs=require('node:fs'); const pkg=JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.exit(pkg.scripts && pkg.scripts['bench'] ? 0 : 1);" "$BASE_PKG_JSON"; then
             echo "available=true" >> "$GITHUB_OUTPUT"
           else
             echo "available=false" >> "$GITHUB_OUTPUT"
@@ -214,10 +223,27 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          BASE_DIR="$(mktemp -d)"
+
+          cleanup() {
+            git worktree remove --force "$BASE_DIR" >/dev/null 2>&1 || true
+            rm -rf "$BASE_DIR" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
+          git worktree add --detach "$BASE_DIR" "$BASE_SHA"
           mkdir -p tmp/bench/base-runs
-          for run_index in $(seq 1 "$BENCH_REPEATS"); do
-            BENCH_GIT_SHA="${{ github.event.pull_request.base.sha }}" pnpm run bench --output "tmp/bench/base-runs/run-${run_index}.json" --time "$BENCH_TIME_MS" --warmup-time "$BENCH_WARMUP_TIME_MS"
-          done
+
+          (
+            cd "$BASE_DIR"
+            pnpm install --frozen-lockfile --prefer-offline
+            for run_index in $(seq 1 "$BENCH_REPEATS"); do
+              BENCH_GIT_SHA="$BASE_SHA" pnpm run bench --output "tmp/bench/base-runs/run-${run_index}.json" --time "$BENCH_TIME_MS" --warmup-time "$BENCH_WARMUP_TIME_MS"
+            done
+          )
+
+          cp "$BASE_DIR"/tmp/bench/base-runs/*.json tmp/bench/base-runs/
 
       - name: Aggregate base benchmark snapshots
         if: steps.detect-bench.outputs.available == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,25 +103,25 @@ jobs:
       - name: Run ${{ matrix.task }}
         run: pnpm run ${{ matrix.task }}
 
-  benchmark-pr:
-    name: Benchmark (PR)
+  benchmark-pr-head:
+    name: Benchmark Head (PR)
     needs: changes
     if: github.event_name == 'pull_request' && needs.changes.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    outputs:
+      snapshot_b64: ${{ steps.aggregate-head.outputs.snapshot_b64 }}
     env:
-      BENCH_TIME_MS: 60
-      BENCH_WARMUP_TIME_MS: 30
-      BENCH_REGRESSION_THRESHOLD: 8
+      BENCH_TIME_MS: 200
+      BENCH_WARMUP_TIME_MS: 100
+      BENCH_REPEATS: 3
     permissions:
       contents: read
-      pull-requests: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup pnpm
@@ -140,46 +140,155 @@ jobs:
         run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Run head benchmark
-        run: BENCH_GIT_SHA="${{ github.event.pull_request.head.sha }}" pnpm run bench --output tmp/bench/head.json --time "$BENCH_TIME_MS" --warmup-time "$BENCH_WARMUP_TIME_MS"
-
-      - name: Run base benchmark
-        id: base-benchmark
         shell: bash
         run: |
           set -euo pipefail
-          BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          BASE_DIR="$(mktemp -d)"
+          mkdir -p tmp/bench/head-runs
+          for run_index in $(seq 1 "$BENCH_REPEATS"); do
+            BENCH_GIT_SHA="${{ github.event.pull_request.head.sha }}" pnpm run bench --output "tmp/bench/head-runs/run-${run_index}.json" --time "$BENCH_TIME_MS" --warmup-time "$BENCH_WARMUP_TIME_MS"
+          done
 
-          cleanup() {
-            git worktree remove --force "$BASE_DIR" >/dev/null 2>&1 || true
-            rm -rf "$BASE_DIR" >/dev/null 2>&1 || true
-          }
-          trap cleanup EXIT
+      - name: Aggregate head benchmark snapshots
+        id: aggregate-head
+        shell: bash
+        run: |
+          set -euo pipefail
+          pnpm run bench:aggregate -- --output tmp/bench/head.json tmp/bench/head-runs/*.json
+          {
+            echo "snapshot_b64<<__SNAPSHOT__"
+            node -e "const fs=require('node:fs'); process.stdout.write(fs.readFileSync('tmp/bench/head.json').toString('base64'));"
+            echo
+            echo "__SNAPSHOT__"
+          } >> "$GITHUB_OUTPUT"
 
-          git worktree add --detach "$BASE_DIR" "$BASE_SHA"
+  benchmark-pr-base:
+    name: Benchmark Base (PR)
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.code_changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      available: ${{ steps.detect-bench.outputs.available }}
+      snapshot_b64: ${{ steps.aggregate-base.outputs.snapshot_b64 }}
+    env:
+      BENCH_TIME_MS: 200
+      BENCH_WARMUP_TIME_MS: 100
+      BENCH_REPEATS: 3
+    permissions:
+      contents: read
 
-          if ! node -e "const fs=require('node:fs'); const pkg=JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.exit(pkg.scripts && pkg.scripts['bench'] ? 0 : 1);" "$BASE_DIR/package.json"; then
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
 
-          if (
-            cd "$BASE_DIR"
-            pnpm install --frozen-lockfile --prefer-offline
-            BENCH_GIT_SHA="$BASE_SHA" pnpm run bench --output tmp/bench/base.json --time "$BENCH_TIME_MS" --warmup-time "$BENCH_WARMUP_TIME_MS"
-          ); then
-            mkdir -p tmp/bench
-            cp "$BASE_DIR/tmp/bench/base.json" tmp/bench/base.json
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Detect benchmark support
+        id: detect-bench
+        shell: bash
+        run: |
+          if node -e "const fs=require('node:fs'); const pkg=JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.exit(pkg.scripts && pkg.scripts['bench'] ? 0 : 1);" package.json; then
             echo "available=true" >> "$GITHUB_OUTPUT"
           else
             echo "available=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Install dependencies
+        if: steps.detect-bench.outputs.available == 'true'
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Run base benchmark
+        if: steps.detect-bench.outputs.available == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p tmp/bench/base-runs
+          for run_index in $(seq 1 "$BENCH_REPEATS"); do
+            BENCH_GIT_SHA="${{ github.event.pull_request.base.sha }}" pnpm run bench --output "tmp/bench/base-runs/run-${run_index}.json" --time "$BENCH_TIME_MS" --warmup-time "$BENCH_WARMUP_TIME_MS"
+          done
+
+      - name: Aggregate base benchmark snapshots
+        if: steps.detect-bench.outputs.available == 'true'
+        id: aggregate-base
+        shell: bash
+        run: |
+          set -euo pipefail
+          pnpm run bench:aggregate -- --output tmp/bench/base.json tmp/bench/base-runs/*.json
+          {
+            echo "snapshot_b64<<__SNAPSHOT__"
+            node -e "const fs=require('node:fs'); process.stdout.write(fs.readFileSync('tmp/bench/base.json').toString('base64'));"
+            echo
+            echo "__SNAPSHOT__"
+          } >> "$GITHUB_OUTPUT"
+
+  benchmark-pr:
+    name: Benchmark (PR)
+    needs:
+      - changes
+      - benchmark-pr-head
+      - benchmark-pr-base
+    if: github.event_name == 'pull_request' && needs.changes.outputs.code_changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      BENCH_REGRESSION_THRESHOLD: 8
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Restore head benchmark snapshot
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p tmp/bench
+          node -e "const fs=require('node:fs'); fs.writeFileSync('tmp/bench/head.json', Buffer.from(process.argv[1], 'base64'));" '${{ needs.benchmark-pr-head.outputs.snapshot_b64 }}'
+
+      - name: Restore base benchmark snapshot
+        if: needs.benchmark-pr-base.outputs.available == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p tmp/bench
+          node -e "const fs=require('node:fs'); fs.writeFileSync('tmp/bench/base.json', Buffer.from(process.argv[1], 'base64'));" '${{ needs.benchmark-pr-base.outputs.snapshot_b64 }}'
+
       - name: Generate benchmark report
         shell: bash
         run: |
           set -euo pipefail
-          if [ "${{ steps.base-benchmark.outputs.available }}" = "true" ]; then
+          if [ "${{ needs.benchmark-pr-base.outputs.available }}" = "true" ]; then
             pnpm run bench:compare --head tmp/bench/head.json --base tmp/bench/base.json --output tmp/bench/pr-benchmark.md --summary tmp/bench/pr-benchmark-summary.json --threshold "$BENCH_REGRESSION_THRESHOLD" --top 12
           else
             pnpm run bench:compare --head tmp/bench/head.json --output tmp/bench/pr-benchmark.md --summary tmp/bench/pr-benchmark-summary.json --threshold "$BENCH_REGRESSION_THRESHOLD" --top 12

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "be-music",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@10.30.3",
   "description": "Be-Music tooling monorepo",
   "scripts": {
     "build": "pnpm -r --sort --workspace-concurrency=Infinity run build:bundle && tsgo -b tsconfig.json",
@@ -15,6 +14,7 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "bench": "tsx --tsconfig tsconfig.typecheck.json scripts/bench/exports.ts",
+    "bench:aggregate": "tsx --tsconfig tsconfig.typecheck.json scripts/bench/aggregate-results.ts",
     "bench:compare": "tsx --tsconfig tsconfig.typecheck.json scripts/bench/compare-results.ts",
     "player": "pnpm --filter @be-music/player run dev",
     "player:sea": "pnpm --filter @be-music/player run build:sea",
@@ -39,6 +39,7 @@
   "engines": {
     "node": ">=22"
   },
+  "packageManager": "pnpm@10.30.3",
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild"

--- a/packages/player/src/bga-video-sizing.test.ts
+++ b/packages/player/src/bga-video-sizing.test.ts
@@ -1,0 +1,181 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, test, vi } from 'vitest';
+import { createEmptyJson } from '../../json/src/index.ts';
+
+vi.mock('./bga-video.ts', () => ({
+  decodeVideoFramesStream: vi.fn(async (_videoPath: string, onFrame: (frame: unknown) => void) => {
+    const width = 320;
+    const height = 240;
+    const rgba = new Uint8Array(width * height * 4);
+    for (let y = 0; y < height; y += 1) {
+      for (let x = 0; x < width; x += 1) {
+        const offset = (y * width + x) * 4;
+        rgba[offset] = 255;
+        rgba[offset + 1] = 0;
+        rgba[offset + 2] = 0;
+        rgba[offset + 3] = 255;
+      }
+    }
+    onFrame({
+      seconds: 0,
+      width,
+      height,
+      rgba,
+    });
+    return {
+      codecName: 'h264',
+      frameCount: 1,
+    };
+  }),
+}));
+
+import { createBgaAnsiRenderer } from './bga.ts';
+
+describe('player bga video sizing', () => {
+  test('stretches video frames to use the full BGA canvas like BMP sources', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-video-size-'));
+    try {
+      await writeFile(join(baseDir, 'movie.mp4'), '');
+
+      const json = createEmptyJson('bms');
+      json.metadata.bpm = 120;
+      json.resources.bmp['01'] = 'movie.mp4';
+      json.events = [{ measure: 0, channel: '04', position: [0, 1], value: '01' }];
+
+      const renderer = await createBgaAnsiRenderer(json, {
+        baseDir,
+        width: 40,
+        height: 20,
+      });
+
+      expect(renderer).toBeDefined();
+      const pixels = parseAnsiPixels(renderer?.getAnsiLines(0) ?? []);
+      const bounds = findOpaqueBounds(pixels);
+      expect(bounds).toBeDefined();
+      expect(bounds).toMatchObject({
+        minX: 0,
+        minY: 0,
+        maxX: 39,
+        maxY: 19,
+      });
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+});
+
+interface RgbColor {
+  r: number;
+  g: number;
+  b: number;
+}
+
+type Pixel = RgbColor | undefined;
+
+function parseAnsiPixels(lines: string[]): Pixel[][] {
+  return lines.map((line) => {
+    const row: Pixel[] = [];
+    let index = 0;
+    let activeBackground: RgbColor | undefined;
+
+    while (index < line.length) {
+      if (line.charCodeAt(index) === 0x1b && index + 1 < line.length && line[index + 1] === '[') {
+        const sequenceEnd = findAnsiSgrSequenceEnd(line, index + 2);
+        if (sequenceEnd < 0) {
+          index += 1;
+          continue;
+        }
+        const params = parseAnsiSgrParams(line, index + 2, sequenceEnd);
+        activeBackground = resolveAnsiBackgroundColor(params, activeBackground);
+        index = sequenceEnd + 1;
+        continue;
+      }
+
+      const codePoint = line.codePointAt(index);
+      if (codePoint === undefined) {
+        break;
+      }
+
+      row.push(activeBackground ? { ...activeBackground } : undefined);
+      index += codePoint > 0xffff ? 2 : 1;
+    }
+
+    return row;
+  });
+}
+
+function findAnsiSgrSequenceEnd(value: string, start: number): number {
+  for (let index = start; index < value.length; index += 1) {
+    if (value[index] === 'm') {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function parseAnsiSgrParams(value: string, start: number, end: number): number[] {
+  const raw = value.slice(start, end);
+  if (raw.length === 0) {
+    return [0];
+  }
+  return raw
+    .split(';')
+    .map((part) => Number.parseInt(part, 10))
+    .filter((part) => Number.isFinite(part));
+}
+
+function resolveAnsiBackgroundColor(params: number[], current: RgbColor | undefined): RgbColor | undefined {
+  if (params.length === 0) {
+    return current;
+  }
+
+  let next = current;
+  for (let index = 0; index < params.length; index += 1) {
+    const code = params[index];
+    if (code === 0 || code === 49) {
+      next = undefined;
+      continue;
+    }
+    if (code === 48 && params[index + 1] === 2) {
+      const r = params[index + 2] ?? 0;
+      const g = params[index + 3] ?? 0;
+      const b = params[index + 4] ?? 0;
+      next = { r, g, b };
+      index += 4;
+    }
+  }
+  return next;
+}
+
+function findOpaqueBounds(pixels: Pixel[][]): { minX: number; minY: number; maxX: number; maxY: number } | undefined {
+  let minX = Number.POSITIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+
+  for (let y = 0; y < pixels.length; y += 1) {
+    const row = pixels[y] ?? [];
+    for (let x = 0; x < row.length; x += 1) {
+      if (!row[x]) {
+        continue;
+      }
+      minX = Math.min(minX, x);
+      minY = Math.min(minY, y);
+      maxX = Math.max(maxX, x);
+      maxY = Math.max(maxY, y);
+    }
+  }
+
+  if (!Number.isFinite(minX)) {
+    return undefined;
+  }
+
+  return {
+    minX,
+    minY,
+    maxX,
+    maxY,
+  };
+}

--- a/packages/player/src/bga-video-sizing.test.ts
+++ b/packages/player/src/bga-video-sizing.test.ts
@@ -5,9 +5,10 @@ import { describe, expect, test, vi } from 'vitest';
 import { createEmptyJson } from '../../json/src/index.ts';
 
 vi.mock('./bga-video.ts', () => ({
-  decodeVideoFramesStream: vi.fn(async (_videoPath: string, onFrame: (frame: unknown) => void) => {
-    const width = 320;
-    const height = 240;
+  decodeVideoFramesStream: vi.fn(async (videoPath: string, onFrame: (frame: unknown) => void) => {
+    const isPortrait = videoPath.includes('portrait');
+    const width = isPortrait ? 180 : 320;
+    const height = isPortrait ? 320 : 240;
     const rgba = new Uint8Array(width * height * 4);
     for (let y = 0; y < height; y += 1) {
       for (let x = 0; x < width; x += 1) {
@@ -34,7 +35,7 @@ vi.mock('./bga-video.ts', () => ({
 import { createBgaAnsiRenderer } from './bga.ts';
 
 describe('player bga video sizing', () => {
-  test('stretches video frames to use the full BGA canvas like BMP sources', async () => {
+  test('fits landscape video frames into the BGA region with contain sizing', async () => {
     const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-video-size-'));
     try {
       await writeFile(join(baseDir, 'movie.mp4'), '');
@@ -56,8 +57,39 @@ describe('player bga video sizing', () => {
       expect(bounds).toBeDefined();
       expect(bounds).toMatchObject({
         minX: 0,
-        minY: 0,
+        minY: 2,
         maxX: 39,
+        maxY: 16,
+      });
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  test('fits portrait video frames into the BGA region with contain sizing', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-video-size-'));
+    try {
+      await writeFile(join(baseDir, 'portrait.mp4'), '');
+
+      const json = createEmptyJson('bms');
+      json.metadata.bpm = 120;
+      json.resources.bmp['01'] = 'portrait.mp4';
+      json.events = [{ measure: 0, channel: '04', position: [0, 1], value: '01' }];
+
+      const renderer = await createBgaAnsiRenderer(json, {
+        baseDir,
+        width: 40,
+        height: 20,
+      });
+
+      expect(renderer).toBeDefined();
+      const pixels = parseAnsiPixels(renderer?.getAnsiLines(0) ?? []);
+      const bounds = findOpaqueBounds(pixels);
+      expect(bounds).toBeDefined();
+      expect(bounds).toMatchObject({
+        minX: 9,
+        minY: 0,
+        maxX: 30,
         maxY: 19,
       });
     } finally {

--- a/packages/player/src/bga-video-sizing.test.ts
+++ b/packages/player/src/bga-video-sizing.test.ts
@@ -6,6 +6,7 @@ import { createEmptyJson } from '../../json/src/index.ts';
 
 vi.mock('./bga-video.ts', () => ({
   decodeVideoFramesStream: vi.fn(async (videoPath: string, onFrame: (frame: unknown) => void) => {
+    const hasBlackBorder = videoPath.includes('bordered');
     const isPortrait = videoPath.includes('portrait');
     const width = isPortrait ? 180 : 320;
     const height = isPortrait ? 320 : 240;
@@ -13,7 +14,8 @@ vi.mock('./bga-video.ts', () => ({
     for (let y = 0; y < height; y += 1) {
       for (let x = 0; x < width; x += 1) {
         const offset = (y * width + x) * 4;
-        rgba[offset] = 255;
+        const insideBorder = !hasBlackBorder || (x >= 32 && x < width - 32 && y >= 24 && y < height - 24);
+        rgba[offset] = insideBorder ? 255 : 0;
         rgba[offset + 1] = 0;
         rgba[offset + 2] = 0;
         rgba[offset + 3] = 255;
@@ -91,6 +93,37 @@ describe('player bga video sizing', () => {
         minY: 0,
         maxX: 30,
         maxY: 19,
+      });
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  test('trims black video borders before fitting into the BGA region', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-video-size-'));
+    try {
+      await writeFile(join(baseDir, 'bordered.mp4'), '');
+
+      const json = createEmptyJson('bms');
+      json.metadata.bpm = 120;
+      json.resources.bmp['01'] = 'bordered.mp4';
+      json.events = [{ measure: 0, channel: '04', position: [0, 1], value: '01' }];
+
+      const renderer = await createBgaAnsiRenderer(json, {
+        baseDir,
+        width: 40,
+        height: 20,
+      });
+
+      expect(renderer).toBeDefined();
+      const pixels = parseAnsiPixels(renderer?.getAnsiLines(0) ?? []);
+      const bounds = findOpaqueBounds(pixels);
+      expect(bounds).toBeDefined();
+      expect(bounds).toMatchObject({
+        minX: 0,
+        minY: 2,
+        maxX: 39,
+        maxY: 16,
       });
     } finally {
       await rm(baseDir, { recursive: true, force: true });

--- a/packages/player/src/bga.test.ts
+++ b/packages/player/src/bga.test.ts
@@ -15,746 +15,749 @@ interface RgbColor {
 
 type Pixel = RgbColor | undefined;
 describe('player bga', () => {
-
-test('player bga: reports loading progress details with target file names', async () => {
-  const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-progress-'));
-  try {
-    await writePng(join(baseDir, 'base.png'), 256, 256, () => ({ r: 255, g: 0, b: 0, a: 255 }));
-    await writePng(join(baseDir, 'stage.png'), 256, 256, () => ({ r: 0, g: 0, b: 255, a: 255 }));
-
-    const json = createEmptyJson('bms');
-    json.metadata.bpm = 120;
-    json.metadata.stageFile = 'stage.png';
-    json.resources.bmp['01'] = 'base.png';
-    json.events = [{ measure: 0, channel: '04', position: [0, 1], value: '01' }];
-
-    const progressDetails: string[] = [];
-    const progressRatios: number[] = [];
-    const renderer = await createBgaAnsiRenderer(json, {
-      baseDir,
-      width: 40,
-      height: 20,
-      onLoadProgress: (progress) => {
-        progressRatios.push(progress.ratio);
-        progressDetails.push(progress.detail);
-      },
-    });
-
-    expect(renderer).toBeDefined();
-    expect(progressDetails).toContain('base.png');
-    expect(progressDetails).toContain('stage.png');
-    expect(progressRatios.at(-1)).toBeCloseTo(1, 6);
-  } finally {
-    await rm(baseDir, { recursive: true, force: true });
-  }
-});
-
-
-test('player bga: composites layer with black treated as transparent', async () => {
-  const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-layer-'));
-  try {
-    await writePng(join(baseDir, 'base.png'), 256, 256, () => ({ r: 255, g: 0, b: 0, a: 255 }));
-    await writeBmp(join(baseDir, 'layer.bmp'), 256, 256, (x) =>
-      x < 128 ? { r: 0, g: 0, b: 0, a: 255 } : { r: 0, g: 255, b: 0, a: 255 },
-    );
-
-    const json = createEmptyJson('bms');
-    json.metadata.bpm = 120;
-    json.resources.bmp['01'] = 'base.png';
-    json.resources.bmp['02'] = 'layer.bmp';
-    json.events = [
-      { measure: 0, channel: '04', position: [0, 1], value: '01' },
-      { measure: 0, channel: '07', position: [0, 1], value: '02' },
-    ];
-
-    const renderer = await createBgaAnsiRenderer(json, {
-      baseDir,
-      width: 40,
-      height: 20,
-    });
-    expect(renderer).toBeDefined();
-
-    const lines = renderer?.getAnsiLines(0);
-    expect(lines).toBeDefined();
-    const pixels = parseAnsiPixels(lines ?? []);
-
-    expect(pixels[10]?.[5]).toEqual({ r: 255, g: 0, b: 0 });
-    expect(pixels[10]?.[30]).toEqual({ r: 0, g: 255, b: 0 });
-  } finally {
-    await rm(baseDir, { recursive: true, force: true });
-  }
-});
-
-test('player bga: composites 4-bit indexed bmp layer with black treated as transparent', async () => {
-  const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-layer-indexed-'));
-  try {
-    await writePng(join(baseDir, 'base.png'), 256, 256, () => ({ r: 255, g: 0, b: 0, a: 255 }));
-    await writeIndexed4BitBmp(join(baseDir, 'layer4.bmp'), 256, 256, (x) => (x < 128 ? 0 : 1));
-
-    const json = createEmptyJson('bms');
-    json.metadata.bpm = 120;
-    json.resources.bmp['01'] = 'base.png';
-    json.resources.bmp['02'] = 'layer4.bmp';
-    json.events = [
-      { measure: 0, channel: '04', position: [0, 1], value: '01' },
-      { measure: 0, channel: '07', position: [0, 1], value: '02' },
-    ];
-
-    const renderer = await createBgaAnsiRenderer(json, {
-      baseDir,
-      width: 40,
-      height: 20,
-    });
-    expect(renderer).toBeDefined();
-
-    const lines = renderer?.getAnsiLines(0);
-    expect(lines).toBeDefined();
-    const pixels = parseAnsiPixels(lines ?? []);
-
-    expect(pixels[10]?.[5]).toEqual({ r: 255, g: 0, b: 0 });
-    expect(pixels[10]?.[30]).toEqual({ r: 0, g: 255, b: 0 });
-  } finally {
-    await rm(baseDir, { recursive: true, force: true });
-  }
-});
-
-test('player bga: composites channel 0A above channel 07', async () => {
-  const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-layer2-'));
-  try {
-    await writePng(join(baseDir, 'base.png'), 256, 256, () => ({ r: 255, g: 0, b: 0, a: 255 }));
-    await writeBmp(join(baseDir, 'layer.bmp'), 256, 256, (x) =>
-      x < 128 ? { r: 0, g: 0, b: 0, a: 255 } : { r: 0, g: 255, b: 0, a: 255 },
-    );
-    await writePng(join(baseDir, 'layer2.png'), 256, 256, (x) =>
-      x < 128 ? { r: 0, g: 0, b: 255, a: 255 } : { r: 0, g: 0, b: 0, a: 0 },
-    );
-
-    const json = createEmptyJson('bms');
-    json.metadata.bpm = 120;
-    json.resources.bmp['01'] = 'base.png';
-    json.resources.bmp['02'] = 'layer.bmp';
-    json.resources.bmp['03'] = 'layer2.png';
-    json.events = [
-      { measure: 0, channel: '04', position: [0, 1], value: '01' },
-      { measure: 0, channel: '07', position: [0, 1], value: '02' },
-      { measure: 0, channel: '0A', position: [0, 1], value: '03' },
-    ];
-
-    const renderer = await createBgaAnsiRenderer(json, {
-      baseDir,
-      width: 40,
-      height: 20,
-    });
-    expect(renderer).toBeDefined();
-
-    const lines = renderer?.getAnsiLines(0);
-    expect(lines).toBeDefined();
-    const pixels = parseAnsiPixels(lines ?? []);
-
-    expect(pixels[10]?.[5]).toEqual({ r: 0, g: 0, b: 255 });
-    expect(pixels[10]?.[30]).toEqual({ r: 0, g: 255, b: 0 });
-  } finally {
-    await rm(baseDir, { recursive: true, force: true });
-  }
-});
-
-test('player bga: renders images smaller than 256x256 centered on X and top-aligned on Y', async () => {
-  const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-small-'));
-  try {
-    await writePng(join(baseDir, 'small.png'), 128, 128, () => ({ r: 255, g: 255, b: 0, a: 255 }));
-
-    const json = createEmptyJson('bms');
-    json.metadata.bpm = 120;
-    json.resources.bmp['01'] = 'small.png';
-    json.events = [{ measure: 0, channel: '04', position: [0, 1], value: '01' }];
-
-    const renderer = await createBgaAnsiRenderer(json, {
-      baseDir,
-      width: 40,
-      height: 20,
-    });
-    expect(renderer).toBeDefined();
-
-    const lines = renderer?.getAnsiLines(0);
-    expect(lines).toBeDefined();
-    const bounds = findOpaqueBounds(parseAnsiPixels(lines ?? []));
-    expect(bounds).toBeDefined();
-    expect(bounds?.minY).toBe(0);
-    expect(bounds?.maxY).toBeGreaterThanOrEqual(9);
-    expect(bounds?.maxY).toBeLessThanOrEqual(10);
-    expect(bounds?.minX).toBeGreaterThanOrEqual(9);
-    expect(bounds?.minX).toBeLessThanOrEqual(10);
-    expect(bounds?.maxX).toBeGreaterThanOrEqual(29);
-    expect(bounds?.maxX).toBeLessThanOrEqual(30);
-  } finally {
-    await rm(baseDir, { recursive: true, force: true });
-  }
-});
-
-test('player bga: scales down sources larger than 256x256 without clipping bottom area', async () => {
-  const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-large-square-'));
-  try {
-    await writePng(join(baseDir, 'large-square.png'), 512, 512, (_x, y) =>
-      y < 256 ? { r: 255, g: 0, b: 0, a: 255 } : { r: 0, g: 0, b: 255, a: 255 },
-    );
-
-    const json = createEmptyJson('bms');
-    json.metadata.bpm = 120;
-    json.resources.bmp['01'] = 'large-square.png';
-    json.events = [{ measure: 0, channel: '04', position: [0, 1], value: '01' }];
-
-    const renderer = await createBgaAnsiRenderer(json, {
-      baseDir,
-      width: 40,
-      height: 20,
-    });
-    expect(renderer).toBeDefined();
-
-    const lines = renderer?.getAnsiLines(0);
-    expect(lines).toBeDefined();
-    const pixels = parseAnsiPixels(lines ?? []);
-
-    expect(pixels[4]?.[20]).toEqual({ r: 255, g: 0, b: 0 });
-    expect(pixels[16]?.[20]).toEqual({ r: 0, g: 0, b: 255 });
-  } finally {
-    await rm(baseDir, { recursive: true, force: true });
-  }
-});
-
-test('player bga: renders undefined base keys as black instead of STAGEFILE', async () => {
-  const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-undefined-base-'));
-  try {
-    await writePng(join(baseDir, 'stage.png'), 256, 256, () => ({ r: 0, g: 0, b: 255, a: 255 }));
-
-    const json = createEmptyJson('bms');
-    json.metadata.bpm = 120;
-    json.metadata.stageFile = 'stage.png';
-    json.events = [{ measure: 0, channel: '04', position: [0, 1], value: '02' }];
-
-    const renderer = await createBgaAnsiRenderer(json, {
-      baseDir,
-      width: 40,
-      height: 20,
-    });
-    expect(renderer).toBeDefined();
-
-    const lines = renderer?.getAnsiLines(0);
-    expect(lines).toBeDefined();
-    const pixels = parseAnsiPixels(lines ?? []);
-    expect(pixels[10]?.[20]).toEqual({ r: 0, g: 0, b: 0 });
-    expect(countColor(pixels, { r: 0, g: 0, b: 255 })).toBe(0);
-  } finally {
-    await rm(baseDir, { recursive: true, force: true });
-  }
-});
-
-test('player bga: uses black viewport background before first BGA cue', async () => {
-  const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-black-viewport-'));
-  try {
-    await writePng(join(baseDir, 'base.png'), 256, 256, () => ({ r: 255, g: 0, b: 0, a: 255 }));
-
-    const json = createEmptyJson('bms');
-    json.metadata.bpm = 120;
-    json.resources.bmp['01'] = 'base.png';
-    json.events = [{ measure: 1, channel: '04', position: [0, 1], value: '01' }];
-
-    const renderer = await createBgaAnsiRenderer(json, {
-      baseDir,
-      width: 40,
-      height: 20,
-    });
-    expect(renderer).toBeDefined();
-
-    const beforeCue = parseAnsiPixels(renderer?.getAnsiLines(0) ?? []);
-    expect(beforeCue[10]?.[20]).toEqual({ r: 0, g: 0, b: 0 });
-
-    const afterCue = parseAnsiPixels(renderer?.getAnsiLines(2.1) ?? []);
-    expect(afterCue[10]?.[20]).toEqual({ r: 255, g: 0, b: 0 });
-  } finally {
-    await rm(baseDir, { recursive: true, force: true });
-  }
-});
-
-test('player bga: switches to channel 06 frame when POOR is triggered', async () => {
-  const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-poor-'));
-  try {
-    await writePng(join(baseDir, 'base.png'), 256, 256, () => ({ r: 255, g: 0, b: 0, a: 255 }));
-    await writePng(join(baseDir, 'poor.png'), 256, 256, () => ({ r: 0, g: 255, b: 0, a: 255 }));
-
-    const json = createEmptyJson('bms');
-    json.metadata.bpm = 120;
-    json.resources.bmp['01'] = 'base.png';
-    json.resources.bmp['02'] = 'poor.png';
-    json.events = [
-      { measure: 0, channel: '04', position: [0, 1], value: '01' },
-      { measure: 0, channel: '06', position: [0, 1], value: '02' },
-    ];
-
-    const renderer = await createBgaAnsiRenderer(json, {
-      baseDir,
-      width: 40,
-      height: 20,
-    });
-    expect(renderer).toBeDefined();
-
-    const beforePoor = parseAnsiPixels(renderer?.getAnsiLines(0) ?? []);
-    expect(beforePoor[10]?.[20]).toEqual({ r: 255, g: 0, b: 0 });
-
-    renderer?.triggerPoor(0);
-    const duringPoor = parseAnsiPixels(renderer?.getAnsiLines(0) ?? []);
-    expect(duringPoor[10]?.[20]).toEqual({ r: 0, g: 255, b: 0 });
-
-    const afterPoor = parseAnsiPixels(renderer?.getAnsiLines(2.1) ?? []);
-    expect(afterPoor[10]?.[20]).toEqual({ r: 255, g: 0, b: 0 });
-  } finally {
-    await rm(baseDir, { recursive: true, force: true });
-  }
-});
-
-test('player bga: clears POOR overlay and resumes normal BGA', async () => {
-  const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-poor-clear-'));
-  try {
-    await writePng(join(baseDir, 'base.png'), 256, 256, () => ({ r: 255, g: 0, b: 0, a: 255 }));
-    await writePng(join(baseDir, 'poor.png'), 256, 256, () => ({ r: 0, g: 255, b: 0, a: 255 }));
-
-    const json = createEmptyJson('bms');
-    json.metadata.bpm = 120;
-    json.resources.bmp['01'] = 'base.png';
-    json.resources.bmp['02'] = 'poor.png';
-    json.events = [
-      { measure: 0, channel: '04', position: [0, 1], value: '01' },
-      { measure: 0, channel: '06', position: [0, 1], value: '02' },
-    ];
-
-    const renderer = await createBgaAnsiRenderer(json, {
-      baseDir,
-      width: 40,
-      height: 20,
-    });
-    expect(renderer).toBeDefined();
-
-    renderer?.triggerPoor(0);
-    const duringPoor = parseAnsiPixels(renderer?.getAnsiLines(0.3) ?? []);
-    expect(duringPoor[10]?.[20]).toEqual({ r: 0, g: 255, b: 0 });
-
-    renderer?.clearPoor();
-    const resumed = parseAnsiPixels(renderer?.getAnsiLines(0.3) ?? []);
-    expect(resumed[10]?.[20]).toEqual({ r: 255, g: 0, b: 0 });
-  } finally {
-    await rm(baseDir, { recursive: true, force: true });
-  }
-});
-
-test('player bga: prioritizes POOR over 04/07/0A while active', async () => {
-  const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-poor-priority-'));
-  try {
-    await writePng(join(baseDir, 'base.png'), 256, 256, () => ({ r: 255, g: 0, b: 0, a: 255 }));
-    await writePng(join(baseDir, 'layer.png'), 256, 256, () => ({ r: 0, g: 255, b: 0, a: 255 }));
-    await writePng(join(baseDir, 'layer2.png'), 256, 256, () => ({ r: 0, g: 0, b: 255, a: 255 }));
-    await writePng(join(baseDir, 'poor.png'), 256, 256, () => ({ r: 255, g: 255, b: 0, a: 255 }));
-
-    const json = createEmptyJson('bms');
-    json.metadata.bpm = 120;
-    json.resources.bmp['01'] = 'base.png';
-    json.resources.bmp['02'] = 'layer.png';
-    json.resources.bmp['03'] = 'layer2.png';
-    json.resources.bmp['04'] = 'poor.png';
-    json.events = [
-      { measure: 0, channel: '04', position: [0, 1], value: '01' },
-      { measure: 0, channel: '07', position: [0, 1], value: '02' },
-      { measure: 0, channel: '0A', position: [0, 1], value: '03' },
-      { measure: 0, channel: '06', position: [0, 1], value: '04' },
-    ];
-
-    const renderer = await createBgaAnsiRenderer(json, {
-      baseDir,
-      width: 40,
-      height: 20,
-    });
-    expect(renderer).toBeDefined();
-
-    const beforePoor = parseAnsiPixels(renderer?.getAnsiLines(0) ?? []);
-    expect(beforePoor[10]?.[20]).toEqual({ r: 0, g: 0, b: 255 });
-
-    renderer?.triggerPoor(0);
-    const duringPoor = parseAnsiPixels(renderer?.getAnsiLines(0.5) ?? []);
-    expect(duringPoor[10]?.[20]).toEqual({ r: 255, g: 255, b: 0 });
-
-    const afterPoor = parseAnsiPixels(renderer?.getAnsiLines(2.1) ?? []);
-    expect(afterPoor[10]?.[20]).toEqual({ r: 0, g: 0, b: 255 });
-  } finally {
-    await rm(baseDir, { recursive: true, force: true });
-  }
-});
-
-test('player bga: uses #BMP00 as default POOR image before first channel 06 cue when #POORBGA is unspecified', async () => {
-  const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-poor-bmp00-'));
-  try {
-    await writePng(join(baseDir, 'base.png'), 256, 256, () => ({ r: 255, g: 0, b: 0, a: 255 }));
-    await writePng(join(baseDir, 'fallback.png'), 256, 256, () => ({ r: 0, g: 0, b: 255, a: 255 }));
-    await writePng(join(baseDir, 'poor.png'), 256, 256, () => ({ r: 0, g: 255, b: 0, a: 255 }));
-
-    const json = createEmptyJson('bms');
-    json.metadata.bpm = 120;
-    json.resources.bmp['00'] = 'fallback.png';
-    json.resources.bmp['01'] = 'base.png';
-    json.resources.bmp['02'] = 'poor.png';
-    json.events = [
-      { measure: 0, channel: '04', position: [0, 1], value: '01' },
-      { measure: 1, channel: '06', position: [0, 1], value: '02' },
-    ];
-
-    const renderer = await createBgaAnsiRenderer(json, {
-      baseDir,
-      width: 40,
-      height: 20,
-    });
-    expect(renderer).toBeDefined();
-
-    renderer?.triggerPoor(0);
-    const beforeFirstPoorCue = parseAnsiPixels(renderer?.getAnsiLines(0) ?? []);
-    expect(beforeFirstPoorCue[10]?.[20]).toEqual({ r: 0, g: 0, b: 255 });
-
-    renderer?.triggerPoor(2.1);
-    const afterFirstPoorCue = parseAnsiPixels(renderer?.getAnsiLines(2.1) ?? []);
-    expect(afterFirstPoorCue[10]?.[20]).toEqual({ r: 0, g: 255, b: 0 });
-  } finally {
-    await rm(baseDir, { recursive: true, force: true });
-  }
-});
-
-test('player bga: does not apply #BMP00 POOR fallback when #POORBGA is specified', async () => {
-  const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-poor-no-fallback-'));
-  try {
-    await writePng(join(baseDir, 'base.png'), 256, 256, () => ({ r: 255, g: 0, b: 0, a: 255 }));
-    await writePng(join(baseDir, 'fallback.png'), 256, 256, () => ({ r: 0, g: 0, b: 255, a: 255 }));
-    await writePng(join(baseDir, 'poor.png'), 256, 256, () => ({ r: 0, g: 255, b: 0, a: 255 }));
-
-    const json = createEmptyJson('bms');
-    json.metadata.bpm = 120;
-    json.bms.poorBga = '01';
-    json.resources.bmp['00'] = 'fallback.png';
-    json.resources.bmp['01'] = 'base.png';
-    json.resources.bmp['02'] = 'poor.png';
-    json.events = [
-      { measure: 0, channel: '04', position: [0, 1], value: '01' },
-      { measure: 1, channel: '06', position: [0, 1], value: '02' },
-    ];
-
-    const renderer = await createBgaAnsiRenderer(json, {
-      baseDir,
-      width: 40,
-      height: 20,
-    });
-    expect(renderer).toBeDefined();
-
-    renderer?.triggerPoor(0);
-    const beforeFirstPoorCue = parseAnsiPixels(renderer?.getAnsiLines(0) ?? []);
-    expect(beforeFirstPoorCue[10]?.[20]).toEqual({ r: 255, g: 0, b: 0 });
-  } finally {
-    await rm(baseDir, { recursive: true, force: true });
-  }
-});
-
-test('player bga: updates output size when display size changes', async () => {
-  const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-resize-'));
-  try {
-    await writePng(join(baseDir, 'base.png'), 256, 256, () => ({ r: 255, g: 0, b: 0, a: 255 }));
-
-    const json = createEmptyJson('bms');
-    json.metadata.bpm = 120;
-    json.resources.bmp['01'] = 'base.png';
-    json.events = [{ measure: 0, channel: '04', position: [0, 1], value: '01' }];
-
-    const renderer = await createBgaAnsiRenderer(json, {
-      baseDir,
-      width: 40,
-      height: 20,
-    });
-    expect(renderer).toBeDefined();
-
-    const before = parseAnsiPixels(renderer?.getAnsiLines(0) ?? []);
-    expect(before.length).toBe(20);
-    expect(before[0]?.length).toBe(40);
-
-    renderer?.setDisplaySize(60, 24);
-    const after = parseAnsiPixels(renderer?.getAnsiLines(0) ?? []);
-    expect(after.length).toBe(24);
-    expect(after[0]?.length).toBe(60);
-    expect(after[12]?.[30]).toEqual({ r: 255, g: 0, b: 0 });
-  } finally {
-    await rm(baseDir, { recursive: true, force: true });
-  }
-});
-
-test('player bga: does not apply terminal aspect correction twice for video frame sources', () => {
-  const frame = createOpaqueAnsiFrame(40, 20, (_x, y) => (y < 10 ? { r: 255, g: 0, b: 0 } : { r: 0, g: 0, b: 255 }));
-  const renderer = new BgaAnsiRenderer({
-    baseTimeline: [{ seconds: 0, key: '01' }],
-    poorTimeline: [],
-    layerTimeline: [],
-    layer2Timeline: [],
-    baseSourceFramesByKey: new Map([
-      [
-        '01',
-        {
-          kind: 'video',
-          frames: [{ seconds: 0, frame }],
+  test('player bga: reports loading progress details with target file names', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-progress-'));
+    try {
+      await writePng(join(baseDir, 'base.png'), 256, 256, () => ({ r: 255, g: 0, b: 0, a: 255 }));
+      await writePng(join(baseDir, 'stage.png'), 256, 256, () => ({ r: 0, g: 0, b: 255, a: 255 }));
+
+      const json = createEmptyJson('bms');
+      json.metadata.bpm = 120;
+      json.metadata.stageFile = 'stage.png';
+      json.resources.bmp['01'] = 'base.png';
+      json.events = [{ measure: 0, channel: '04', position: [0, 1], value: '01' }];
+
+      const progressDetails: string[] = [];
+      const progressRatios: number[] = [];
+      const renderer = await createBgaAnsiRenderer(json, {
+        baseDir,
+        width: 40,
+        height: 20,
+        onLoadProgress: (progress) => {
+          progressRatios.push(progress.ratio);
+          progressDetails.push(progress.detail);
         },
-      ],
-    ]) as any,
-    poorSourceFramesByKey: new Map(),
-    layerSourceFramesByKey: new Map(),
-    layer2SourceFramesByKey: new Map(),
-    stageFileSourceFrame: undefined,
-    missingBaseSourceFrame: createOpaqueAnsiFrame(256, 256, () => ({ r: 0, g: 0, b: 0 })),
-    missingPoorSourceFrame: createOpaqueAnsiFrame(256, 256, () => ({ r: 0, g: 0, b: 0 })),
-    missingLayerSourceFrame: createTransparentAnsiFrame(256, 256),
-    poorFallbackKey: undefined,
-    poorFallbackUntilSeconds: Number.POSITIVE_INFINITY,
-    width: 40,
-    height: 20,
+      });
+
+      expect(renderer).toBeDefined();
+      expect(progressDetails).toContain('base.png');
+      expect(progressDetails).toContain('stage.png');
+      expect(progressRatios.at(-1)).toBeCloseTo(1, 6);
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
   });
 
-  const pixels = parseAnsiPixels(renderer.getAnsiLines(0) ?? []);
-  expect(pixels[2]?.[20]).toEqual({ r: 255, g: 0, b: 0 });
-  expect(pixels[18]?.[20]).toEqual({ r: 0, g: 0, b: 255 });
-});
+  test('player bga: composites layer with black treated as transparent', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-layer-'));
+    try {
+      await writePng(join(baseDir, 'base.png'), 256, 256, () => ({ r: 255, g: 0, b: 0, a: 255 }));
+      await writeBmp(join(baseDir, 'layer.bmp'), 256, 256, (x) =>
+        x < 128 ? { r: 0, g: 0, b: 0, a: 255 } : { r: 0, g: 255, b: 0, a: 255 },
+      );
 
-async function writePng(
-  path: string,
-  width: number,
-  height: number,
-  pixel: (x: number, y: number) => { r: number; g: number; b: number; a: number },
-): Promise<void> {
-  const data = new Uint8Array(width * height * 4);
-  for (let y = 0; y < height; y += 1) {
-    for (let x = 0; x < width; x += 1) {
-      const value = pixel(x, y);
-      const offset = (y * width + x) * 4;
-      data[offset] = value.r;
-      data[offset + 1] = value.g;
-      data[offset + 2] = value.b;
-      data[offset + 3] = value.a;
+      const json = createEmptyJson('bms');
+      json.metadata.bpm = 120;
+      json.resources.bmp['01'] = 'base.png';
+      json.resources.bmp['02'] = 'layer.bmp';
+      json.events = [
+        { measure: 0, channel: '04', position: [0, 1], value: '01' },
+        { measure: 0, channel: '07', position: [0, 1], value: '02' },
+      ];
+
+      const renderer = await createBgaAnsiRenderer(json, {
+        baseDir,
+        width: 40,
+        height: 20,
+      });
+      expect(renderer).toBeDefined();
+
+      const lines = renderer?.getAnsiLines(0);
+      expect(lines).toBeDefined();
+      const pixels = parseAnsiPixels(lines ?? []);
+
+      expect(pixels[10]?.[5]).toEqual({ r: 255, g: 0, b: 0 });
+      expect(pixels[10]?.[30]).toEqual({ r: 0, g: 255, b: 0 });
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
     }
+  });
+
+  test('player bga: composites 4-bit indexed bmp layer with black treated as transparent', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-layer-indexed-'));
+    try {
+      await writePng(join(baseDir, 'base.png'), 256, 256, () => ({ r: 255, g: 0, b: 0, a: 255 }));
+      await writeIndexed4BitBmp(join(baseDir, 'layer4.bmp'), 256, 256, (x) => (x < 128 ? 0 : 1));
+
+      const json = createEmptyJson('bms');
+      json.metadata.bpm = 120;
+      json.resources.bmp['01'] = 'base.png';
+      json.resources.bmp['02'] = 'layer4.bmp';
+      json.events = [
+        { measure: 0, channel: '04', position: [0, 1], value: '01' },
+        { measure: 0, channel: '07', position: [0, 1], value: '02' },
+      ];
+
+      const renderer = await createBgaAnsiRenderer(json, {
+        baseDir,
+        width: 40,
+        height: 20,
+      });
+      expect(renderer).toBeDefined();
+
+      const lines = renderer?.getAnsiLines(0);
+      expect(lines).toBeDefined();
+      const pixels = parseAnsiPixels(lines ?? []);
+
+      expect(pixels[10]?.[5]).toEqual({ r: 255, g: 0, b: 0 });
+      expect(pixels[10]?.[30]).toEqual({ r: 0, g: 255, b: 0 });
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  test('player bga: composites channel 0A above channel 07', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-layer2-'));
+    try {
+      await writePng(join(baseDir, 'base.png'), 256, 256, () => ({ r: 255, g: 0, b: 0, a: 255 }));
+      await writeBmp(join(baseDir, 'layer.bmp'), 256, 256, (x) =>
+        x < 128 ? { r: 0, g: 0, b: 0, a: 255 } : { r: 0, g: 255, b: 0, a: 255 },
+      );
+      await writePng(join(baseDir, 'layer2.png'), 256, 256, (x) =>
+        x < 128 ? { r: 0, g: 0, b: 255, a: 255 } : { r: 0, g: 0, b: 0, a: 0 },
+      );
+
+      const json = createEmptyJson('bms');
+      json.metadata.bpm = 120;
+      json.resources.bmp['01'] = 'base.png';
+      json.resources.bmp['02'] = 'layer.bmp';
+      json.resources.bmp['03'] = 'layer2.png';
+      json.events = [
+        { measure: 0, channel: '04', position: [0, 1], value: '01' },
+        { measure: 0, channel: '07', position: [0, 1], value: '02' },
+        { measure: 0, channel: '0A', position: [0, 1], value: '03' },
+      ];
+
+      const renderer = await createBgaAnsiRenderer(json, {
+        baseDir,
+        width: 40,
+        height: 20,
+      });
+      expect(renderer).toBeDefined();
+
+      const lines = renderer?.getAnsiLines(0);
+      expect(lines).toBeDefined();
+      const pixels = parseAnsiPixels(lines ?? []);
+
+      expect(pixels[10]?.[5]).toEqual({ r: 0, g: 0, b: 255 });
+      expect(pixels[10]?.[30]).toEqual({ r: 0, g: 255, b: 0 });
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  test('player bga: renders images smaller than 256x256 centered on X and top-aligned on Y', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-small-'));
+    try {
+      await writePng(join(baseDir, 'small.png'), 128, 128, () => ({ r: 255, g: 255, b: 0, a: 255 }));
+
+      const json = createEmptyJson('bms');
+      json.metadata.bpm = 120;
+      json.resources.bmp['01'] = 'small.png';
+      json.events = [{ measure: 0, channel: '04', position: [0, 1], value: '01' }];
+
+      const renderer = await createBgaAnsiRenderer(json, {
+        baseDir,
+        width: 40,
+        height: 20,
+      });
+      expect(renderer).toBeDefined();
+
+      const lines = renderer?.getAnsiLines(0);
+      expect(lines).toBeDefined();
+      const bounds = findOpaqueBounds(parseAnsiPixels(lines ?? []));
+      expect(bounds).toBeDefined();
+      expect(bounds?.minY).toBe(0);
+      expect(bounds?.maxY).toBeGreaterThanOrEqual(9);
+      expect(bounds?.maxY).toBeLessThanOrEqual(10);
+      expect(bounds?.minX).toBeGreaterThanOrEqual(9);
+      expect(bounds?.minX).toBeLessThanOrEqual(10);
+      expect(bounds?.maxX).toBeGreaterThanOrEqual(29);
+      expect(bounds?.maxX).toBeLessThanOrEqual(30);
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  test('player bga: scales down sources larger than 256x256 without clipping bottom area', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-large-square-'));
+    try {
+      await writePng(join(baseDir, 'large-square.png'), 512, 512, (_x, y) =>
+        y < 256 ? { r: 255, g: 0, b: 0, a: 255 } : { r: 0, g: 0, b: 255, a: 255 },
+      );
+
+      const json = createEmptyJson('bms');
+      json.metadata.bpm = 120;
+      json.resources.bmp['01'] = 'large-square.png';
+      json.events = [{ measure: 0, channel: '04', position: [0, 1], value: '01' }];
+
+      const renderer = await createBgaAnsiRenderer(json, {
+        baseDir,
+        width: 40,
+        height: 20,
+      });
+      expect(renderer).toBeDefined();
+
+      const lines = renderer?.getAnsiLines(0);
+      expect(lines).toBeDefined();
+      const pixels = parseAnsiPixels(lines ?? []);
+
+      expect(pixels[4]?.[20]).toEqual({ r: 255, g: 0, b: 0 });
+      expect(pixels[16]?.[20]).toEqual({ r: 0, g: 0, b: 255 });
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  test('player bga: renders undefined base keys as black instead of STAGEFILE', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-undefined-base-'));
+    try {
+      await writePng(join(baseDir, 'stage.png'), 256, 256, () => ({ r: 0, g: 0, b: 255, a: 255 }));
+
+      const json = createEmptyJson('bms');
+      json.metadata.bpm = 120;
+      json.metadata.stageFile = 'stage.png';
+      json.events = [{ measure: 0, channel: '04', position: [0, 1], value: '02' }];
+
+      const renderer = await createBgaAnsiRenderer(json, {
+        baseDir,
+        width: 40,
+        height: 20,
+      });
+      expect(renderer).toBeDefined();
+
+      const lines = renderer?.getAnsiLines(0);
+      expect(lines).toBeDefined();
+      const pixels = parseAnsiPixels(lines ?? []);
+      expect(pixels[10]?.[20]).toEqual({ r: 0, g: 0, b: 0 });
+      expect(countColor(pixels, { r: 0, g: 0, b: 255 })).toBe(0);
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  test('player bga: uses black viewport background before first BGA cue', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-black-viewport-'));
+    try {
+      await writePng(join(baseDir, 'base.png'), 256, 256, () => ({ r: 255, g: 0, b: 0, a: 255 }));
+
+      const json = createEmptyJson('bms');
+      json.metadata.bpm = 120;
+      json.resources.bmp['01'] = 'base.png';
+      json.events = [{ measure: 1, channel: '04', position: [0, 1], value: '01' }];
+
+      const renderer = await createBgaAnsiRenderer(json, {
+        baseDir,
+        width: 40,
+        height: 20,
+      });
+      expect(renderer).toBeDefined();
+
+      const beforeCue = parseAnsiPixels(renderer?.getAnsiLines(0) ?? []);
+      expect(beforeCue[10]?.[20]).toEqual({ r: 0, g: 0, b: 0 });
+
+      const afterCue = parseAnsiPixels(renderer?.getAnsiLines(2.1) ?? []);
+      expect(afterCue[10]?.[20]).toEqual({ r: 255, g: 0, b: 0 });
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  test('player bga: switches to channel 06 frame when POOR is triggered', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-poor-'));
+    try {
+      await writePng(join(baseDir, 'base.png'), 256, 256, () => ({ r: 255, g: 0, b: 0, a: 255 }));
+      await writePng(join(baseDir, 'poor.png'), 256, 256, () => ({ r: 0, g: 255, b: 0, a: 255 }));
+
+      const json = createEmptyJson('bms');
+      json.metadata.bpm = 120;
+      json.resources.bmp['01'] = 'base.png';
+      json.resources.bmp['02'] = 'poor.png';
+      json.events = [
+        { measure: 0, channel: '04', position: [0, 1], value: '01' },
+        { measure: 0, channel: '06', position: [0, 1], value: '02' },
+      ];
+
+      const renderer = await createBgaAnsiRenderer(json, {
+        baseDir,
+        width: 40,
+        height: 20,
+      });
+      expect(renderer).toBeDefined();
+
+      const beforePoor = parseAnsiPixels(renderer?.getAnsiLines(0) ?? []);
+      expect(beforePoor[10]?.[20]).toEqual({ r: 255, g: 0, b: 0 });
+
+      renderer?.triggerPoor(0);
+      const duringPoor = parseAnsiPixels(renderer?.getAnsiLines(0) ?? []);
+      expect(duringPoor[10]?.[20]).toEqual({ r: 0, g: 255, b: 0 });
+
+      const afterPoor = parseAnsiPixels(renderer?.getAnsiLines(2.1) ?? []);
+      expect(afterPoor[10]?.[20]).toEqual({ r: 255, g: 0, b: 0 });
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  test('player bga: clears POOR overlay and resumes normal BGA', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-poor-clear-'));
+    try {
+      await writePng(join(baseDir, 'base.png'), 256, 256, () => ({ r: 255, g: 0, b: 0, a: 255 }));
+      await writePng(join(baseDir, 'poor.png'), 256, 256, () => ({ r: 0, g: 255, b: 0, a: 255 }));
+
+      const json = createEmptyJson('bms');
+      json.metadata.bpm = 120;
+      json.resources.bmp['01'] = 'base.png';
+      json.resources.bmp['02'] = 'poor.png';
+      json.events = [
+        { measure: 0, channel: '04', position: [0, 1], value: '01' },
+        { measure: 0, channel: '06', position: [0, 1], value: '02' },
+      ];
+
+      const renderer = await createBgaAnsiRenderer(json, {
+        baseDir,
+        width: 40,
+        height: 20,
+      });
+      expect(renderer).toBeDefined();
+
+      renderer?.triggerPoor(0);
+      const duringPoor = parseAnsiPixels(renderer?.getAnsiLines(0.3) ?? []);
+      expect(duringPoor[10]?.[20]).toEqual({ r: 0, g: 255, b: 0 });
+
+      renderer?.clearPoor();
+      const resumed = parseAnsiPixels(renderer?.getAnsiLines(0.3) ?? []);
+      expect(resumed[10]?.[20]).toEqual({ r: 255, g: 0, b: 0 });
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  test('player bga: prioritizes POOR over 04/07/0A while active', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-poor-priority-'));
+    try {
+      await writePng(join(baseDir, 'base.png'), 256, 256, () => ({ r: 255, g: 0, b: 0, a: 255 }));
+      await writePng(join(baseDir, 'layer.png'), 256, 256, () => ({ r: 0, g: 255, b: 0, a: 255 }));
+      await writePng(join(baseDir, 'layer2.png'), 256, 256, () => ({ r: 0, g: 0, b: 255, a: 255 }));
+      await writePng(join(baseDir, 'poor.png'), 256, 256, () => ({ r: 255, g: 255, b: 0, a: 255 }));
+
+      const json = createEmptyJson('bms');
+      json.metadata.bpm = 120;
+      json.resources.bmp['01'] = 'base.png';
+      json.resources.bmp['02'] = 'layer.png';
+      json.resources.bmp['03'] = 'layer2.png';
+      json.resources.bmp['04'] = 'poor.png';
+      json.events = [
+        { measure: 0, channel: '04', position: [0, 1], value: '01' },
+        { measure: 0, channel: '07', position: [0, 1], value: '02' },
+        { measure: 0, channel: '0A', position: [0, 1], value: '03' },
+        { measure: 0, channel: '06', position: [0, 1], value: '04' },
+      ];
+
+      const renderer = await createBgaAnsiRenderer(json, {
+        baseDir,
+        width: 40,
+        height: 20,
+      });
+      expect(renderer).toBeDefined();
+
+      const beforePoor = parseAnsiPixels(renderer?.getAnsiLines(0) ?? []);
+      expect(beforePoor[10]?.[20]).toEqual({ r: 0, g: 0, b: 255 });
+
+      renderer?.triggerPoor(0);
+      const duringPoor = parseAnsiPixels(renderer?.getAnsiLines(0.5) ?? []);
+      expect(duringPoor[10]?.[20]).toEqual({ r: 255, g: 255, b: 0 });
+
+      const afterPoor = parseAnsiPixels(renderer?.getAnsiLines(2.1) ?? []);
+      expect(afterPoor[10]?.[20]).toEqual({ r: 0, g: 0, b: 255 });
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  test('player bga: uses #BMP00 as default POOR image before first channel 06 cue when #POORBGA is unspecified', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-poor-bmp00-'));
+    try {
+      await writePng(join(baseDir, 'base.png'), 256, 256, () => ({ r: 255, g: 0, b: 0, a: 255 }));
+      await writePng(join(baseDir, 'fallback.png'), 256, 256, () => ({ r: 0, g: 0, b: 255, a: 255 }));
+      await writePng(join(baseDir, 'poor.png'), 256, 256, () => ({ r: 0, g: 255, b: 0, a: 255 }));
+
+      const json = createEmptyJson('bms');
+      json.metadata.bpm = 120;
+      json.resources.bmp['00'] = 'fallback.png';
+      json.resources.bmp['01'] = 'base.png';
+      json.resources.bmp['02'] = 'poor.png';
+      json.events = [
+        { measure: 0, channel: '04', position: [0, 1], value: '01' },
+        { measure: 1, channel: '06', position: [0, 1], value: '02' },
+      ];
+
+      const renderer = await createBgaAnsiRenderer(json, {
+        baseDir,
+        width: 40,
+        height: 20,
+      });
+      expect(renderer).toBeDefined();
+
+      renderer?.triggerPoor(0);
+      const beforeFirstPoorCue = parseAnsiPixels(renderer?.getAnsiLines(0) ?? []);
+      expect(beforeFirstPoorCue[10]?.[20]).toEqual({ r: 0, g: 0, b: 255 });
+
+      renderer?.triggerPoor(2.1);
+      const afterFirstPoorCue = parseAnsiPixels(renderer?.getAnsiLines(2.1) ?? []);
+      expect(afterFirstPoorCue[10]?.[20]).toEqual({ r: 0, g: 255, b: 0 });
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  test('player bga: does not apply #BMP00 POOR fallback when #POORBGA is specified', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-poor-no-fallback-'));
+    try {
+      await writePng(join(baseDir, 'base.png'), 256, 256, () => ({ r: 255, g: 0, b: 0, a: 255 }));
+      await writePng(join(baseDir, 'fallback.png'), 256, 256, () => ({ r: 0, g: 0, b: 255, a: 255 }));
+      await writePng(join(baseDir, 'poor.png'), 256, 256, () => ({ r: 0, g: 255, b: 0, a: 255 }));
+
+      const json = createEmptyJson('bms');
+      json.metadata.bpm = 120;
+      json.bms.poorBga = '01';
+      json.resources.bmp['00'] = 'fallback.png';
+      json.resources.bmp['01'] = 'base.png';
+      json.resources.bmp['02'] = 'poor.png';
+      json.events = [
+        { measure: 0, channel: '04', position: [0, 1], value: '01' },
+        { measure: 1, channel: '06', position: [0, 1], value: '02' },
+      ];
+
+      const renderer = await createBgaAnsiRenderer(json, {
+        baseDir,
+        width: 40,
+        height: 20,
+      });
+      expect(renderer).toBeDefined();
+
+      renderer?.triggerPoor(0);
+      const beforeFirstPoorCue = parseAnsiPixels(renderer?.getAnsiLines(0) ?? []);
+      expect(beforeFirstPoorCue[10]?.[20]).toEqual({ r: 255, g: 0, b: 0 });
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  test('player bga: updates output size when display size changes', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-resize-'));
+    try {
+      await writePng(join(baseDir, 'base.png'), 256, 256, () => ({ r: 255, g: 0, b: 0, a: 255 }));
+
+      const json = createEmptyJson('bms');
+      json.metadata.bpm = 120;
+      json.resources.bmp['01'] = 'base.png';
+      json.events = [{ measure: 0, channel: '04', position: [0, 1], value: '01' }];
+
+      const renderer = await createBgaAnsiRenderer(json, {
+        baseDir,
+        width: 40,
+        height: 20,
+      });
+      expect(renderer).toBeDefined();
+
+      const before = parseAnsiPixels(renderer?.getAnsiLines(0) ?? []);
+      expect(before.length).toBe(20);
+      expect(before[0]?.length).toBe(40);
+
+      renderer?.setDisplaySize(60, 24);
+      const after = parseAnsiPixels(renderer?.getAnsiLines(0) ?? []);
+      expect(after.length).toBe(24);
+      expect(after[0]?.length).toBe(60);
+      expect(after[12]?.[30]).toEqual({ r: 255, g: 0, b: 0 });
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  test('player bga: fits raw video frames with terminal aspect correction once', () => {
+    const frame = createOpaqueAnsiFrame(40, 20, (_x, y) => (y < 10 ? { r: 255, g: 0, b: 0 } : { r: 0, g: 0, b: 255 }));
+    const renderer = new BgaAnsiRenderer({
+      baseTimeline: [{ seconds: 0, key: '01' }],
+      poorTimeline: [],
+      layerTimeline: [],
+      layer2Timeline: [],
+      baseSourceFramesByKey: new Map([
+        [
+          '01',
+          {
+            kind: 'video',
+            frames: [{ seconds: 0, frame }],
+          },
+        ],
+      ]) as any,
+      poorSourceFramesByKey: new Map(),
+      layerSourceFramesByKey: new Map(),
+      layer2SourceFramesByKey: new Map(),
+      stageFileSourceFrame: undefined,
+      missingBaseSourceFrame: createOpaqueAnsiFrame(256, 256, () => ({ r: 0, g: 0, b: 0 })),
+      missingPoorSourceFrame: createOpaqueAnsiFrame(256, 256, () => ({ r: 0, g: 0, b: 0 })),
+      missingLayerSourceFrame: createTransparentAnsiFrame(256, 256),
+      poorFallbackKey: undefined,
+      poorFallbackUntilSeconds: Number.POSITIVE_INFINITY,
+      width: 40,
+      height: 20,
+    });
+
+    const pixels = parseAnsiPixels(renderer.getAnsiLines(0) ?? []);
+    expect(pixels[7]?.[20]).toEqual({ r: 255, g: 0, b: 0 });
+    expect(pixels[12]?.[20]).toEqual({ r: 0, g: 0, b: 255 });
+    expect(pixels[4]?.[20]).toBeUndefined();
+    expect(pixels[15]?.[20]).toBeUndefined();
+  });
+
+  async function writePng(
+    path: string,
+    width: number,
+    height: number,
+    pixel: (x: number, y: number) => { r: number; g: number; b: number; a: number },
+  ): Promise<void> {
+    const data = new Uint8Array(width * height * 4);
+    for (let y = 0; y < height; y += 1) {
+      for (let x = 0; x < width; x += 1) {
+        const value = pixel(x, y);
+        const offset = (y * width + x) * 4;
+        data[offset] = value.r;
+        data[offset + 1] = value.g;
+        data[offset + 2] = value.b;
+        data[offset + 3] = value.a;
+      }
+    }
+    await writeFile(
+      path,
+      encodePng({
+        width,
+        height,
+        data,
+        depth: 8,
+        channels: 4,
+      }),
+    );
   }
-  await writeFile(
-    path,
-    encodePng({
+
+  async function writeBmp(
+    path: string,
+    width: number,
+    height: number,
+    pixel: (x: number, y: number) => { r: number; g: number; b: number; a: number },
+  ): Promise<void> {
+    const data = new Uint8Array(width * height * 4);
+    for (let y = 0; y < height; y += 1) {
+      for (let x = 0; x < width; x += 1) {
+        const value = pixel(x, y);
+        const offset = (y * width + x) * 4;
+        data[offset] = value.r;
+        data[offset + 1] = value.g;
+        data[offset + 2] = value.b;
+        data[offset + 3] = value.a;
+      }
+    }
+    await writeFile(
+      path,
+      encodeBmp({
+        width,
+        height,
+        data,
+        channels: 4,
+        components: 3,
+        bitsPerPixel: 32,
+      }),
+    );
+  }
+
+  async function writeIndexed4BitBmp(
+    path: string,
+    width: number,
+    height: number,
+    pixel: (x: number, y: number) => number,
+  ): Promise<void> {
+    const rowStride = Math.floor((Math.max(1, width) * 4 + 31) / 32) * 4;
+    const imageSize = rowStride * Math.max(1, height);
+    const paletteEntryCount = 16;
+    const paletteSize = paletteEntryCount * 4;
+    const pixelDataOffset = 14 + 40 + paletteSize;
+    const fileSize = pixelDataOffset + imageSize;
+    const data = new Uint8Array(fileSize);
+    const view = new DataView(data.buffer);
+
+    data[0] = 0x42;
+    data[1] = 0x4d;
+    view.setUint32(2, fileSize, true);
+    view.setUint32(10, pixelDataOffset, true);
+    view.setUint32(14, 40, true);
+    view.setInt32(18, width, true);
+    view.setInt32(22, height, true);
+    view.setUint16(26, 1, true);
+    view.setUint16(28, 4, true);
+    view.setUint32(30, 0, true);
+    view.setUint32(34, imageSize, true);
+    view.setInt32(38, 2835, true);
+    view.setInt32(42, 2835, true);
+    view.setUint32(46, paletteEntryCount, true);
+    view.setUint32(50, paletteEntryCount, true);
+
+    const paletteOffset = 14 + 40;
+    // Palette index 0: black (transparent key for layer BMP)
+    data[paletteOffset] = 0;
+    data[paletteOffset + 1] = 0;
+    data[paletteOffset + 2] = 0;
+    data[paletteOffset + 3] = 0;
+    // Palette index 1: green
+    data[paletteOffset + 4] = 0;
+    data[paletteOffset + 5] = 255;
+    data[paletteOffset + 6] = 0;
+    data[paletteOffset + 7] = 0;
+
+    for (let row = 0; row < height; row += 1) {
+      const sourceY = height - 1 - row;
+      const rowOffset = pixelDataOffset + row * rowStride;
+      let byteOffset = 0;
+      for (let x = 0; x < width; x += 2) {
+        const left = pixel(x, sourceY) & 0x0f;
+        const right = x + 1 < width ? pixel(x + 1, sourceY) & 0x0f : 0;
+        data[rowOffset + byteOffset] = (left << 4) | right;
+        byteOffset += 1;
+      }
+    }
+
+    await writeFile(path, data);
+  }
+
+  function parseAnsiPixels(lines: string[]): Pixel[][] {
+    return lines.map(parseAnsiPixelLine);
+  }
+
+  function parseAnsiPixelLine(line: string): Pixel[] {
+    const pixels: Pixel[] = [];
+    let currentColor: Pixel = undefined;
+    let index = 0;
+    while (index < line.length) {
+      if (line.charCodeAt(index) === 0x1b && index + 1 < line.length && line[index + 1] === '[') {
+        const sequenceEnd = line.indexOf('m', index + 2);
+        if (sequenceEnd < 0) {
+          index += 1;
+          continue;
+        }
+        const sequence = line.slice(index + 2, sequenceEnd);
+        currentColor = applySgr(currentColor, sequence);
+        index = sequenceEnd + 1;
+        continue;
+      }
+      pixels.push(currentColor ? { ...currentColor } : undefined);
+      index += 1;
+    }
+    return pixels;
+  }
+
+  function applySgr(currentColor: Pixel, sequence: string): Pixel {
+    if (sequence === '0') {
+      return undefined;
+    }
+    const parts = sequence.split(';').map((part) => Number.parseInt(part, 10));
+    if (parts.length >= 5 && parts[0] === 48 && parts[1] === 2) {
+      const r = parts[2] ?? 0;
+      const g = parts[3] ?? 0;
+      const b = parts[4] ?? 0;
+      return { r, g, b };
+    }
+    return currentColor;
+  }
+
+  function findOpaqueBounds(pixels: Pixel[][]): { minX: number; minY: number; maxX: number; maxY: number } | undefined {
+    let minX = Number.POSITIVE_INFINITY;
+    let minY = Number.POSITIVE_INFINITY;
+    let maxX = -1;
+    let maxY = -1;
+
+    for (let y = 0; y < pixels.length; y += 1) {
+      const row = pixels[y] ?? [];
+      for (let x = 0; x < row.length; x += 1) {
+        if (!row[x]) {
+          continue;
+        }
+        minX = Math.min(minX, x);
+        minY = Math.min(minY, y);
+        maxX = Math.max(maxX, x);
+        maxY = Math.max(maxY, y);
+      }
+    }
+
+    if (maxX < 0 || maxY < 0) {
+      return undefined;
+    }
+    return { minX, minY, maxX, maxY };
+  }
+
+  function countColor(pixels: Pixel[][], color: RgbColor): number {
+    let count = 0;
+    for (const row of pixels) {
+      for (const pixel of row) {
+        if (!pixel) {
+          continue;
+        }
+        if (pixel.r === color.r && pixel.g === color.g && pixel.b === color.b) {
+          count += 1;
+        }
+      }
+    }
+    return count;
+  }
+
+  function createOpaqueAnsiFrame(
+    width: number,
+    height: number,
+    pixel: (x: number, y: number) => RgbColor,
+  ): {
+    width: number;
+    height: number;
+    rgb: Uint8Array;
+    opaqueMask: Uint8Array;
+  } {
+    const rgb = new Uint8Array(width * height * 3);
+    const opaqueMask = new Uint8Array(width * height);
+    for (let y = 0; y < height; y += 1) {
+      for (let x = 0; x < width; x += 1) {
+        const color = pixel(x, y);
+        const pixelOffset = y * width + x;
+        const rgbOffset = pixelOffset * 3;
+        rgb[rgbOffset] = color.r;
+        rgb[rgbOffset + 1] = color.g;
+        rgb[rgbOffset + 2] = color.b;
+        opaqueMask[pixelOffset] = 1;
+      }
+    }
+    return { width, height, rgb, opaqueMask };
+  }
+
+  function createTransparentAnsiFrame(
+    width: number,
+    height: number,
+  ): {
+    width: number;
+    height: number;
+    rgb: Uint8Array;
+    opaqueMask: Uint8Array;
+  } {
+    return {
       width,
       height,
-      data,
-      depth: 8,
-      channels: 4,
-    }),
-  );
-}
-
-async function writeBmp(
-  path: string,
-  width: number,
-  height: number,
-  pixel: (x: number, y: number) => { r: number; g: number; b: number; a: number },
-): Promise<void> {
-  const data = new Uint8Array(width * height * 4);
-  for (let y = 0; y < height; y += 1) {
-    for (let x = 0; x < width; x += 1) {
-      const value = pixel(x, y);
-      const offset = (y * width + x) * 4;
-      data[offset] = value.r;
-      data[offset + 1] = value.g;
-      data[offset + 2] = value.b;
-      data[offset + 3] = value.a;
-    }
+      rgb: new Uint8Array(width * height * 3),
+      opaqueMask: new Uint8Array(width * height),
+    };
   }
-  await writeFile(
-    path,
-    encodeBmp({
-      width,
-      height,
-      data,
-      channels: 4,
-      components: 3,
-      bitsPerPixel: 32,
-    }),
-  );
-}
-
-async function writeIndexed4BitBmp(
-  path: string,
-  width: number,
-  height: number,
-  pixel: (x: number, y: number) => number,
-): Promise<void> {
-  const rowStride = Math.floor((Math.max(1, width) * 4 + 31) / 32) * 4;
-  const imageSize = rowStride * Math.max(1, height);
-  const paletteEntryCount = 16;
-  const paletteSize = paletteEntryCount * 4;
-  const pixelDataOffset = 14 + 40 + paletteSize;
-  const fileSize = pixelDataOffset + imageSize;
-  const data = new Uint8Array(fileSize);
-  const view = new DataView(data.buffer);
-
-  data[0] = 0x42;
-  data[1] = 0x4d;
-  view.setUint32(2, fileSize, true);
-  view.setUint32(10, pixelDataOffset, true);
-  view.setUint32(14, 40, true);
-  view.setInt32(18, width, true);
-  view.setInt32(22, height, true);
-  view.setUint16(26, 1, true);
-  view.setUint16(28, 4, true);
-  view.setUint32(30, 0, true);
-  view.setUint32(34, imageSize, true);
-  view.setInt32(38, 2835, true);
-  view.setInt32(42, 2835, true);
-  view.setUint32(46, paletteEntryCount, true);
-  view.setUint32(50, paletteEntryCount, true);
-
-  const paletteOffset = 14 + 40;
-  // Palette index 0: black (transparent key for layer BMP)
-  data[paletteOffset] = 0;
-  data[paletteOffset + 1] = 0;
-  data[paletteOffset + 2] = 0;
-  data[paletteOffset + 3] = 0;
-  // Palette index 1: green
-  data[paletteOffset + 4] = 0;
-  data[paletteOffset + 5] = 255;
-  data[paletteOffset + 6] = 0;
-  data[paletteOffset + 7] = 0;
-
-  for (let row = 0; row < height; row += 1) {
-    const sourceY = height - 1 - row;
-    const rowOffset = pixelDataOffset + row * rowStride;
-    let byteOffset = 0;
-    for (let x = 0; x < width; x += 2) {
-      const left = pixel(x, sourceY) & 0x0f;
-      const right = x + 1 < width ? pixel(x + 1, sourceY) & 0x0f : 0;
-      data[rowOffset + byteOffset] = (left << 4) | right;
-      byteOffset += 1;
-    }
-  }
-
-  await writeFile(path, data);
-}
-
-function parseAnsiPixels(lines: string[]): Pixel[][] {
-  return lines.map(parseAnsiPixelLine);
-}
-
-function parseAnsiPixelLine(line: string): Pixel[] {
-  const pixels: Pixel[] = [];
-  let currentColor: Pixel = undefined;
-  let index = 0;
-  while (index < line.length) {
-    if (line.charCodeAt(index) === 0x1b && index + 1 < line.length && line[index + 1] === '[') {
-      const sequenceEnd = line.indexOf('m', index + 2);
-      if (sequenceEnd < 0) {
-        index += 1;
-        continue;
-      }
-      const sequence = line.slice(index + 2, sequenceEnd);
-      currentColor = applySgr(currentColor, sequence);
-      index = sequenceEnd + 1;
-      continue;
-    }
-    pixels.push(currentColor ? { ...currentColor } : undefined);
-    index += 1;
-  }
-  return pixels;
-}
-
-function applySgr(currentColor: Pixel, sequence: string): Pixel {
-  if (sequence === '0') {
-    return undefined;
-  }
-  const parts = sequence.split(';').map((part) => Number.parseInt(part, 10));
-  if (parts.length >= 5 && parts[0] === 48 && parts[1] === 2) {
-    const r = parts[2] ?? 0;
-    const g = parts[3] ?? 0;
-    const b = parts[4] ?? 0;
-    return { r, g, b };
-  }
-  return currentColor;
-}
-
-function findOpaqueBounds(pixels: Pixel[][]): { minX: number; minY: number; maxX: number; maxY: number } | undefined {
-  let minX = Number.POSITIVE_INFINITY;
-  let minY = Number.POSITIVE_INFINITY;
-  let maxX = -1;
-  let maxY = -1;
-
-  for (let y = 0; y < pixels.length; y += 1) {
-    const row = pixels[y] ?? [];
-    for (let x = 0; x < row.length; x += 1) {
-      if (!row[x]) {
-        continue;
-      }
-      minX = Math.min(minX, x);
-      minY = Math.min(minY, y);
-      maxX = Math.max(maxX, x);
-      maxY = Math.max(maxY, y);
-    }
-  }
-
-  if (maxX < 0 || maxY < 0) {
-    return undefined;
-  }
-  return { minX, minY, maxX, maxY };
-}
-
-function countColor(pixels: Pixel[][], color: RgbColor): number {
-  let count = 0;
-  for (const row of pixels) {
-    for (const pixel of row) {
-      if (!pixel) {
-        continue;
-      }
-      if (pixel.r === color.r && pixel.g === color.g && pixel.b === color.b) {
-        count += 1;
-      }
-    }
-  }
-  return count;
-}
-
-function createOpaqueAnsiFrame(
-  width: number,
-  height: number,
-  pixel: (x: number, y: number) => RgbColor,
-): {
-  width: number;
-  height: number;
-  rgb: Uint8Array;
-  opaqueMask: Uint8Array;
-} {
-  const rgb = new Uint8Array(width * height * 3);
-  const opaqueMask = new Uint8Array(width * height);
-  for (let y = 0; y < height; y += 1) {
-    for (let x = 0; x < width; x += 1) {
-      const color = pixel(x, y);
-      const pixelOffset = y * width + x;
-      const rgbOffset = pixelOffset * 3;
-      rgb[rgbOffset] = color.r;
-      rgb[rgbOffset + 1] = color.g;
-      rgb[rgbOffset + 2] = color.b;
-      opaqueMask[pixelOffset] = 1;
-    }
-  }
-  return { width, height, rgb, opaqueMask };
-}
-
-function createTransparentAnsiFrame(width: number, height: number): {
-  width: number;
-  height: number;
-  rgb: Uint8Array;
-  opaqueMask: Uint8Array;
-} {
-  return {
-    width,
-    height,
-    rgb: new Uint8Array(width * height * 3),
-    opaqueMask: new Uint8Array(width * height),
-  };
-}
 });

--- a/packages/player/src/bga.ts
+++ b/packages/player/src/bga.ts
@@ -653,7 +653,7 @@ function resizeFrameSource(source: FrameSource, width: number, height: number): 
     kind: 'video',
     frames: source.frames.map((entry) => ({
       seconds: entry.seconds,
-      frame: resizeAnsiFrameInDisplaySpace(entry.frame, width, height),
+      frame: resizeAnsiFrame(entry.frame, width, height),
     })),
   };
 }
@@ -934,8 +934,8 @@ function createConvertImageToSpecFrameWorker(): WorkerizedSpecFrameConverter {
 async function loadFrameSource(
   resourcePath: string,
   mode: FrameMode,
-  width: number,
-  height: number,
+  _width: number,
+  _height: number,
   signal?: AbortSignal,
 ): Promise<FrameSource | undefined> {
   throwIfAborted(signal);
@@ -944,14 +944,12 @@ async function loadFrameSource(
     return createStaticFrameSource(imageFrame);
   }
 
-  return loadVideoAsFrameSource(resourcePath, mode, width, height, signal);
+  return loadVideoAsFrameSource(resourcePath, mode, signal);
 }
 
 async function loadVideoAsFrameSource(
   videoPath: string,
   mode: FrameMode,
-  width: number,
-  height: number,
   signal?: AbortSignal,
 ): Promise<FrameSource | undefined> {
   throwIfAborted(signal);
@@ -960,7 +958,7 @@ async function loadVideoAsFrameSource(
     videoPath,
     (frame) => {
       throwIfAborted(signal);
-      const specFrame = convertImageToSpecFrame(
+      const sourceFrame = convertImageToSourceFrame(
         {
           width: frame.width,
           height: frame.height,
@@ -971,7 +969,7 @@ async function loadVideoAsFrameSource(
       );
       frames.push({
         seconds: frame.seconds,
-        frame: resizeAnsiFrame(specFrame, width, height),
+        frame: sourceFrame,
       });
     },
     signal,
@@ -1374,6 +1372,34 @@ function convertImageToSpecFrame(image: DecodedImage, mode: FrameMode): AnsiFram
   return specFrame;
 }
 
+function convertImageToSourceFrame(image: DecodedImage, mode: FrameMode): AnsiFrame {
+  const safeWidth = Math.max(1, Math.floor(image.width));
+  const safeHeight = Math.max(1, Math.floor(image.height));
+  const sourceFrame = createSolidAnsiFrame(safeWidth, safeHeight, 0, 0, 0, 0);
+
+  for (let y = 0; y < safeHeight; y += 1) {
+    for (let x = 0; x < safeWidth; x += 1) {
+      const sourceOffset = (y * safeWidth + x) * 4;
+      const r = image.data[sourceOffset] ?? 0;
+      const g = image.data[sourceOffset + 1] ?? 0;
+      const b = image.data[sourceOffset + 2] ?? 0;
+      const a = image.data[sourceOffset + 3] ?? 255;
+      if (!isOpaquePixel(r, g, b, a, image.format, mode)) {
+        continue;
+      }
+
+      const targetPixelOffset = y * safeWidth + x;
+      const targetRgbOffset = targetPixelOffset * 3;
+      sourceFrame.rgb[targetRgbOffset] = r;
+      sourceFrame.rgb[targetRgbOffset + 1] = g;
+      sourceFrame.rgb[targetRgbOffset + 2] = b;
+      sourceFrame.opaqueMask[targetPixelOffset] = 1;
+    }
+  }
+
+  return sourceFrame;
+}
+
 function fitSizeWithinSpecCanvas(sourceWidth: number, sourceHeight: number): { width: number; height: number } {
   const safeSourceWidth = Math.max(1, Math.floor(sourceWidth));
   const safeSourceHeight = Math.max(1, Math.floor(sourceHeight));
@@ -1388,10 +1414,6 @@ function fitSizeWithinSpecCanvas(sourceWidth: number, sourceHeight: number): { w
 
 function resizeAnsiFrame(source: AnsiFrame, maxWidth: number, maxHeight: number): AnsiFrame {
   return resizeAnsiFrameWithAspect(source, maxWidth, maxHeight, TERMINAL_PIXEL_ASPECT_X, TERMINAL_PIXEL_ASPECT_Y);
-}
-
-function resizeAnsiFrameInDisplaySpace(source: AnsiFrame, maxWidth: number, maxHeight: number): AnsiFrame {
-  return resizeAnsiFrameWithAspect(source, maxWidth, maxHeight, 1, 1);
 }
 
 function resizeAnsiFrameWithAspect(

--- a/packages/player/src/bga.ts
+++ b/packages/player/src/bga.ts
@@ -24,6 +24,7 @@ const DEFAULT_BGA_ASCII_WIDTH = 34;
 const DEFAULT_BGA_ASCII_HEIGHT = 20;
 const DEFAULT_POOR_BGA_DISPLAY_SECONDS = 2;
 const TRANSPARENT_ALPHA_THRESHOLD = 16;
+const VIDEO_BLACK_BORDER_THRESHOLD = 8;
 const ANSI_RESET = '\u001b[0m';
 const SPEC_BGA_CANVAS_SIZE = 256;
 const TERMINAL_PIXEL_ASPECT_X = 2;
@@ -1397,7 +1398,65 @@ function convertImageToSourceFrame(image: DecodedImage, mode: FrameMode): AnsiFr
     }
   }
 
-  return sourceFrame;
+  return image.format === 'video' ? trimBlackVideoFrameBorders(sourceFrame) : sourceFrame;
+}
+
+function trimBlackVideoFrameBorders(source: AnsiFrame): AnsiFrame {
+  let minX = source.width;
+  let minY = source.height;
+  let maxX = -1;
+  let maxY = -1;
+
+  for (let y = 0; y < source.height; y += 1) {
+    for (let x = 0; x < source.width; x += 1) {
+      const pixelOffset = y * source.width + x;
+      if (source.opaqueMask[pixelOffset] === 0) {
+        continue;
+      }
+      const rgbOffset = pixelOffset * 3;
+      const r = source.rgb[rgbOffset] ?? 0;
+      const g = source.rgb[rgbOffset + 1] ?? 0;
+      const b = source.rgb[rgbOffset + 2] ?? 0;
+      if (r <= VIDEO_BLACK_BORDER_THRESHOLD && g <= VIDEO_BLACK_BORDER_THRESHOLD && b <= VIDEO_BLACK_BORDER_THRESHOLD) {
+        continue;
+      }
+      minX = Math.min(minX, x);
+      minY = Math.min(minY, y);
+      maxX = Math.max(maxX, x);
+      maxY = Math.max(maxY, y);
+    }
+  }
+
+  if (maxX < 0 || maxY < 0) {
+    return source;
+  }
+  if (minX === 0 && minY === 0 && maxX === source.width - 1 && maxY === source.height - 1) {
+    return source;
+  }
+
+  const width = maxX - minX + 1;
+  const height = maxY - minY + 1;
+  const trimmed = createSolidAnsiFrame(width, height, 0, 0, 0, 0);
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const sourceX = minX + x;
+      const sourceY = minY + y;
+      const sourcePixelOffset = sourceY * source.width + sourceX;
+      if (source.opaqueMask[sourcePixelOffset] === 0) {
+        continue;
+      }
+      const targetPixelOffset = y * width + x;
+      const sourceRgbOffset = sourcePixelOffset * 3;
+      const targetRgbOffset = targetPixelOffset * 3;
+      trimmed.rgb[targetRgbOffset] = source.rgb[sourceRgbOffset] ?? 0;
+      trimmed.rgb[targetRgbOffset + 1] = source.rgb[sourceRgbOffset + 1] ?? 0;
+      trimmed.rgb[targetRgbOffset + 2] = source.rgb[sourceRgbOffset + 2] ?? 0;
+      trimmed.opaqueMask[targetPixelOffset] = 1;
+    }
+  }
+
+  return trimmed;
 }
 
 function fitSizeWithinSpecCanvas(sourceWidth: number, sourceHeight: number): { width: number; height: number } {

--- a/packages/player/src/bga.ts
+++ b/packages/player/src/bga.ts
@@ -1,6 +1,12 @@
 import { readFile } from 'node:fs/promises';
 import { extname } from 'node:path';
-import { invokeWorkerizedFunction, isAbortError, resolveFirstExistingPath, throwIfAborted, workerize } from '@be-music/utils';
+import {
+  invokeWorkerizedFunction,
+  isAbortError,
+  resolveFirstExistingPath,
+  throwIfAborted,
+  workerize,
+} from '@be-music/utils';
 import { normalizeChannel, normalizeObjectKey, sortEvents, type BeMusicEvent, type BeMusicJson } from '@be-music/json';
 import { createTimingResolver } from '@be-music/audio-renderer';
 import { decode as decodeBmpFast } from 'fast-bmp';
@@ -333,7 +339,10 @@ export class BgaAnsiRenderer {
       poorActive && poorSelection.frame
         ? mergeCompositeFrames(poorSelection.frame)
         : mergeCompositeFrames(
-            ...[baseSelection.frame, layerSelection.frame, layer2Selection.frame].slice(0, MAX_NORMAL_BGA_COMPOSITE_LAYERS),
+            ...[baseSelection.frame, layerSelection.frame, layer2Selection.frame].slice(
+              0,
+              MAX_NORMAL_BGA_COMPOSITE_LAYERS,
+            ),
           );
     this.cachedLines = undefined;
   }
@@ -418,7 +427,9 @@ export async function createBgaAnsiRenderer(
   const layerKeys = new Set(layerTimeline.flatMap((cue) => (cue.key ? [cue.key] : [])));
   const layer2Keys = new Set(layer2Timeline.flatMap((cue) => (cue.key ? [cue.key] : [])));
   const shouldUsePoorBmp00Fallback =
-    typeof json.bms.poorBga !== 'string' && typeof json.resources.bmp['00'] === 'string' && json.resources.bmp['00'].length > 0;
+    typeof json.bms.poorBga !== 'string' &&
+    typeof json.resources.bmp['00'] === 'string' &&
+    json.resources.bmp['00'].length > 0;
   const poorFallbackKey = shouldUsePoorBmp00Fallback ? '00' : undefined;
   if (poorFallbackKey) {
     poorKeys.add(poorFallbackKey);
@@ -492,7 +503,13 @@ export async function createBgaAnsiRenderer(
     reportLoadProgress(json.metadata.stageFile);
     const resolved = await resolveMediaPath(options.baseDir, json.metadata.stageFile, options.signal);
     if (resolved) {
-      stageFileSourceFrame = await loadFrameSource(resolved, 'base', displaySize.width, displaySize.height, options.signal);
+      stageFileSourceFrame = await loadFrameSource(
+        resolved,
+        'base',
+        displaySize.width,
+        displaySize.height,
+        options.signal,
+      );
     }
   }
 
@@ -599,7 +616,11 @@ function normalizeDisplaySize(width?: number, height?: number): { width: number;
   };
 }
 
-function resizeFrameSourceMap(sourceMap: Map<string, FrameSource>, width: number, height: number): Map<string, FrameSource> {
+function resizeFrameSourceMap(
+  sourceMap: Map<string, FrameSource>,
+  width: number,
+  height: number,
+): Map<string, FrameSource> {
   const map = new Map<string, FrameSource>();
   const cache = new WeakMap<FrameSource, FrameSource>();
   for (const [key, source] of sourceMap) {
@@ -1245,8 +1266,7 @@ function convertToRgba8(
     rgba[targetOffset] = toByte(data[sourceOffset] ?? 0, sampleMax);
     rgba[targetOffset + 1] = toByte(data[sourceOffset + 1] ?? 0, sampleMax);
     rgba[targetOffset + 2] = toByte(data[sourceOffset + 2] ?? 0, sampleMax);
-    rgba[targetOffset + 3] =
-      safeChannels >= 4 ? toByte(data[sourceOffset + 3] ?? sampleMax, sampleMax) : 255;
+    rgba[targetOffset + 3] = safeChannels >= 4 ? toByte(data[sourceOffset + 3] ?? sampleMax, sampleMax) : 255;
   }
   return rgba;
 }
@@ -1303,8 +1323,14 @@ function createSolidAnsiFrame(
 
 function convertImageToSpecFrame(image: DecodedImage, mode: FrameMode): AnsiFrame {
   const specFrame = createSolidAnsiFrame(SPEC_BGA_CANVAS_SIZE, SPEC_BGA_CANVAS_SIZE, 0, 0, 0, 0);
-  const fittedSize = fitSizeWithinSpecCanvas(image.width, image.height);
-  const offsetX = Math.floor((SPEC_BGA_CANVAS_SIZE - fittedSize.width) / 2);
+  const fittedSize =
+    image.format === 'video'
+      ? {
+          width: SPEC_BGA_CANVAS_SIZE,
+          height: SPEC_BGA_CANVAS_SIZE,
+        }
+      : fitSizeWithinSpecCanvas(image.width, image.height);
+  const offsetX = image.format === 'video' ? 0 : Math.floor((SPEC_BGA_CANVAS_SIZE - fittedSize.width) / 2);
   const offsetY = 0;
 
   for (let targetYWithinImage = 0; targetYWithinImage < fittedSize.height; targetYWithinImage += 1) {
@@ -1361,13 +1387,7 @@ function fitSizeWithinSpecCanvas(sourceWidth: number, sourceHeight: number): { w
 }
 
 function resizeAnsiFrame(source: AnsiFrame, maxWidth: number, maxHeight: number): AnsiFrame {
-  return resizeAnsiFrameWithAspect(
-    source,
-    maxWidth,
-    maxHeight,
-    TERMINAL_PIXEL_ASPECT_X,
-    TERMINAL_PIXEL_ASPECT_Y,
-  );
+  return resizeAnsiFrameWithAspect(source, maxWidth, maxHeight, TERMINAL_PIXEL_ASPECT_X, TERMINAL_PIXEL_ASPECT_Y);
 }
 
 function resizeAnsiFrameInDisplaySpace(source: AnsiFrame, maxWidth: number, maxHeight: number): AnsiFrame {

--- a/packages/player/src/node/node-ui-worker.ts
+++ b/packages/player/src/node/node-ui-worker.ts
@@ -11,22 +11,13 @@ import {
 import { createBgaAnsiRenderer } from '../bga.ts';
 import type { PlayerUiCommand, PlayerUiFramePayload } from '../core/player-ui-signal-bus.ts';
 import { PlayerTui } from '../tui.ts';
+import { estimateBgaAnsiDisplaySize as resolveBgaDisplaySize, resolveLaneWidths } from '../tui/layout.ts';
 import { createDeferredUiFlush } from './deferred-ui-flush.ts';
 import type {
   NodeUiWorkerInboundMessage,
   NodeUiWorkerInitData,
   NodeUiWorkerOutboundMessage,
 } from './node-ui-worker-protocol.ts';
-
-const DEFAULT_LANE_WIDTH = 3;
-const WIDE_SCRATCH_LANE_WIDTH = DEFAULT_LANE_WIDTH * 2;
-const DEFAULT_GRID_ROWS = 14;
-const MIN_GRID_ROWS = 4;
-const STATIC_TUI_LINES = 15;
-const BGA_LANE_GAP = 3;
-const MIN_BGA_ASCII_WIDTH = 8;
-const MIN_BGA_ASCII_HEIGHT = 6;
-const DEFAULT_TERMINAL_COLUMNS = 120;
 
 const port = parentPort;
 const initData = workerData as NodeUiWorkerInitData;
@@ -123,6 +114,13 @@ async function bootstrap(): Promise<void> {
   let latestFrame: PlayerUiFramePayload | undefined;
   const queuedCommands: PlayerUiCommand[] = [];
   let bridgePort: MessagePort | undefined;
+  let terminalColumns: number | undefined;
+  let terminalRows: number | undefined;
+
+  const syncBgaDisplaySize = (frame: PlayerUiFramePayload | undefined): void => {
+    const size = estimateBgaAnsiDisplaySize(initData.laneBindings, terminalColumns, terminalRows, frame);
+    bgaRenderer?.setDisplaySize(size.width, size.height);
+  };
 
   const deferredUiFlush = createDeferredUiFlush(({ commands, frame }) => {
     if (commands) {
@@ -156,6 +154,7 @@ async function bootstrap(): Promise<void> {
     }
 
     if (frame && latestFrame) {
+      syncBgaDisplaySize(latestFrame);
       tui.render({
         ...latestFrame,
         bgaAnsiLines: bgaRenderer?.getAnsiLines(latestFrame.currentSeconds),
@@ -170,6 +169,7 @@ async function bootstrap(): Promise<void> {
     }
     if (message.kind === 'frame') {
       latestFrame = message.frame;
+      syncBgaDisplaySize(latestFrame);
       deferredUiFlush.markFrameDirty();
       return true;
     }
@@ -246,8 +246,9 @@ async function bootstrap(): Promise<void> {
     }
 
     tui.setTerminalSize(message.columns, message.rows);
-    const size = estimateBgaAnsiDisplaySize(initData.laneBindings, message.columns, message.rows);
-    bgaRenderer?.setDisplaySize(size.width, size.height);
+    terminalColumns = message.columns;
+    terminalRows = message.rows;
+    syncBgaDisplaySize(latestFrame);
     if (latestFrame) {
       deferredUiFlush.markFrameDirty();
     }
@@ -273,22 +274,20 @@ function resolveSplitAfterIndex(bindings: NodeUiWorkerInitData['laneBindings']):
 
 function estimateBgaAnsiDisplaySize(
   bindings: NodeUiWorkerInitData['laneBindings'],
-  columns = process.stdout.columns ?? DEFAULT_TERMINAL_COLUMNS,
-  rows = process.stdout.rows ?? DEFAULT_GRID_ROWS + STATIC_TUI_LINES,
+  columns = process.stdout.columns,
+  rows = process.stdout.rows,
+  frame?: Pick<PlayerUiFramePayload, 'activeAudioFiles' | 'activeAudioVoiceCount'>,
 ): { width: number; height: number } {
-  const laneWidths = bindings.map((binding) => (binding.isScratch ? WIDE_SCRATCH_LANE_WIDTH : DEFAULT_LANE_WIDTH));
-  const laneCount = laneWidths.length;
-  const splitAfterIndex = resolveSplitAfterIndex(bindings);
-  const laneTextWidth = laneWidths.reduce((sum, width) => sum + width, 0);
-  const laneSpacingWidth = laneCount > 0 ? laneCount - 1 : 0;
-  const splitExtraWidth = splitAfterIndex >= 0 && splitAfterIndex < laneCount - 1 ? 2 : 0;
-  const laneBlockWidth = laneTextWidth + laneSpacingWidth + splitExtraWidth;
-
-  const width = Math.max(MIN_BGA_ASCII_WIDTH, columns - laneBlockWidth - BGA_LANE_GAP);
-  const rowCount = Math.max(MIN_GRID_ROWS, rows - STATIC_TUI_LINES);
-  const laneBlockHeight = rowCount + 4;
-  const height = Math.max(MIN_BGA_ASCII_HEIGHT, laneBlockHeight);
-  return { width, height };
+  return resolveBgaDisplaySize({
+    laneWidths: resolveLaneWidths(bindings),
+    splitAfterIndex: resolveSplitAfterIndex(bindings),
+    columns,
+    rows,
+    showLaneChannels: initData.showLaneChannels === true,
+    hasRandomPatternSummary:
+      typeof initData.randomPatternSummary === 'string' && initData.randomPatternSummary.length > 0,
+    hasAudioDebugLine: frame?.activeAudioFiles !== undefined || frame?.activeAudioVoiceCount !== undefined,
+  });
 }
 
 function postWorkerMessage(message: NodeUiWorkerOutboundMessage): void {

--- a/packages/player/src/tui.test.ts
+++ b/packages/player/src/tui.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import { formatMeasureSignature, resolveAnimatedHighSpeedValue, resolveVisibleBeatsForTuiGrid } from './tui.ts';
 import { PlayerTui } from './tui.ts';
+import { estimateBgaAnsiDisplaySize, resolveLaneWidths } from './tui/layout.ts';
 
 const STDOUT_IS_TTY_DESCRIPTOR = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
 const STDIN_IS_TTY_DESCRIPTOR = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
@@ -145,6 +146,91 @@ describe('player tui', () => {
 
     const resizedRender = writeSpy.mock.calls.at(-1)?.[0];
     expect(resizedRender).toContain('\u001b[2J\u001b[H');
+
+    tui.stop();
+  });
+
+  test('tui: estimates BGA size from the actual lane block layout', () => {
+    const laneWidths = resolveLaneWidths([
+      { isScratch: true },
+      { isScratch: false },
+      { isScratch: false },
+      { isScratch: false },
+      { isScratch: false },
+      { isScratch: false },
+      { isScratch: false },
+      { isScratch: false },
+    ]);
+
+    expect(
+      estimateBgaAnsiDisplaySize({
+        laneWidths,
+        splitAfterIndex: -1,
+        columns: 120,
+        rows: 32,
+        showLaneChannels: true,
+        hasRandomPatternSummary: true,
+        hasAudioDebugLine: true,
+      }),
+    ).toEqual({
+      width: 81,
+      height: 17,
+    });
+  });
+
+  test('tui: keeps rendered lines within terminal height when optional rows are enabled', () => {
+    mockTerminal({ columns: 120, rows: 32 });
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((() => true) as typeof process.stdout.write);
+    const tui = new PlayerTui({
+      mode: 'MANUAL',
+      laneDisplayMode: '7 KEY',
+      title: 'Test Song',
+      lanes: [
+        { channel: '16', key: 'A', isScratch: true },
+        { channel: '11', key: 'S' },
+        { channel: '12', key: 'D' },
+      ],
+      speed: 1,
+      highSpeed: 1,
+      judgeWindowMs: 16.67,
+      showLaneChannels: true,
+      randomPatternSummary: 'RANDOM 42: 1 -> 3 -> 2',
+      stdinIsTTY: true,
+      stdoutIsTTY: true,
+    });
+    const frame: Parameters<PlayerTui['render']>[0] = {
+      currentBeat: 0,
+      currentSeconds: 0,
+      totalSeconds: 120,
+      summary: {
+        total: 100,
+        perfect: 0,
+        fast: 0,
+        slow: 0,
+        great: 0,
+        good: 0,
+        bad: 0,
+        poor: 0,
+        exScore: 0,
+        score: 0,
+      },
+      notes: [],
+      activeAudioFiles: [],
+      activeAudioVoiceCount: 0,
+    };
+
+    tui.start();
+    writeSpy.mockClear();
+
+    tui.render(frame);
+
+    const renderOutput = String(writeSpy.mock.calls.at(-1)?.[0] ?? '');
+    const visibleFrame = renderOutput.startsWith('\u001b[2J\u001b[H')
+      ? renderOutput.slice('\u001b[2J\u001b[H'.length)
+      : renderOutput.startsWith('\u001b[H')
+        ? renderOutput.slice('\u001b[H'.length)
+        : renderOutput;
+    expect(visibleFrame.split('\n')).toHaveLength(32);
 
     tui.stop();
   });

--- a/packages/player/src/tui/layout.ts
+++ b/packages/player/src/tui/layout.ts
@@ -1,0 +1,100 @@
+export const DEFAULT_LANE_WIDTH = 3;
+export const WIDE_SCRATCH_LANE_WIDTH = DEFAULT_LANE_WIDTH * 2;
+export const DEFAULT_GRID_ROWS = 14;
+export const MIN_GRID_ROWS = 4;
+export const BASE_TUI_RESERVED_LINES = 16;
+export const SPLIT_PANEL_INNER_WIDTH = 5;
+export const BGA_LANE_GAP = 3;
+export const MIN_BGA_ASCII_WIDTH = 8;
+export const MIN_BGA_ASCII_HEIGHT = 6;
+export const DEFAULT_TERMINAL_COLUMNS = 120;
+
+interface TuiLayoutOptions {
+  showLaneChannels?: boolean;
+  hasRandomPatternSummary?: boolean;
+  hasAudioDebugLine?: boolean;
+}
+
+interface TuiBgaDisplaySizeOptions extends TuiLayoutOptions {
+  laneWidths: number[];
+  splitAfterIndex: number;
+  columns?: number;
+  rows?: number;
+}
+
+export function resolveLaneWidths(lanes: ReadonlyArray<{ isScratch?: boolean }>): number[] {
+  return lanes.map((lane) => (lane.isScratch ? WIDE_SCRATCH_LANE_WIDTH : DEFAULT_LANE_WIDTH));
+}
+
+export function calculateTuiReservedLineCount(options: TuiLayoutOptions): number {
+  return (
+    BASE_TUI_RESERVED_LINES +
+    (options.showLaneChannels === true ? 1 : 0) +
+    (options.hasRandomPatternSummary === true ? 1 : 0) +
+    (options.hasAudioDebugLine === true ? 1 : 0)
+  );
+}
+
+export function calculateTuiGridRowCount(rows: number | undefined, options: TuiLayoutOptions): number {
+  const reservedLineCount = calculateTuiReservedLineCount(options);
+  const terminalRows = rows ?? DEFAULT_GRID_ROWS + reservedLineCount;
+  return Math.max(MIN_GRID_ROWS, terminalRows - reservedLineCount);
+}
+
+export function calculateTuiLaneLinesCount(rowCount: number, showLaneChannels = false): number {
+  return rowCount + 3 + (showLaneChannels ? 1 : 0);
+}
+
+export function calculateLaneBlockVisibleWidth(laneWidths: number[], splitAfterIndex: number): number {
+  if (laneWidths.length <= 0) {
+    return calculateLaneSectionVisibleWidth([DEFAULT_LANE_WIDTH]);
+  }
+
+  if (splitAfterIndex < 0 || splitAfterIndex >= laneWidths.length - 1) {
+    return calculateLaneSectionVisibleWidth(laneWidths);
+  }
+
+  const left = laneWidths.slice(0, splitAfterIndex + 1);
+  const right = laneWidths.slice(splitAfterIndex + 1);
+  const splitPanelWidth = SPLIT_PANEL_INNER_WIDTH + 2;
+  return Math.max(
+    1,
+    calculateLaneSectionVisibleWidth(left) + splitPanelWidth + calculateLaneSectionVisibleWidth(right),
+  );
+}
+
+export function estimateBgaAnsiDisplaySize(options: TuiBgaDisplaySizeOptions): { width: number; height: number } {
+  const width = Math.max(
+    MIN_BGA_ASCII_WIDTH,
+    (options.columns ?? DEFAULT_TERMINAL_COLUMNS) -
+      calculateLaneBlockVisibleWidth(options.laneWidths, options.splitAfterIndex) -
+      BGA_LANE_GAP,
+  );
+  const rowCount = calculateTuiGridRowCount(options.rows, options);
+  const height = Math.max(
+    MIN_BGA_ASCII_HEIGHT,
+    calculateTuiLaneLinesCount(rowCount, options.showLaneChannels === true),
+  );
+  return { width, height };
+}
+
+export function calculateLaneSectionVisibleWidth(sectionLaneWidths: number[]): number {
+  const innerWidth = calculateLaneSectionInnerVisibleWidth(sectionLaneWidths);
+  if (innerWidth <= 0) {
+    return 0;
+  }
+  return innerWidth + 2;
+}
+
+function calculateLaneSectionInnerVisibleWidth(sectionLaneWidths: number[]): number {
+  const laneCount = Math.max(0, sectionLaneWidths.length);
+  if (laneCount <= 0) {
+    return 0;
+  }
+  let width = 0;
+  for (let index = 0; index < laneCount; index += 1) {
+    width += sectionLaneWidths[index] ?? DEFAULT_LANE_WIDTH;
+  }
+  width += Math.max(0, laneCount - 1);
+  return width;
+}

--- a/packages/player/src/tui/player-tui.ts
+++ b/packages/player/src/tui/player-tui.ts
@@ -4,6 +4,14 @@ import { formatSeconds, resolveAltModifierLabel } from '../player-utils.ts';
 import type { PlayerStateSignals } from '../player-state-signals.ts';
 import { findStackableRowIndex } from './lane-stacking.ts';
 import { normalizeHighSpeed, resolveAnimatedHighSpeedValue, resolveVisibleBeatsForTuiGrid } from './high-speed.ts';
+import {
+  calculateLaneBlockVisibleWidth,
+  calculateLaneSectionVisibleWidth,
+  calculateTuiGridRowCount,
+  DEFAULT_LANE_WIDTH,
+  resolveLaneWidths,
+  SPLIT_PANEL_INNER_WIDTH,
+} from './layout.ts';
 export { resolveAnimatedHighSpeedValue, resolveVisibleBeatsForTuiGrid } from './high-speed.ts';
 
 interface TuiLane {
@@ -93,16 +101,11 @@ const MAX_SCROLL_LOOKAHEAD_BEATS = IIDX_MEASURE_BEATS * 64;
 const MAX_NOTES_PER_RENDER_WINDOW = 2048;
 const BEAT_EPSILON = 1e-9;
 const FLASH_DURATION_MS = 180;
-const DEFAULT_LANE_WIDTH = 3;
-const DEFAULT_GRID_ROWS = 14;
-const MIN_GRID_ROWS = 4;
-const STATIC_TUI_LINES = 16;
 const MEASURE_LINE_SYMBOL = '▔';
 const MEASURE_LINE_DIVIDER_SYMBOL = '┬';
 const LANE_FILL_SYMBOL = '│';
 const LANE_DIVIDER_SYMBOL = '│';
 const LANE_OUTER_BORDER_SYMBOL = '┃';
-const SPLIT_PANEL_INNER_WIDTH = 5;
 const JUDGE_LINE_SYMBOL = '█';
 const HIGHLIGHT_DECAY_POWER = 0.72;
 const HIGHLIGHT_R_BOOST = 56;
@@ -205,8 +208,6 @@ export class PlayerTui {
 
   private readonly laneWidths: number[] = [];
 
-  private readonly laneBlockVisibleWidth: number;
-
   private readonly scrollDistanceMapper: ScrollDistanceMapper;
 
   private readonly supported: boolean;
@@ -276,9 +277,10 @@ export class PlayerTui {
     this.supported = Boolean(
       (options.stdoutIsTTY ?? process.stdout.isTTY) && (options.stdinIsTTY ?? process.stdin.isTTY),
     );
+    const laneWidths = resolveLaneWidths(options.lanes);
     options.lanes.forEach((lane, index) => {
       this.laneIndex.set(lane.channel, index);
-      this.laneWidths[index] = lane.isScratch ? DEFAULT_LANE_WIDTH * 2 : DEFAULT_LANE_WIDTH;
+      this.laneWidths[index] = laneWidths[index] ?? DEFAULT_LANE_WIDTH;
     });
     if (!this.laneIndex.has('17') && this.laneIndex.has('16')) {
       this.freeZoneChannelToScratchChannel.set('17', '16');
@@ -288,7 +290,6 @@ export class PlayerTui {
       this.freeZoneChannelToScratchChannel.set('27', '26');
       this.freeZoneSourceChannels.add('27');
     }
-    this.laneBlockVisibleWidth = calculateLaneBlockVisibleWidth(this.laneWidths, options.splitAfterIndex ?? -1);
     this.lastSignalPaused = this.paused;
     this.lastSignalHighSpeed = this.targetHighSpeed;
     this.lastSignalJudgeComboTick = Number.NaN;
@@ -451,9 +452,14 @@ export class PlayerTui {
     }
     this.syncStateSignals();
 
-    const terminalRows = this.terminalRows ?? process.stdout.rows ?? DEFAULT_GRID_ROWS + STATIC_TUI_LINES;
+    const terminalRows = this.terminalRows ?? process.stdout.rows;
     const debugLineCount = frame.activeAudioFiles === undefined && frame.activeAudioVoiceCount === undefined ? 0 : 1;
-    const rowCount = Math.max(MIN_GRID_ROWS, terminalRows - STATIC_TUI_LINES - debugLineCount);
+    const rowCount = calculateTuiGridRowCount(terminalRows, {
+      showLaneChannels: this.options.showLaneChannels === true,
+      hasRandomPatternSummary:
+        typeof this.options.randomPatternSummary === 'string' && this.options.randomPatternSummary.length > 0,
+      hasAudioDebugLine: debugLineCount > 0,
+    });
     const laneCount = Math.max(1, this.options.lanes.length);
     const now = Date.now();
     const currentFps = this.resolveFps(now);
@@ -2074,45 +2080,6 @@ function inferLaneSideByChannel(channel: string): '1P' | '2P' {
     return '2P';
   }
   return '1P';
-}
-
-function calculateLaneBlockVisibleWidth(laneWidths: number[], splitAfterIndex: number): number {
-  if (laneWidths.length <= 0) {
-    return calculateLaneSectionVisibleWidth([DEFAULT_LANE_WIDTH]);
-  }
-
-  if (splitAfterIndex < 0 || splitAfterIndex >= laneWidths.length - 1) {
-    return calculateLaneSectionVisibleWidth(laneWidths);
-  }
-
-  const left = laneWidths.slice(0, splitAfterIndex + 1);
-  const right = laneWidths.slice(splitAfterIndex + 1);
-  const splitPanelWidth = SPLIT_PANEL_INNER_WIDTH + 2; // split borders
-  return Math.max(
-    1,
-    calculateLaneSectionVisibleWidth(left) + splitPanelWidth + calculateLaneSectionVisibleWidth(right),
-  );
-}
-
-function calculateLaneSectionVisibleWidth(sectionLaneWidths: number[]): number {
-  const innerWidth = calculateLaneSectionInnerVisibleWidth(sectionLaneWidths);
-  if (innerWidth <= 0) {
-    return 0;
-  }
-  return innerWidth + 2; // outer borders
-}
-
-function calculateLaneSectionInnerVisibleWidth(sectionLaneWidths: number[]): number {
-  const laneCount = Math.max(0, sectionLaneWidths.length);
-  if (laneCount <= 0) {
-    return 0;
-  }
-  let width = 0;
-  for (let index = 0; index < laneCount; index += 1) {
-    width += sectionLaneWidths[index] ?? DEFAULT_LANE_WIDTH;
-  }
-  width += Math.max(0, laneCount - 1); // lane dividers
-  return width;
 }
 
 function findAnsiSgrSequenceEnd(value: string, start: number): number {

--- a/scripts/bench/aggregate-results.test.ts
+++ b/scripts/bench/aggregate-results.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { aggregateBenchmarkSnapshots } from './aggregate-results.ts';
+import type { ExportsBenchmarkSnapshot } from './exports.types.ts';
+
+function createSnapshot(
+  hz: number,
+  meanMs: number,
+  overrides: Partial<ExportsBenchmarkSnapshot> = {},
+): ExportsBenchmarkSnapshot {
+  return {
+    schemaVersion: 1,
+    createdAt: '2026-03-09T00:00:00.000Z',
+    gitSha: 'abc123',
+    nodeVersion: 'v22.0.0',
+    platform: 'linux',
+    options: {
+      timeMs: 200,
+      warmupTimeMs: 100,
+      packages: ['utils'],
+      includeInteractive: false,
+    },
+    exports: {
+      utils: ['clamp'],
+      json: [],
+      parser: [],
+      stringifier: [],
+      editor: [],
+      'audio-renderer': [],
+      player: [],
+    },
+    totals: {
+      exported: 1,
+      benchmarked: 1,
+      skipped: 0,
+      filteredOut: 0,
+    },
+    skipped: {},
+    results: {
+      'utils.clamp': {
+        hz,
+        meanMs,
+        p75Ms: meanMs + 1,
+        p99Ms: meanMs + 2,
+        minMs: meanMs - 1,
+        maxMs: meanMs + 3,
+        rmePercent: 1,
+        sampleCount: 100,
+        totalTimeMs: 200,
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('aggregateBenchmarkSnapshots', () => {
+  it('aggregates benchmark task stats by median', () => {
+    const aggregated = aggregateBenchmarkSnapshots([
+      createSnapshot(100, 10),
+      createSnapshot(140, 8),
+      createSnapshot(120, 9),
+    ]);
+
+    expect(aggregated.aggregation).toEqual({
+      strategy: 'median',
+      runCount: 3,
+    });
+    expect(aggregated.results['utils.clamp'].hz).toBe(120);
+    expect(aggregated.results['utils.clamp'].meanMs).toBe(9);
+    expect(aggregated.results['utils.clamp'].p99Ms).toBe(11);
+  });
+
+  it('rejects incompatible snapshots', () => {
+    expect(() =>
+      aggregateBenchmarkSnapshots([
+        createSnapshot(100, 10),
+        createSnapshot(120, 9, {
+          options: {
+            timeMs: 500,
+            warmupTimeMs: 100,
+            packages: ['utils'],
+            includeInteractive: false,
+          },
+        }),
+      ]),
+    ).toThrow('Benchmark snapshots are incompatible');
+  });
+});

--- a/scripts/bench/aggregate-results.ts
+++ b/scripts/bench/aggregate-results.ts
@@ -1,0 +1,232 @@
+#!/usr/bin/env tsx
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import type { BenchmarkTaskStats, ExportsBenchmarkSnapshot } from './exports.types.ts';
+
+interface CliDefaults {
+  outputPath: string;
+}
+
+interface CliOptions {
+  inputPaths: string[];
+  outputPath: string;
+}
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repositoryDir = resolve(scriptDir, '../..');
+
+const DEFAULTS: CliDefaults = {
+  outputPath: resolve(repositoryDir, 'tmp/bench/exports-aggregated.json'),
+};
+
+const BENCHMARK_RESULT_FIELDS = [
+  'hz',
+  'meanMs',
+  'p75Ms',
+  'p99Ms',
+  'minMs',
+  'maxMs',
+  'rmePercent',
+  'sampleCount',
+  'totalTimeMs',
+] as const satisfies readonly (keyof BenchmarkTaskStats)[];
+
+export async function aggregateBenchmarkSnapshotsFromFiles(
+  inputPaths: readonly string[],
+): Promise<ExportsBenchmarkSnapshot> {
+  const snapshots = await Promise.all(inputPaths.map((inputPath) => loadSnapshot(inputPath)));
+  return aggregateBenchmarkSnapshots(snapshots);
+}
+
+export function aggregateBenchmarkSnapshots(snapshots: readonly ExportsBenchmarkSnapshot[]): ExportsBenchmarkSnapshot {
+  if (snapshots.length === 0) {
+    throw new Error('At least one benchmark snapshot is required.');
+  }
+
+  const [firstSnapshot, ...remainingSnapshots] = snapshots;
+  for (const snapshot of remainingSnapshots) {
+    assertCompatibleSnapshot(firstSnapshot, snapshot);
+  }
+
+  const aggregatedResults: Record<string, BenchmarkTaskStats> = {};
+  const resultKeys = Object.keys(firstSnapshot.results).sort((left, right) => left.localeCompare(right));
+
+  for (const key of resultKeys) {
+    const values = snapshots.map((snapshot) => snapshot.results[key]);
+    aggregatedResults[key] = aggregateTaskStats(values);
+  }
+
+  return {
+    ...firstSnapshot,
+    createdAt: new Date().toISOString(),
+    aggregation: {
+      strategy: 'median',
+      runCount: snapshots.length,
+    },
+    results: aggregatedResults,
+  };
+}
+
+export async function runAggregateBenchmarkSnapshotsCli(
+  args: readonly string[] = process.argv.slice(2),
+): Promise<ExportsBenchmarkSnapshot> {
+  const options = parseArgs([...args], DEFAULTS);
+  const snapshot = await aggregateBenchmarkSnapshotsFromFiles(options.inputPaths);
+
+  await mkdir(dirname(options.outputPath), { recursive: true });
+  await writeFile(options.outputPath, `${JSON.stringify(snapshot, null, 2)}\n`, 'utf8');
+
+  process.stdout.write(`Aggregated ${options.inputPaths.length} benchmark snapshots into ${options.outputPath}\n`);
+  if (snapshot.aggregation) {
+    process.stdout.write(`Strategy=${snapshot.aggregation.strategy} runCount=${snapshot.aggregation.runCount}\n`);
+  }
+  return snapshot;
+}
+
+async function loadSnapshot(pathValue: string): Promise<ExportsBenchmarkSnapshot> {
+  const raw = await readFile(pathValue, 'utf8');
+  const parsed = JSON.parse(raw) as Partial<ExportsBenchmarkSnapshot>;
+  if (parsed.schemaVersion !== 1) {
+    throw new Error(`Unsupported snapshot schema at ${pathValue}`);
+  }
+  if (!parsed.results || typeof parsed.results !== 'object') {
+    throw new Error(`Invalid snapshot (results is missing): ${pathValue}`);
+  }
+  if (!parsed.totals || typeof parsed.totals !== 'object') {
+    throw new Error(`Invalid snapshot (totals is missing): ${pathValue}`);
+  }
+  return parsed as ExportsBenchmarkSnapshot;
+}
+
+function assertCompatibleSnapshot(expected: ExportsBenchmarkSnapshot, actual: ExportsBenchmarkSnapshot): void {
+  const checks = [
+    ['gitSha', expected.gitSha ?? '', actual.gitSha ?? ''],
+    ['nodeVersion', expected.nodeVersion, actual.nodeVersion],
+    ['platform', expected.platform, actual.platform],
+    ['options', stableStringify(expected.options), stableStringify(actual.options)],
+    ['exports', stableStringify(expected.exports), stableStringify(actual.exports)],
+    ['totals', stableStringify(expected.totals), stableStringify(actual.totals)],
+    ['skipped', stableStringify(expected.skipped), stableStringify(actual.skipped)],
+    [
+      'resultKeys',
+      stableStringify(Object.keys(expected.results).sort((left, right) => left.localeCompare(right))),
+      stableStringify(Object.keys(actual.results).sort((left, right) => left.localeCompare(right))),
+    ],
+  ] as const;
+
+  for (const [label, expectedValue, actualValue] of checks) {
+    if (expectedValue !== actualValue) {
+      throw new Error(`Benchmark snapshots are incompatible: ${label} does not match.`);
+    }
+  }
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function aggregateTaskStats(values: readonly BenchmarkTaskStats[]): BenchmarkTaskStats {
+  const aggregated = {} as BenchmarkTaskStats;
+  for (const field of BENCHMARK_RESULT_FIELDS) {
+    const aggregatedValue = median(values.map((value) => value[field]));
+    aggregated[field] = field === 'sampleCount' ? Math.round(aggregatedValue) : aggregatedValue;
+  }
+  return aggregated;
+}
+
+function median(values: readonly number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+
+  const sorted = [...values].sort((left, right) => left - right);
+  const middleIndex = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) {
+    return sorted[middleIndex];
+  }
+  return (sorted[middleIndex - 1] + sorted[middleIndex]) / 2;
+}
+
+function parseArgs(args: string[], defaults: CliDefaults): CliOptions {
+  const options: CliOptions = {
+    inputPaths: [],
+    outputPath: defaults.outputPath,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === '--') {
+      continue;
+    }
+    if (token === '--help' || token === '-h') {
+      printUsage(defaults);
+      process.exit(0);
+    }
+
+    if (token === '--output') {
+      options.outputPath = resolveValue(args[index + 1], '--output');
+      index += 1;
+      continue;
+    }
+
+    if (token === '--input') {
+      options.inputPaths.push(resolveValue(args[index + 1], '--input'));
+      index += 1;
+      continue;
+    }
+
+    if (token.startsWith('-')) {
+      throw new Error(`Unknown option: ${token}`);
+    }
+
+    options.inputPaths.push(token);
+  }
+
+  if (options.inputPaths.length === 0) {
+    throw new Error('At least one benchmark snapshot input path is required.');
+  }
+
+  return options;
+}
+
+function printUsage(defaults: CliDefaults): void {
+  const lines = [
+    'Usage: pnpm run bench:aggregate -- [options] <input...>',
+    '',
+    'Essential options:',
+    '  <input...>               Benchmark snapshot paths to aggregate',
+    `  --output <path>          Output snapshot path (default: ${defaults.outputPath})`,
+    '',
+    'Advanced options:',
+    '  --input <path>           Add an input snapshot path (can be repeated)',
+    '',
+    'Developer options:',
+    '  -h, --help               Show this help',
+  ];
+  process.stdout.write(`${lines.join('\n')}\n`);
+}
+
+function resolveValue(value: string | undefined, optionName: string): string {
+  if (!value) {
+    throw new Error(`Missing value for ${optionName}`);
+  }
+  return value;
+}
+
+function isExecutedAsScript(): boolean {
+  const entryPath = process.argv[1];
+  if (!entryPath) {
+    return false;
+  }
+  return import.meta.url === pathToFileURL(entryPath).href;
+}
+
+if (isExecutedAsScript()) {
+  void runAggregateBenchmarkSnapshotsCli().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/bench/compare-results.ts
+++ b/scripts/bench/compare-results.ts
@@ -3,6 +3,7 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import type { ExportsBenchmarkSnapshot } from './exports.types.ts';
 
 interface CliDefaults {
   outputPath: string;
@@ -18,40 +19,6 @@ interface CliOptions {
   topCount: number;
   summaryPath?: string;
   failOnRegression: boolean;
-}
-
-interface BenchmarkTaskStats {
-  hz: number;
-  meanMs: number;
-  p75Ms: number;
-  p99Ms: number;
-  minMs: number;
-  maxMs: number;
-  rmePercent: number;
-  sampleCount: number;
-  totalTimeMs: number;
-}
-
-interface ExportsBenchmarkSnapshot {
-  schemaVersion: 1;
-  createdAt: string;
-  gitSha?: string;
-  nodeVersion: string;
-  platform: string;
-  options: {
-    timeMs: number;
-    warmupTimeMs: number;
-    includeInteractive: boolean;
-    filter?: string;
-  };
-  totals: {
-    exported: number;
-    benchmarked: number;
-    skipped: number;
-    filteredOut: number;
-  };
-  skipped: Record<string, string>;
-  results: Record<string, BenchmarkTaskStats>;
 }
 
 interface ComparedRow {
@@ -180,6 +147,8 @@ function buildDiffMarkdown(
   lines.push(`- Head SHA: \`${formatSha(headSnapshot.gitSha)}\``);
   lines.push(`- Comparable cases: \`${summary.comparableCaseCount}\``);
   lines.push(`- Regression threshold: \`${thresholdPercent.toFixed(2)}%\``);
+  lines.push(`- Base runs: \`${formatRunCount(baseSnapshot)}\``);
+  lines.push(`- Head runs: \`${formatRunCount(headSnapshot)}\``);
   lines.push('');
   lines.push('### Summary');
   lines.push('| Metric | Value |');
@@ -232,11 +201,7 @@ function buildDiffMarkdown(
   return lines.join('\n');
 }
 
-function buildHeadOnlyMarkdown(
-  headSnapshot: ExportsBenchmarkSnapshot,
-  topCount: number,
-  basePath?: string,
-): string {
+function buildHeadOnlyMarkdown(headSnapshot: ExportsBenchmarkSnapshot, topCount: number, basePath?: string): string {
   const slowest = Object.entries(headSnapshot.results)
     .map(([key, value]) => ({ key, hz: value.hz, meanMs: value.meanMs }))
     .sort((left, right) => left.hz - right.hz)
@@ -253,6 +218,7 @@ function buildHeadOnlyMarkdown(
   lines.push(`- Head SHA: \`${formatSha(headSnapshot.gitSha)}\``);
   lines.push(`- Head benchmarked cases: \`${headSnapshot.totals.benchmarked}\``);
   lines.push(`- Head skipped cases: \`${headSnapshot.totals.skipped}\``);
+  lines.push(`- Head runs: \`${formatRunCount(headSnapshot)}\``);
   lines.push('');
   lines.push('### Slowest Cases In Head');
   if (slowest.length === 0) {
@@ -277,7 +243,7 @@ function compareSnapshots(
     if (!baseResult || !Number.isFinite(baseResult.hz) || baseResult.hz <= 0) {
       continue;
     }
-    const deltaPercent = ((headResult.hz / baseResult.hz) - 1) * 100;
+    const deltaPercent = (headResult.hz / baseResult.hz - 1) * 100;
     rows.push({
       key,
       baseHz: baseResult.hz,
@@ -356,6 +322,9 @@ function parseArgs(args: string[], defaults: CliDefaults): CliOptions {
 
   for (let index = 0; index < args.length; index += 1) {
     const token = args[index];
+    if (token === '--') {
+      continue;
+    }
 
     if (token === '--help' || token === '-h') {
       printUsage(defaults);
@@ -477,6 +446,14 @@ function formatPercent(value: number): string {
     return 'n/a';
   }
   return `${value >= 0 ? '+' : ''}${value.toFixed(2)}%`;
+}
+
+function formatRunCount(snapshot: ExportsBenchmarkSnapshot): string {
+  const runCount = snapshot.aggregation?.runCount ?? 1;
+  if (snapshot.aggregation?.strategy === 'median') {
+    return `median of ${runCount}`;
+  }
+  return `${runCount}`;
 }
 
 void main().catch((error: unknown) => {

--- a/scripts/bench/exports.ts
+++ b/scripts/bench/exports.ts
@@ -299,38 +299,38 @@ function convertTaskResult(result: TaskResult): BenchmarkTaskStats {
     const throughput = typedResult.throughput;
     // tinybench v6 exposes period/latency in milliseconds.
     const meanMs = Number.isFinite(periodSeconds) ? periodSeconds : Number.NaN;
-    const p75Ms = Number.isFinite(latency?.p75) ? latency?.p75 ?? meanMs : meanMs;
-    const p99Ms = Number.isFinite(latency?.p99) ? latency?.p99 ?? meanMs : meanMs;
-    const minMs = Number.isFinite(latency?.min) ? latency?.min ?? meanMs : meanMs;
-    const maxMs = Number.isFinite(latency?.max) ? latency?.max ?? meanMs : meanMs;
+    const p75Ms = Number.isFinite(latency?.p75) ? (latency?.p75 ?? meanMs) : meanMs;
+    const p99Ms = Number.isFinite(latency?.p99) ? (latency?.p99 ?? meanMs) : meanMs;
+    const minMs = Number.isFinite(latency?.min) ? (latency?.min ?? meanMs) : meanMs;
+    const maxMs = Number.isFinite(latency?.max) ? (latency?.max ?? meanMs) : meanMs;
     return {
-      hz: Number.isFinite(throughput?.mean) ? throughput?.mean ?? 0 : 0,
+      hz: Number.isFinite(throughput?.mean) ? (throughput?.mean ?? 0) : 0,
       meanMs,
       p75Ms,
       p99Ms,
       minMs,
       maxMs,
-      rmePercent: Number.isFinite(throughput?.rme) ? throughput?.rme ?? 0 : 0,
+      rmePercent: Number.isFinite(throughput?.rme) ? (throughput?.rme ?? 0) : 0,
       sampleCount:
         Number.isFinite(latency?.samplesCount) && (latency?.samplesCount ?? 0) > 0
           ? Math.floor(latency?.samplesCount ?? 0)
           : 0,
-      totalTimeMs: Number.isFinite(typedResult.totalTime) ? typedResult.totalTime ?? 0 : 0,
+      totalTimeMs: Number.isFinite(typedResult.totalTime) ? (typedResult.totalTime ?? 0) : 0,
     };
   }
 
   const samples = Array.isArray(typedResult.samples) ? typedResult.samples : [];
-  const meanMs = Number.isFinite(typedResult.mean) ? typedResult.mean ?? Number.NaN : Number.NaN;
+  const meanMs = Number.isFinite(typedResult.mean) ? (typedResult.mean ?? Number.NaN) : Number.NaN;
   return {
-    hz: Number.isFinite(typedResult.hz) ? typedResult.hz ?? 0 : 0,
+    hz: Number.isFinite(typedResult.hz) ? (typedResult.hz ?? 0) : 0,
     meanMs,
-    p75Ms: Number.isFinite(typedResult.p75) ? typedResult.p75 ?? meanMs : meanMs,
-    p99Ms: Number.isFinite(typedResult.p99) ? typedResult.p99 ?? meanMs : meanMs,
-    minMs: Number.isFinite(typedResult.min) ? typedResult.min ?? meanMs : meanMs,
-    maxMs: Number.isFinite(typedResult.max) ? typedResult.max ?? meanMs : meanMs,
-    rmePercent: Number.isFinite(typedResult.rme) ? typedResult.rme ?? 0 : 0,
+    p75Ms: Number.isFinite(typedResult.p75) ? (typedResult.p75 ?? meanMs) : meanMs,
+    p99Ms: Number.isFinite(typedResult.p99) ? (typedResult.p99 ?? meanMs) : meanMs,
+    minMs: Number.isFinite(typedResult.min) ? (typedResult.min ?? meanMs) : meanMs,
+    maxMs: Number.isFinite(typedResult.max) ? (typedResult.max ?? meanMs) : meanMs,
+    rmePercent: Number.isFinite(typedResult.rme) ? (typedResult.rme ?? 0) : 0,
     sampleCount: samples.length,
-    totalTimeMs: Number.isFinite(typedResult.totalTime) ? typedResult.totalTime ?? 0 : 0,
+    totalTimeMs: Number.isFinite(typedResult.totalTime) ? (typedResult.totalTime ?? 0) : 0,
   };
 }
 
@@ -470,9 +470,7 @@ function validateCaseCoverage(
   const selectedPrefixSet = new Set(selectedPackages.map((packageName) => `${packageName}.`));
   const missingCases = exportedKeys.filter((key) => !cases.has(key));
   const staleCases = [...cases.keys()].filter(
-    (key) =>
-      !exportedKeys.includes(key) &&
-      [...selectedPrefixSet].some((prefix) => key.startsWith(prefix)),
+    (key) => !exportedKeys.includes(key) && [...selectedPrefixSet].some((prefix) => key.startsWith(prefix)),
   );
 
   if (missingCases.length === 0 && staleCases.length === 0) {
@@ -518,6 +516,9 @@ function parseArgs(args: string[], defaults: CliDefaults): CliOptions {
 
   for (let index = 0; index < args.length; index += 1) {
     const token = args[index];
+    if (token === '--') {
+      continue;
+    }
     if (token === '--help' || token === '-h') {
       printUsage(defaults);
       process.exit(0);

--- a/scripts/bench/exports.types.ts
+++ b/scripts/bench/exports.types.ts
@@ -2,15 +2,7 @@ import type { RenderResult } from '@be-music/audio-renderer';
 import type { BeMusicEvent, BeMusicJson } from '@be-music/json';
 import type { RandomPatternSelection } from '@be-music/player';
 
-export const PACKAGE_NAMES = [
-  'utils',
-  'json',
-  'parser',
-  'stringifier',
-  'editor',
-  'audio-renderer',
-  'player',
-] as const;
+export const PACKAGE_NAMES = ['utils', 'json', 'parser', 'stringifier', 'editor', 'audio-renderer', 'player'] as const;
 
 export type PackageName = (typeof PACKAGE_NAMES)[number];
 
@@ -37,6 +29,10 @@ export interface ExportsBenchmarkSnapshot {
   gitSha?: string;
   nodeVersion: string;
   platform: string;
+  aggregation?: {
+    strategy: 'median';
+    runCount: number;
+  };
   options: {
     timeMs: number;
     warmupTimeMs: number;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,7 +24,16 @@ export default defineConfig({
   },
   test: {
     environment: 'node',
-    projects: workspaceProjects,
+    projects: [
+      ...workspaceProjects,
+      {
+        extends: true as const,
+        test: {
+          name: 'benchmark-scripts',
+          include: ['scripts/bench/**/*.test.ts'],
+        },
+      },
+    ],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'text-summary', 'html', 'lcov'],


### PR DESCRIPTION
## Summary
- align BGA width and height estimation with the actual TUI lane block layout
- share lane/BGA layout calculations between `PlayerTui` and the UI worker so resize and optional rows stay in sync
- let video BGA use the full BGA canvas and add regression coverage for layout and sizing

## Testing
- npx pnpm@10.30.3 --filter @be-music/player exec vitest run src/tui.test.ts src/bga.test.ts src/bga-video-sizing.test.ts
- npx pnpm@10.30.3 --filter @be-music/player run typecheck
- npx pnpm@10.30.3 --filter @be-music/player exec oxlint src/tui/layout.ts src/tui.test.ts src/tui/player-tui.ts src/node/node-ui-worker.ts src/bga.ts src/bga-video-sizing.test.ts
- npx pnpm@10.30.3 --filter @be-music/player exec oxfmt --check src/tui/layout.ts src/tui.test.ts src/tui/player-tui.ts src/node/node-ui-worker.ts src/bga.ts src/bga-video-sizing.test.ts
