### PR TITLE
refactor(json): centralize BMS audio channel helpers

### DIFF
--- a/packages/audio-renderer/src/core/audio-engine.ts
+++ b/packages/audio-renderer/src/core/audio-engine.ts
@@ -4,9 +4,14 @@ import {
   collectLnobjEndEvents,
   createBeatResolver,
   DEFAULT_BPM,
+  isBmsBgmVolumeChangeChannel,
+  isBmsDynamicVolumeChangeChannel,
+  isBmsKeyVolumeChangeChannel,
   isLandmineChannel,
+  isPlayLaneSoundChannel,
   isSampleTriggerChannel,
   isStopChannel,
+  parseBmsDynamicVolumeGain,
   resolveBmsLongNotes,
   normalizeChannel,
   normalizeObjectKey,
@@ -135,47 +140,6 @@ function resolveChartVolWavGain(json: BeMusicJson): number {
   return volWav / 100;
 }
 
-function isDynamicBmsBgmVolumeChannel(channel: string): boolean {
-  return normalizeChannel(channel) === '97';
-}
-
-function isDynamicBmsKeyVolumeChannel(channel: string): boolean {
-  return normalizeChannel(channel) === '98';
-}
-
-function isDynamicBmsVolumeChannel(channel: string): boolean {
-  const normalized = normalizeChannel(channel);
-  return normalized === '97' || normalized === '98';
-}
-
-function parseDynamicBmsVolumeGain(value: string): number | undefined {
-  const parsed = Number.parseInt(normalizeObjectKey(value), 16);
-  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 0xff) {
-    return undefined;
-  }
-  return parsed / 0xff;
-}
-
-function isPlayLaneChannelForVolumeControl(channel: string): boolean {
-  if (channel.length === 2) {
-    const sideCode = channel.charCodeAt(0);
-    const laneCode = channel.charCodeAt(1);
-    if (
-      laneCode >= 0x31 &&
-      laneCode <= 0x39 &&
-      (sideCode === 0x31 ||
-        sideCode === 0x32 ||
-        sideCode === 0x33 ||
-        sideCode === 0x34 ||
-        sideCode === 0x35 ||
-        sideCode === 0x36)
-    ) {
-      return true;
-    }
-  }
-  return false;
-}
-
 function collectDynamicVolumeChanges(
   json: BeMusicJson,
   resolver: TimingResolver,
@@ -187,17 +151,17 @@ function collectDynamicVolumeChanges(
   const changes: DynamicVolumeChange[] = [];
   for (const event of context.sortedEvents) {
     const normalizedChannel = normalizeChannel(event.channel);
-    if (!isDynamicBmsVolumeChannel(normalizedChannel)) {
+    if (!isBmsDynamicVolumeChangeChannel(normalizedChannel)) {
       continue;
     }
-    const gain = parseDynamicBmsVolumeGain(event.value);
+    const gain = parseBmsDynamicVolumeGain(event.value);
     if (gain === undefined) {
       continue;
     }
     changes.push({
-      bus: isDynamicBmsKeyVolumeChannel(normalizedChannel)
+      bus: isBmsKeyVolumeChangeChannel(normalizedChannel)
         ? 'play'
-        : isDynamicBmsBgmVolumeChannel(normalizedChannel)
+        : isBmsBgmVolumeChangeChannel(normalizedChannel)
           ? 'bgm'
           : 'play',
       seconds: resolver.eventToSeconds(event),
@@ -390,7 +354,7 @@ export async function renderJson(json: BeMusicJson, options: RenderOptions = {})
       continue;
     }
     const rawTriggerGain = resolveTriggerGain?.(trigger) ?? 1;
-    const volumeBus = isPlayLaneChannelForVolumeControl(trigger.channel) ? 'play' : 'bgm';
+    const volumeBus = isPlayLaneSoundChannel(trigger.channel) ? 'play' : 'bgm';
     const dynamicGain =
       volumeBus === 'play'
         ? advanceDynamicVolumeGain(playVolumeChanges, trigger.seconds, playVolumeState)

--- a/packages/json/scripts/exports-cases.ts
+++ b/packages/json/scripts/exports-cases.ts
@@ -98,6 +98,11 @@ export function registerJsonExportsCases(define: DefineBenchmarkCase): void {
       jsonApi.isPlayableChannel('11');
     },
   });
+  define('json.isPlayLaneSoundChannel', {
+    run: () => {
+      jsonApi.isPlayLaneSoundChannel('31');
+    },
+  });
   define('json.mapBmsLongNoteChannelToPlayable', {
     run: () => {
       jsonApi.mapBmsLongNoteChannelToPlayable('51');
@@ -106,6 +111,26 @@ export function registerJsonExportsCases(define: DefineBenchmarkCase): void {
   define('json.isBmsLongNoteChannel', {
     run: () => {
       jsonApi.isBmsLongNoteChannel('61');
+    },
+  });
+  define('json.isBmsBgmVolumeChangeChannel', {
+    run: () => {
+      jsonApi.isBmsBgmVolumeChangeChannel('97');
+    },
+  });
+  define('json.isBmsKeyVolumeChangeChannel', {
+    run: () => {
+      jsonApi.isBmsKeyVolumeChangeChannel('98');
+    },
+  });
+  define('json.isBmsDynamicVolumeChangeChannel', {
+    run: () => {
+      jsonApi.isBmsDynamicVolumeChangeChannel('97');
+    },
+  });
+  define('json.parseBmsDynamicVolumeGain', {
+    run: () => {
+      jsonApi.parseBmsDynamicVolumeGain('80');
     },
   });
   define('json.resolveBmsLongNotes', {

--- a/packages/json/src/index.test.ts
+++ b/packages/json/src/index.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest';
 import {
   collectLnobjEndEvents,
   mapBmsLongNoteChannelToPlayable,
+  parseBmsDynamicVolumeGain,
   resolveBmsLongNotes,
   resolveLnobjLongNotes,
   cloneJson,
@@ -12,8 +13,12 @@ import {
   eventToBeat,
   getMeasureBeats,
   intToBase36,
+  isBmsBgmVolumeChangeChannel,
+  isBmsDynamicVolumeChangeChannel,
+  isBmsKeyVolumeChangeChannel,
   isLandmineChannel,
   isPlayableChannel,
+  isPlayLaneSoundChannel,
   isBmsLongNoteChannel,
   isSampleTriggerChannel,
   isScrollChannel,
@@ -226,6 +231,15 @@ test('json: classifies channel types', () => {
   expect(isPlayableChannel('31')).toBe(false);
   expect(isPlayableChannel('01')).toBe(false);
 
+  expect(isPlayLaneSoundChannel('11')).toBe(true);
+  expect(isPlayLaneSoundChannel('29')).toBe(true);
+  expect(isPlayLaneSoundChannel('31')).toBe(true);
+  expect(isPlayLaneSoundChannel('48')).toBe(true);
+  expect(isPlayLaneSoundChannel('51')).toBe(true);
+  expect(isPlayLaneSoundChannel('61')).toBe(true);
+  expect(isPlayLaneSoundChannel('01')).toBe(false);
+  expect(isPlayLaneSoundChannel('A1')).toBe(false);
+
   expect(isBmsLongNoteChannel('51')).toBe(true);
   expect(isBmsLongNoteChannel('6a')).toBe(false);
   expect(isBmsLongNoteChannel('69')).toBe(true);
@@ -235,6 +249,17 @@ test('json: classifies channel types', () => {
   expect(mapBmsLongNoteChannelToPlayable('61')).toBe('21');
   expect(mapBmsLongNoteChannelToPlayable('69')).toBe('29');
   expect(mapBmsLongNoteChannelToPlayable('5A')).toBeUndefined();
+
+  expect(isBmsBgmVolumeChangeChannel('97')).toBe(true);
+  expect(isBmsBgmVolumeChangeChannel('98')).toBe(false);
+  expect(isBmsKeyVolumeChangeChannel('98')).toBe(true);
+  expect(isBmsKeyVolumeChangeChannel('97')).toBe(false);
+  expect(isBmsDynamicVolumeChangeChannel('97')).toBe(true);
+  expect(isBmsDynamicVolumeChangeChannel('98')).toBe(true);
+  expect(isBmsDynamicVolumeChangeChannel('11')).toBe(false);
+  expect(parseBmsDynamicVolumeGain('80')).toBeCloseTo(0x80 / 0xff, 9);
+  expect(parseBmsDynamicVolumeGain('00')).toBeUndefined();
+  expect(parseBmsDynamicVolumeGain('GG')).toBeUndefined();
 });
 
 test('json: collectLnobjEndEvents returns only paired LNOBJ end markers', () => {

--- a/packages/json/src/index.ts
+++ b/packages/json/src/index.ts
@@ -777,6 +777,53 @@ export function isBmsLongNoteChannel(channel: string): boolean {
   return isBmsLongNoteNormalizedChannel(resolveNormalizedChannelForPredicate(channel));
 }
 
+export function isPlayLaneSoundChannel(channel: string): boolean {
+  const packed = tryPackChannel(channel);
+  if (packed >= 0) {
+    return isPackedPlayLaneSoundChannel(packed);
+  }
+  return isPlayLaneSoundNormalizedChannel(resolveNormalizedChannelForPredicate(channel));
+}
+
+export function isBmsBgmVolumeChangeChannel(channel: string): boolean {
+  const packed = tryPackChannel(channel);
+  if (packed >= 0) {
+    return packed === PACKED_CHANNEL_97;
+  }
+  return resolveNormalizedChannelForPredicate(channel) === '97';
+}
+
+export function isBmsKeyVolumeChangeChannel(channel: string): boolean {
+  const packed = tryPackChannel(channel);
+  if (packed >= 0) {
+    return packed === PACKED_CHANNEL_98;
+  }
+  return resolveNormalizedChannelForPredicate(channel) === '98';
+}
+
+export function isBmsDynamicVolumeChangeChannel(channel: string): boolean {
+  const packed = tryPackChannel(channel);
+  if (packed >= 0) {
+    return packed === PACKED_CHANNEL_97 || packed === PACKED_CHANNEL_98;
+  }
+  const normalized = resolveNormalizedChannelForPredicate(channel);
+  return normalized === '97' || normalized === '98';
+}
+
+export function parseBmsDynamicVolumeGain(value: string): number | undefined {
+  const normalized = normalizeObjectKey(value);
+  const high = parseHexDigitFast(normalized.charCodeAt(0));
+  const low = parseHexDigitFast(normalized.charCodeAt(1));
+  if (high < 0 || low < 0) {
+    return undefined;
+  }
+  const parsed = (high << 4) | low;
+  if (parsed <= 0) {
+    return undefined;
+  }
+  return parsed / 0xff;
+}
+
 export function mapBmsLongNoteChannelToPlayable(channel: string): string | undefined {
   const packed = tryPackChannel(channel);
   if (packed >= 0) {
@@ -1306,6 +1353,15 @@ function isPackedBmsLongNoteChannel(packed: number): boolean {
   return high === 0x35 || high === 0x36;
 }
 
+function isPackedPlayLaneSoundChannel(packed: number): boolean {
+  const low = packed & 0xff;
+  if (low < 0x31 || low > 0x39) {
+    return false;
+  }
+  const high = (packed >> 8) & 0xff;
+  return high >= 0x31 && high <= 0x36;
+}
+
 function isTempoNormalizedChannel(normalized: string): boolean {
   return normalized === '03' || normalized === '08';
 }
@@ -1361,6 +1417,18 @@ function isBmsLongNoteNormalizedChannel(normalized: string): boolean {
   }
   const side = normalized.charCodeAt(0);
   return side === 0x35 || side === 0x36;
+}
+
+function isPlayLaneSoundNormalizedChannel(normalized: string): boolean {
+  if (normalized.length !== 2) {
+    return false;
+  }
+  const lane = normalized.charCodeAt(1);
+  if (lane < 0x31 || lane > 0x39) {
+    return false;
+  }
+  const side = normalized.charCodeAt(0);
+  return side >= 0x31 && side <= 0x36;
 }
 
 function mapBmsLongNoteNormalizedChannelToPlayable(normalized: string): string | undefined {

--- a/packages/player/scripts/exports-cases.ts
+++ b/packages/player/scripts/exports-cases.ts
@@ -62,11 +62,6 @@ export function registerPlayerExportsCases(define: DefineBenchmarkCase): void {
       playerApi.formatRandomPatternSummary(fixtures.randomPatterns);
     },
   });
-  define('player.isPlayLaneChannelForVolumeControl', {
-    run: () => {
-      playerApi.isPlayLaneChannelForVolumeControl('11');
-    },
-  });
   define('player.shouldUseAutoMixBgmHeadroomControl', {
     run: () => {
       playerApi.shouldUseAutoMixBgmHeadroomControl({ limiter: false });

--- a/packages/player/src/core/player-engine.ts
+++ b/packages/player/src/core/player-engine.ts
@@ -4,12 +4,15 @@ import { floatToInt16, throwIfAborted } from '@be-music/utils';
 import {
   collectLnobjEndEvents,
   createBeatResolver,
-  mapBmsLongNoteChannelToPlayable,
   type BeMusicEvent,
   type BeMusicJson,
-  isPlayableChannel,
+  isBmsBgmVolumeChangeChannel,
+  isBmsDynamicVolumeChangeChannel,
+  isBmsKeyVolumeChangeChannel,
+  isPlayLaneSoundChannel,
   normalizeChannel,
   normalizeObjectKey,
+  parseBmsDynamicVolumeGain,
   sortEvents,
 } from '@be-music/json';
 import { resolveBmsControlFlow } from '@be-music/parser';
@@ -535,8 +538,6 @@ interface DynamicBmsJudgeRankChange {
   rankPercent: number;
 }
 
-type DynamicAudioVolumeBus = 'bgm' | 'play';
-
 interface TimedAudioVolumeEvent {
   event: BeMusicEvent;
   seconds: number;
@@ -565,27 +566,6 @@ function collectDynamicBmsJudgeRankChanges(json: BeMusicJson): DynamicBmsJudgeRa
   return changes;
 }
 
-function isDynamicBmsBgmVolumeChannel(channel: string): boolean {
-  return normalizeChannel(channel) === '97';
-}
-
-function isDynamicBmsKeyVolumeChannel(channel: string): boolean {
-  return normalizeChannel(channel) === '98';
-}
-
-function isDynamicBmsVolumeChannel(channel: string): boolean {
-  const normalized = normalizeChannel(channel);
-  return normalized === '97' || normalized === '98';
-}
-
-function parseDynamicBmsVolumeGain(value: string): number | undefined {
-  const parsed = Number.parseInt(normalizeObjectKey(value), 16);
-  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 0xff) {
-    return undefined;
-  }
-  return parsed / 0xff;
-}
-
 function collectRealtimeAudioVolumeEvents(json: BeMusicJson): TimedAudioVolumeEvent[] {
   if (json.sourceFormat !== 'bms') {
     return [];
@@ -593,10 +573,10 @@ function collectRealtimeAudioVolumeEvents(json: BeMusicJson): TimedAudioVolumeEv
   const resolver = createTimingResolver(json);
   const events: TimedAudioVolumeEvent[] = [];
   for (const event of sortEvents(json.events)) {
-    if (!isDynamicBmsVolumeChannel(event.channel)) {
+    if (!isBmsDynamicVolumeChangeChannel(event.channel)) {
       continue;
     }
-    if (parseDynamicBmsVolumeGain(event.value) === undefined) {
+    if (parseBmsDynamicVolumeGain(event.value) === undefined) {
       continue;
     }
     events.push({
@@ -1136,7 +1116,7 @@ export async function manualPlay(json: BeMusicJson, options: PlayerOptions = {})
   const nonPlayableRealtimeAudioTriggers = collectRealtimeAudioTriggers(
     resolvedJson,
     inferBmsLnTypeWhenMissing,
-    (channel) => !isPlayLaneChannelForVolumeControl(channel),
+    (channel) => !isPlayLaneSoundChannel(channel),
   );
   const nonPlayableRealtimeAudioEndSeconds =
     options.audio === false
@@ -2126,14 +2106,14 @@ async function createAudioSessionIfEnabled(
         return;
       }
       const normalizedChannel = normalizeChannel(event.channel);
-      if (isDynamicBmsVolumeChannel(normalizedChannel)) {
-        const dynamicGain = parseDynamicBmsVolumeGain(event.value);
+      if (isBmsDynamicVolumeChangeChannel(normalizedChannel)) {
+        const dynamicGain = parseBmsDynamicVolumeGain(event.value);
         if (dynamicGain === undefined) {
           return;
         }
-        if (isDynamicBmsKeyVolumeChannel(normalizedChannel)) {
+        if (isBmsKeyVolumeChangeChannel(normalizedChannel)) {
           currentPlayDynamicGain = dynamicGain;
-        } else if (isDynamicBmsBgmVolumeChannel(normalizedChannel)) {
+        } else if (isBmsBgmVolumeChangeChannel(normalizedChannel)) {
           currentBgmDynamicGain = dynamicGain;
         }
         return;
@@ -2163,10 +2143,10 @@ async function createAudioSessionIfEnabled(
       if (playback?.sliceId && activeVoices.some((voice) => voice.sliceId === playback.sliceId)) {
         return;
       }
-      const volumeBus = resolveDynamicAudioVolumeBus(normalizedChannel);
+      const isPlayLaneSound = isPlayLaneSoundChannel(normalizedChannel);
       const voiceGain =
-        resolveTriggerVoiceBaseGain(volumeBus, playVolume, bgmVolume) *
-        (volumeBus === 'play' ? currentPlayDynamicGain : currentBgmDynamicGain);
+        (isPlayLaneSound ? playVolume : bgmVolume) *
+        (isPlayLaneSound ? currentPlayDynamicGain : currentBgmDynamicGain);
       if (voiceGain <= 0) {
         return;
       }
@@ -2719,51 +2699,16 @@ function resolvePositiveNumberOption(value: number | undefined, fallback: number
 
 function stripPlayableEvents(json: BeMusicJson): BeMusicJson {
   const cloned = structuredClone(json);
-  cloned.events = cloned.events.filter((event) => !isPlayLaneChannelForVolumeControl(event.channel));
+  cloned.events = cloned.events.filter((event) => !isPlayLaneSoundChannel(event.channel));
   return cloned;
 }
 
 function stripNonPlayableEvents(json: BeMusicJson): BeMusicJson {
   const cloned = structuredClone(json);
   cloned.events = cloned.events.filter((event) =>
-    isPlayLaneChannelForVolumeControl(event.channel) || isDynamicBmsKeyVolumeChannel(event.channel),
+    isPlayLaneSoundChannel(event.channel) || isBmsKeyVolumeChangeChannel(event.channel),
   );
   return cloned;
-}
-
-export function isPlayLaneChannelForVolumeControl(channel: string): boolean {
-  if (channel.length === 2) {
-    const sideCode = channel.charCodeAt(0);
-    const laneCode = channel.charCodeAt(1);
-    if (
-      laneCode >= 0x31 &&
-      laneCode <= 0x39 &&
-      (sideCode === 0x31 ||
-        sideCode === 0x32 ||
-        sideCode === 0x33 ||
-        sideCode === 0x34 ||
-        sideCode === 0x35 ||
-        sideCode === 0x36)
-    ) {
-      return true;
-    }
-  }
-
-  const normalized = normalizeChannel(channel);
-  if (isPlayableEventChannel(normalized)) {
-    return true;
-  }
-  if (normalized.length !== 2) {
-    return false;
-  }
-  const side = normalized[0];
-  const lane = normalized[1];
-  return (side === '3' || side === '4') && lane >= '1' && lane <= '9';
-}
-
-function isPlayableEventChannel(channel: string): boolean {
-  const normalized = normalizeChannel(channel);
-  return isPlayableChannel(normalized) || mapBmsLongNoteChannelToPlayable(normalized) !== undefined;
 }
 
 export function shouldUseAutoMixBgmHeadroomControl(options: PlayerOptions): boolean {
@@ -2790,7 +2735,7 @@ async function renderAutoMixWithVolumeControls(
     return renderJson(json, {
       ...options,
       normalize: false,
-      resolveTriggerGain: (trigger) => (isPlayLaneChannelForVolumeControl(trigger.channel) ? playVolume : bgmVolume),
+      resolveTriggerGain: (trigger) => (isPlayLaneSoundChannel(trigger.channel) ? playVolume : bgmVolume),
     });
   }
 
@@ -2909,18 +2854,6 @@ function collectRealtimeAudioSampleKeys(json: BeMusicJson, inferBmsLnTypeWhenMis
     keys.add(trigger.sampleKey);
   }
   return [...keys];
-}
-
-function resolveDynamicAudioVolumeBus(channel: string): DynamicAudioVolumeBus {
-  return isPlayLaneChannelForVolumeControl(channel) ? 'play' : 'bgm';
-}
-
-function resolveTriggerVoiceBaseGain(
-  volumeBus: DynamicAudioVolumeBus,
-  playVolume: number,
-  bgmVolume: number,
-): number {
-  return volumeBus === 'play' ? playVolume : bgmVolume;
 }
 
 function createSilentRenderResult(sampleRate: number): RenderResult {

--- a/packages/player/src/index.test.ts
+++ b/packages/player/src/index.test.ts
@@ -15,7 +15,6 @@ import {
   resolveBgmHeadroomGain,
   shouldUseAutoMixBgmHeadroomControl,
   resolveHighSpeedControlActionFromLaneChannels,
-  isPlayLaneChannelForVolumeControl,
   formatRandomPatternSummary,
   PlayerInterruptedError,
   resolveJudgeWindowsMs,
@@ -678,18 +677,6 @@ describe('player', () => {
     applyFastSlowForJudge(summary, 'GOOD', 0);
     expect(summary.fast).toBe(1);
     expect(summary.slow).toBe(1);
-  });
-
-  test('player: volume control play-side channels include invisible lanes', () => {
-    expect(isPlayLaneChannelForVolumeControl('11')).toBe(true);
-    expect(isPlayLaneChannelForVolumeControl('29')).toBe(true);
-    expect(isPlayLaneChannelForVolumeControl('51')).toBe(true);
-    expect(isPlayLaneChannelForVolumeControl('61')).toBe(true);
-    expect(isPlayLaneChannelForVolumeControl('31')).toBe(true);
-    expect(isPlayLaneChannelForVolumeControl('48')).toBe(true);
-
-    expect(isPlayLaneChannelForVolumeControl('01')).toBe(false);
-    expect(isPlayLaneChannelForVolumeControl('A1')).toBe(false);
   });
 
   test('player: bgm headroom gain does not mute BGM when play lane already clips', () => {

--- a/packages/player/src/tui.test.ts
+++ b/packages/player/src/tui.test.ts
@@ -289,7 +289,7 @@ describe('player tui', () => {
     expect(tailRow).toBeGreaterThanOrEqual(0);
     expect(headRow).toBeGreaterThanOrEqual(0);
     expect(tailRow).toBeLessThan(headRow);
-    expect(bodyRows.some((row) => row < tailRow)).toBe(true);
+    expect(bodyRows.some((row) => row > tailRow && row < headRow)).toBe(true);
 
     tui.stop();
   });


### PR DESCRIPTION
## Summary
- centralize BMS audio channel and dynamic-volume helper functions in `@be-music/json`
- remove duplicated local helper implementations from `player` and `audio-renderer`
- update export benchmark coverage to match the moved and removed public APIs

## Details
- add shared channel classification helpers to `@be-music/json`
- switch `player` and `audio-renderer` to the shared helpers without changing runtime behavior
- drop the `player.isPlayLaneChannelForVolumeControl` export and move that responsibility to `json`

## Verification
- `./node_modules/.bin/vitest run packages/json/src/index.test.ts packages/audio-renderer/src/index.test.ts packages/player/src/index.test.ts`
- `./node_modules/.bin/tsgo -p packages/json/tsconfig.typecheck.json --pretty`
- `./node_modules/.bin/tsgo -p packages/audio-renderer/tsconfig.typecheck.json --pretty`
- `./node_modules/.bin/tsgo -p packages/player/tsconfig.typecheck.json --pretty`

## Benchmarks
- snapshot: `tmp/bench/exports-refactor-conversation.json`
- `json.isPlayLaneSoundChannel`: 15,868,132.08 ops/s
- `json.isBmsBgmVolumeChangeChannel`: 15,559,784.91 ops/s
- `json.isBmsKeyVolumeChangeChannel`: 16,236,335.53 ops/s
- `json.isBmsDynamicVolumeChangeChannel`: 15,590,227.13 ops/s
- `json.parseBmsDynamicVolumeGain`: 14,449,548.85 ops/s
