### PR TITLE
feat(player): add STAGEFILE loading screen support

### DIFF
--- a/docs/bms-spec.md
+++ b/docs/bms-spec.md
@@ -62,6 +62,7 @@
 - [x] メタヘッダ `#GENRE` を解釈
 - [x] メタヘッダ `#COMMENT` を解釈
 - [x] メタヘッダ `#STAGEFILE` を解釈
+- [x] `#STAGEFILE` を選曲後の loading screen 専用画像として表示
 - [x] メタヘッダ `#PLAYLEVEL` を解釈
 - [x] メタヘッダ `#RANK` を解釈
 - [x] `#RANK 0-4` を判定難易度指定として保持

--- a/docs/player-spec.md
+++ b/docs/player-spec.md
@@ -453,6 +453,18 @@ manual long note で保持が切れた場合は、対応チャンネルの再生
 player 本体は UI 実装に依存せず、`stateSignals` と `uiSignals` を通じて状態を通知します。
 judge/combo、フレーム情報、POOR BGA、レーンフラッシュ、レーン保持表示はこの信号経由で伝えます。
 
+### Loading screen
+
+選曲後の loading 中は、CLI が progress bar と現在の手順を標準出力へ描画します。
+このとき `metadata.stageFile` が存在し、画像を解決できる場合は、その画像を ANSI 化して terminal 全体へ描画し、loading 文言はその上にオーバーレイします。
+
+`#STAGEFILE` の表示サイズは現在の端末サイズいっぱいまで使います。
+描画時は画像の縦横比を維持したまま、terminal 全体を覆うように `cover` 相当で拡大します。端末比率と合わない場合は中央基準で一部を crop します。
+loading 文言はその上へオーバーレイし、各文字セルの背景色には対応する `STAGEFILE` ピクセル色を使います。文字色は背景とのコントラスト比が高いほうを選ぶため、白または黒のどちらかになります。
+
+`#STAGEFILE` が未指定、ファイル未発見、非対応形式、デコード失敗の場合は、画像なしのテキスト loading screen へフォールバックします。
+`#STAGEFILE` は loading 専用であり、gameplay 中の BGA renderer は参照しません。最初の base BGA cue がまだ有効でない間は、viewport は黒背景のままです。
+
 ### TUI
 
 標準 TUI は次の情報を表示します。

--- a/packages/audio-renderer/package.json
+++ b/packages/audio-renderer/package.json
@@ -14,6 +14,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -14,6 +14,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -11,6 +11,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -14,6 +14,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/parser/src/index.test.ts
+++ b/packages/parser/src/index.test.ts
@@ -86,6 +86,20 @@ test('BMS: parses #RANK 4 as metadata rank 4', () => {
   expect(parsed.metadata.rank).toBe(4);
 });
 
+test('BMS: parses #STAGEFILE into metadata.stageFile', () => {
+  const parsed = parseChart(
+    [
+      '#TITLE StageFile',
+      '#STAGEFILE loading.png',
+      '#00111:01',
+      '',
+    ].join('\n'),
+  );
+
+  expect(parsed.sourceFormat).toBe('bms');
+  expect(parsed.metadata.stageFile).toBe('loading.png');
+});
+
 test('BMS: keeps the last #DEFEXRANK with decimals', () => {
   const parsed = parseChart(
     [

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -14,6 +14,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/player/src/bga.test.ts
+++ b/packages/player/src/bga.test.ts
@@ -5,7 +5,7 @@ import { createEmptyJson } from '../../json/src/index.ts';
 import { describe, expect, test } from 'vitest';
 import { encode as encodeBmp } from 'fast-bmp';
 import { encode as encodePng } from 'fast-png';
-import { BgaAnsiRenderer, createBgaAnsiRenderer } from './bga.ts';
+import { BgaAnsiRenderer, createBgaAnsiRenderer, loadStageFileAnsiLines } from './bga.ts';
 
 interface RgbColor {
   r: number;
@@ -41,8 +41,54 @@ describe('player bga', () => {
 
       expect(renderer).toBeDefined();
       expect(progressDetails).toContain('base.png');
-      expect(progressDetails).toContain('stage.png');
+      expect(progressDetails).not.toContain('stage.png');
       expect(progressRatios.at(-1)).toBeCloseTo(1, 6);
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  test('player bga: loads STAGEFILE splash lines as a full-screen cover image', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'be-music-stagefile-splash-'));
+    try {
+      await writePng(join(baseDir, 'stage.png'), 64, 256, () => ({ r: 0, g: 0, b: 255, a: 255 }));
+
+      const json = createEmptyJson('bms');
+      json.metadata.bpm = 120;
+      json.metadata.stageFile = 'stage.png';
+
+      const lines = await loadStageFileAnsiLines(json, {
+        baseDir,
+        width: 40,
+        height: 20,
+      });
+
+      expect(lines).toBeDefined();
+      const pixels = parseAnsiPixels(lines ?? []);
+      expect(pixels[10]?.[20]).toEqual({ r: 0, g: 0, b: 255 });
+      expect(pixels[0]?.[0]).toEqual({ r: 0, g: 0, b: 255 });
+      expect(pixels[19]?.[39]).toEqual({ r: 0, g: 0, b: 255 });
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  test('player bga: does not create a gameplay renderer for STAGEFILE-only charts', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'be-music-stagefile-only-'));
+    try {
+      await writePng(join(baseDir, 'stage.png'), 64, 256, () => ({ r: 0, g: 0, b: 255, a: 255 }));
+
+      const json = createEmptyJson('bms');
+      json.metadata.bpm = 120;
+      json.metadata.stageFile = 'stage.png';
+
+      const renderer = await createBgaAnsiRenderer(json, {
+        baseDir,
+        width: 40,
+        height: 20,
+      });
+
+      expect(renderer).toBeUndefined();
     } finally {
       await rm(baseDir, { recursive: true, force: true });
     }
@@ -250,9 +296,11 @@ describe('player bga', () => {
     const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-black-viewport-'));
     try {
       await writePng(join(baseDir, 'base.png'), 256, 256, () => ({ r: 255, g: 0, b: 0, a: 255 }));
+      await writePng(join(baseDir, 'stage.png'), 256, 256, () => ({ r: 0, g: 0, b: 255, a: 255 }));
 
       const json = createEmptyJson('bms');
       json.metadata.bpm = 120;
+      json.metadata.stageFile = 'stage.png';
       json.resources.bmp['01'] = 'base.png';
       json.events = [{ measure: 1, channel: '04', position: [0, 1], value: '01' }];
 
@@ -504,7 +552,6 @@ describe('player bga', () => {
       poorSourceFramesByKey: new Map(),
       layerSourceFramesByKey: new Map(),
       layer2SourceFramesByKey: new Map(),
-      stageFileSourceFrame: undefined,
       missingBaseSourceFrame: createOpaqueAnsiFrame(256, 256, () => ({ r: 0, g: 0, b: 0 })),
       missingPoorSourceFrame: createOpaqueAnsiFrame(256, 256, () => ({ r: 0, g: 0, b: 0 })),
       missingLayerSourceFrame: createTransparentAnsiFrame(256, 256),

--- a/packages/player/src/bga.ts
+++ b/packages/player/src/bga.ts
@@ -102,6 +102,50 @@ export interface BgaAnsiLoadProgress {
   detail: string;
 }
 
+export interface StageFileAnsiImage {
+  width: number;
+  height: number;
+  rgb: Uint8Array;
+  lines: string[];
+}
+
+export async function loadStageFileAnsiImage(
+  json: BeMusicJson,
+  options: Omit<BgaAnsiOptions, 'onLoadProgress'>,
+): Promise<StageFileAnsiImage | undefined> {
+  const stageFile = json.metadata.stageFile;
+  if (typeof stageFile !== 'string' || stageFile.length === 0) {
+    return undefined;
+  }
+
+  throwIfAborted(options.signal);
+  const displaySize = normalizeDisplaySize(options.width, options.height);
+  const stageFileSourceFrame = await loadStageFileLoadingSourceFrame(options.baseDir, stageFile, options.signal);
+  if (!stageFileSourceFrame) {
+    return undefined;
+  }
+
+  const stageFileFrame = resizeFrameSourceCover(stageFileSourceFrame, displaySize.width, displaySize.height);
+  const selected = selectFrameFromSource(stageFileFrame, 0);
+  if (!selected.frame) {
+    return undefined;
+  }
+  const filledFrame = fillAnsiFrameBackground(selected.frame, 0, 0, 0);
+  return {
+    width: filledFrame.width,
+    height: filledFrame.height,
+    rgb: filledFrame.rgb,
+    lines: composeAnsiLines(filledFrame.rgb, filledFrame.opaqueMask, filledFrame.width, filledFrame.height),
+  };
+}
+
+export async function loadStageFileAnsiLines(
+  json: BeMusicJson,
+  options: Omit<BgaAnsiOptions, 'onLoadProgress'>,
+): Promise<string[] | undefined> {
+  return (await loadStageFileAnsiImage(json, options))?.lines;
+}
+
 export class BgaAnsiRenderer {
   private readonly baseTimeline: BgaCue[];
 
@@ -118,8 +162,6 @@ export class BgaAnsiRenderer {
   private readonly layerSourceFramesByKey: Map<string, FrameSource>;
 
   private readonly layer2SourceFramesByKey: Map<string, FrameSource>;
-
-  private readonly stageFileSourceFrame?: FrameSource;
 
   private readonly missingBaseSourceFrame: AnsiFrame;
 
@@ -138,8 +180,6 @@ export class BgaAnsiRenderer {
   private layerFramesByKey = new Map<string, FrameSource>();
 
   private layer2FramesByKey = new Map<string, FrameSource>();
-
-  private stageFileFrame?: FrameSource;
 
   private missingBaseFrame: AnsiFrame;
 
@@ -186,7 +226,6 @@ export class BgaAnsiRenderer {
     poorSourceFramesByKey: Map<string, FrameSource>;
     layerSourceFramesByKey: Map<string, FrameSource>;
     layer2SourceFramesByKey: Map<string, FrameSource>;
-    stageFileSourceFrame?: FrameSource;
     missingBaseSourceFrame: AnsiFrame;
     missingPoorSourceFrame: AnsiFrame;
     missingLayerSourceFrame: AnsiFrame;
@@ -203,7 +242,6 @@ export class BgaAnsiRenderer {
     this.poorSourceFramesByKey = params.poorSourceFramesByKey;
     this.layerSourceFramesByKey = params.layerSourceFramesByKey;
     this.layer2SourceFramesByKey = params.layer2SourceFramesByKey;
-    this.stageFileSourceFrame = params.stageFileSourceFrame;
     this.missingBaseSourceFrame = params.missingBaseSourceFrame;
     this.missingPoorSourceFrame = params.missingPoorSourceFrame;
     this.missingLayerSourceFrame = params.missingLayerSourceFrame;
@@ -271,9 +309,6 @@ export class BgaAnsiRenderer {
     this.poorFramesByKey = resizeFrameSourceMap(this.poorSourceFramesByKey, this.displayWidth, this.displayHeight);
     this.layerFramesByKey = resizeFrameSourceMap(this.layerSourceFramesByKey, this.displayWidth, this.displayHeight);
     this.layer2FramesByKey = resizeFrameSourceMap(this.layer2SourceFramesByKey, this.displayWidth, this.displayHeight);
-    this.stageFileFrame = this.stageFileSourceFrame
-      ? resizeFrameSource(this.stageFileSourceFrame, this.displayWidth, this.displayHeight)
-      : undefined;
     this.missingBaseFrame = resizeAnsiFrame(this.missingBaseSourceFrame, this.displayWidth, this.displayHeight);
     this.missingPoorFrame = resizeAnsiFrame(this.missingPoorSourceFrame, this.displayWidth, this.displayHeight);
     this.missingLayerFrame = resizeAnsiFrame(this.missingLayerSourceFrame, this.displayWidth, this.displayHeight);
@@ -350,7 +385,10 @@ export class BgaAnsiRenderer {
 
   private resolveBaseFrame(baseKey: string, seconds: number): FrameSelection {
     if (!baseKey) {
-      return selectFrameFromSource(this.stageFileFrame, seconds);
+      return {
+        frame: undefined,
+        index: -1,
+      };
     }
     const source = this.baseFramesByKey.get(baseKey) ?? createStaticFrameSource(this.missingBaseFrame);
     return selectFrameFromSource(source, seconds);
@@ -440,8 +478,7 @@ export async function createBgaAnsiRenderer(
     countMappedBmpResourceTargets(baseKeys, json.resources.bmp) +
     countMappedBmpResourceTargets(poorKeys, json.resources.bmp) +
     countMappedBmpResourceTargets(layerKeys, json.resources.bmp) +
-    countMappedBmpResourceTargets(layer2Keys, json.resources.bmp) +
-    countMappedStageFileTarget(json.metadata.stageFile);
+    countMappedBmpResourceTargets(layer2Keys, json.resources.bmp);
   let loadedTargetCount = 0;
   const reportLoadProgress = (detail: string): void => {
     if (!options.onLoadProgress || totalLoadTargetCount <= 0) {
@@ -499,27 +536,15 @@ export async function createBgaAnsiRenderer(
   });
   throwIfAborted(options.signal);
 
-  let stageFileSourceFrame: FrameSource | undefined;
-  if (json.metadata.stageFile) {
-    reportLoadProgress(json.metadata.stageFile);
-    const resolved = await resolveMediaPath(options.baseDir, json.metadata.stageFile, options.signal);
-    if (resolved) {
-      stageFileSourceFrame = await loadFrameSource(
-        resolved,
-        'base',
-        displaySize.width,
-        displaySize.height,
-        options.signal,
-      );
-    }
-  }
-
   if (
     baseSourceFramesByKey.size === 0 &&
     poorSourceFramesByKey.size === 0 &&
     layerSourceFramesByKey.size === 0 &&
     layer2SourceFramesByKey.size === 0 &&
-    !stageFileSourceFrame
+    baseTimeline.length === 0 &&
+    poorTimeline.length === 0 &&
+    layerTimeline.length === 0 &&
+    layer2Timeline.length === 0
   ) {
     return undefined;
   }
@@ -537,7 +562,6 @@ export async function createBgaAnsiRenderer(
     poorSourceFramesByKey,
     layerSourceFramesByKey,
     layer2SourceFramesByKey,
-    stageFileSourceFrame,
     missingBaseSourceFrame,
     missingPoorSourceFrame,
     missingLayerSourceFrame,
@@ -599,13 +623,6 @@ function countMappedBmpResourceTargets(keys: ReadonlySet<string>, resources: Rec
   return count;
 }
 
-function countMappedStageFileTarget(stageFile: string | undefined): number {
-  if (typeof stageFile !== 'string' || stageFile.length === 0) {
-    return 0;
-  }
-  return 1;
-}
-
 function normalizeProgressDetail(detail: string): string {
   return detail.replaceAll('\\', '/');
 }
@@ -642,6 +659,19 @@ function createStaticFrameSource(frame: AnsiFrame): FrameSource {
   };
 }
 
+function fillFrameSourceBackground(source: FrameSource, r: number, g: number, b: number): FrameSource {
+  if (source.kind === 'static') {
+    return createStaticFrameSource(fillAnsiFrameBackground(source.frame, r, g, b));
+  }
+  return {
+    kind: 'video',
+    frames: source.frames.map((entry) => ({
+      seconds: entry.seconds,
+      frame: fillAnsiFrameBackground(entry.frame, r, g, b),
+    })),
+  };
+}
+
 function resizeFrameSource(source: FrameSource, width: number, height: number): FrameSource {
   if (source.kind === 'static') {
     return {
@@ -655,6 +685,23 @@ function resizeFrameSource(source: FrameSource, width: number, height: number): 
     frames: source.frames.map((entry) => ({
       seconds: entry.seconds,
       frame: resizeAnsiFrame(entry.frame, width, height),
+    })),
+  };
+}
+
+function resizeFrameSourceCover(source: FrameSource, width: number, height: number): FrameSource {
+  if (source.kind === 'static') {
+    return {
+      kind: 'static',
+      frame: resizeAnsiFrameCover(source.frame, width, height),
+    };
+  }
+
+  return {
+    kind: 'video',
+    frames: source.frames.map((entry) => ({
+      seconds: entry.seconds,
+      frame: resizeAnsiFrameCover(entry.frame, width, height),
     })),
   };
 }
@@ -774,6 +821,20 @@ function mergeCompositeFrames(...sourceFrames: Array<AnsiFrame | undefined>): Co
   };
 }
 
+function fillAnsiFrameBackground(source: AnsiFrame, r: number, g: number, b: number): AnsiFrame {
+  const frame = createSolidAnsiFrame(source.width, source.height, r, g, b, 1);
+  for (let pixelOffset = 0; pixelOffset < source.width * source.height; pixelOffset += 1) {
+    if (source.opaqueMask[pixelOffset] === 0) {
+      continue;
+    }
+    const rgbOffset = pixelOffset * 3;
+    frame.rgb[rgbOffset] = source.rgb[rgbOffset] ?? 0;
+    frame.rgb[rgbOffset + 1] = source.rgb[rgbOffset + 1] ?? 0;
+    frame.rgb[rgbOffset + 2] = source.rgb[rgbOffset + 2] ?? 0;
+  }
+  return frame;
+}
+
 function paintFrame(
   canvasRgb: Uint8Array,
   canvasMask: Uint8Array,
@@ -885,6 +946,30 @@ async function loadImageAsSpecFrame(
   }
 }
 
+async function loadImageAsSourceFrame(
+  imagePath: string,
+  mode: FrameMode,
+  signal?: AbortSignal,
+): Promise<AnsiFrame | undefined> {
+  const extension = extname(imagePath).toLowerCase();
+  if (extension !== '.bmp' && extension !== '.png' && extension !== '.jpg' && extension !== '.jpeg') {
+    return undefined;
+  }
+  try {
+    throwIfAborted(signal);
+    const buffer = await readFile(imagePath, { signal });
+    throwIfAborted(signal);
+    const decoded = decodeImageBuffer(buffer, imagePath);
+    throwIfAborted(signal);
+    return convertImageToSourceFrame(decoded, mode);
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw error;
+    }
+    return undefined;
+  }
+}
+
 async function convertImageToSpecFrameOffThread(
   image: DecodedImage,
   mode: FrameMode,
@@ -985,6 +1070,23 @@ async function loadVideoAsFrameSource(
     kind: 'video',
     frames,
   };
+}
+
+async function loadStageFileLoadingSourceFrame(
+  baseDir: string,
+  stageFile: string,
+  signal?: AbortSignal,
+): Promise<FrameSource | undefined> {
+  throwIfAborted(signal);
+  const resolved = await resolveMediaPath(baseDir, stageFile, signal);
+  if (!resolved) {
+    return undefined;
+  }
+  const imageFrame = await loadImageAsSourceFrame(resolved, 'base', signal);
+  if (imageFrame) {
+    return createStaticFrameSource(imageFrame);
+  }
+  return loadVideoAsFrameSource(resolved, 'base', signal);
 }
 
 async function resolveMediaPath(baseDir: string, mediaPath: string, signal?: AbortSignal): Promise<string | undefined> {
@@ -1475,6 +1577,17 @@ function resizeAnsiFrame(source: AnsiFrame, maxWidth: number, maxHeight: number)
   return resizeAnsiFrameWithAspect(source, maxWidth, maxHeight, TERMINAL_PIXEL_ASPECT_X, TERMINAL_PIXEL_ASPECT_Y);
 }
 
+function resizeAnsiFrameCover(source: AnsiFrame, maxWidth: number, maxHeight: number): AnsiFrame {
+  return resizeAnsiFrameWithAspectMode(
+    source,
+    maxWidth,
+    maxHeight,
+    TERMINAL_PIXEL_ASPECT_X,
+    TERMINAL_PIXEL_ASPECT_Y,
+    'cover',
+  );
+}
+
 function resizeAnsiFrameWithAspect(
   source: AnsiFrame,
   maxWidth: number,
@@ -1482,17 +1595,36 @@ function resizeAnsiFrameWithAspect(
   aspectX: number,
   aspectY: number,
 ): AnsiFrame {
+  return resizeAnsiFrameWithAspectMode(source, maxWidth, maxHeight, aspectX, aspectY, 'contain');
+}
+
+function resizeAnsiFrameWithAspectMode(
+  source: AnsiFrame,
+  maxWidth: number,
+  maxHeight: number,
+  aspectX: number,
+  aspectY: number,
+  mode: 'contain' | 'cover',
+): AnsiFrame {
   const canvasWidth = Math.max(1, maxWidth);
   const canvasHeight = Math.max(1, maxHeight);
   if (source.width === canvasWidth && source.height === canvasHeight && aspectX === 1 && aspectY === 1) {
     return source;
   }
-  const fitted = fitSizeKeepingAspect(
-    source.width * Math.max(1, aspectX),
-    source.height * Math.max(1, aspectY),
-    canvasWidth,
-    canvasHeight,
-  );
+  const fitted =
+    mode === 'cover'
+      ? fitSizeCoveringAspect(
+          source.width * Math.max(1, aspectX),
+          source.height * Math.max(1, aspectY),
+          canvasWidth,
+          canvasHeight,
+        )
+      : fitSizeKeepingAspect(
+          source.width * Math.max(1, aspectX),
+          source.height * Math.max(1, aspectY),
+          canvasWidth,
+          canvasHeight,
+        );
   const offsetX = Math.floor((canvasWidth - fitted.width) / 2);
   const offsetY = Math.floor((canvasHeight - fitted.height) / 2);
   const rgb = new Uint8Array(canvasWidth * canvasHeight * 3);
@@ -1566,6 +1698,29 @@ function fitSizeKeepingAspect(
   if (height > safeMaxHeight) {
     height = safeMaxHeight;
     width = Math.max(1, Math.floor(height * aspect));
+  }
+
+  return { width, height };
+}
+
+function fitSizeCoveringAspect(
+  sourceWidth: number,
+  sourceHeight: number,
+  maxWidth: number,
+  maxHeight: number,
+): { width: number; height: number } {
+  const safeSourceWidth = Math.max(1, sourceWidth);
+  const safeSourceHeight = Math.max(1, sourceHeight);
+  const safeMaxWidth = Math.max(1, maxWidth);
+  const safeMaxHeight = Math.max(1, maxHeight);
+  const aspect = safeSourceWidth / safeSourceHeight;
+
+  let width = safeMaxWidth;
+  let height = Math.max(1, Math.ceil(width / aspect));
+
+  if (height < safeMaxHeight) {
+    height = safeMaxHeight;
+    width = Math.max(1, Math.ceil(height * aspect));
   }
 
   return { width, height };

--- a/packages/player/src/cli.test.ts
+++ b/packages/player/src/cli.test.ts
@@ -2,10 +2,13 @@ import { describe, expect, test } from 'vitest';
 import type readline from 'node:readline';
 import {
   applyPersistedPlayerConfigToArgs,
+  createPlayLoadingProgressScreenOutput,
+  createPlayLoadingProgressScreenLines,
   cyclePlayMode,
   formatPlayModeLabel,
   parseArgs,
   resolveCliConfigOverrideFlags,
+  resolvePlayLoadingStageFileDisplaySize,
   resolvePersistedPlayerConfigFromArgs,
   resolveCircularSelectableIndex,
   resolvePageSelectableIndex,
@@ -110,6 +113,103 @@ describe('player cli', () => {
   test('cli: formats DEFEXRANK values without dropping decimals', () => {
     expect(formatRankLabel(4)).toBe('VERY EASY');
     expect(formatRankLabel(199.97)).toBe('199.97');
+  });
+
+  test('cli: renders loading overlay lines with opaque styling', () => {
+    const lines = createPlayLoadingProgressScreenLines(
+      '/charts/stagefile-test.bms',
+      {
+        ratio: 0.5,
+        message: 'Preparing audio...',
+        detail: 'sample.wav',
+      },
+      { columns: 48 },
+    );
+
+    expect(lines[0]).toContain('Loading selected chart...');
+    expect(lines.some((line) => line.includes('Preparing audio...'))).toBe(true);
+    expect(lines.some((line) => line.includes('/charts/stagefile-test.bms'))).toBe(true);
+    expect(lines.some((line) => line.includes('sample.wav'))).toBe(true);
+    expect(lines.every((line) => line.startsWith('\u001b[38;2;255;255;255;48;2;0;0;0m'))).toBe(true);
+  });
+
+  test('cli: chooses black text on bright stage pixels and white text on dark stage pixels', () => {
+    const whiteRow = new Uint8Array(Array.from({ length: 48 * 3 }, () => 255));
+    const blackRow = new Uint8Array(48 * 3);
+    const rgb = new Uint8Array([...whiteRow, ...blackRow]);
+    const lines = createPlayLoadingProgressScreenLines(
+      '/charts/stagefile-test.bms',
+      {
+        ratio: 0.5,
+        message: 'Preparing audio...',
+      },
+      {
+        columns: 48,
+        stageFileImage: {
+          width: 48,
+          height: 2,
+          rgb,
+          lines: ['IMG1', 'IMG2'],
+        },
+      },
+    );
+
+    expect(lines[0]).toContain('\u001b[38;2;0;0;0;48;2;255;255;255mL');
+    expect(lines[1]).toContain('\u001b[38;2;255;255;255;48;2;0;0;0m[');
+  });
+
+  test('cli: overlays loading text onto full-screen STAGEFILE output', () => {
+    const output = createPlayLoadingProgressScreenOutput(
+      '/charts/stagefile-test.bms',
+      {
+        ratio: 0.5,
+        message: 'Preparing audio...',
+      },
+      {
+        columns: 48,
+        stageFileImage: {
+          width: 48,
+          height: 2,
+          rgb: new Uint8Array(48 * 2 * 3),
+          lines: ['ANSI_STAGE_LINE_1', 'ANSI_STAGE_LINE_2'],
+        },
+      },
+    );
+
+    expect(output).toContain('\u001b[2J\u001b[HANSI_STAGE_LINE_1\nANSI_STAGE_LINE_2\u001b[H');
+    expect(output).toContain('Loading selected chart...');
+  });
+
+  test('cli: updates loading overlay without redrawing the STAGEFILE background', () => {
+    const output = createPlayLoadingProgressScreenOutput(
+      '/charts/stagefile-test.bms',
+      {
+        ratio: 0.75,
+        message: 'Preparing audio...',
+        detail: 'sample.wav',
+      },
+      {
+        columns: 48,
+        stageFileImage: {
+          width: 48,
+          height: 2,
+          rgb: new Uint8Array(48 * 2 * 3),
+          lines: ['ANSI_STAGE_LINE_1', 'ANSI_STAGE_LINE_2'],
+        },
+        resetScreen: false,
+        includeStageFileImage: false,
+      },
+    );
+
+    expect(output.startsWith('\u001b[H')).toBe(true);
+    expect(output).not.toContain('\u001b[2J');
+    expect(output).not.toContain('ANSI_STAGE_LINE_1');
+    expect(output).toContain('Detail: sample.wav');
+  });
+
+  test('cli: expands STAGEFILE splash bounds to the available loading screen area', () => {
+    expect(resolvePlayLoadingStageFileDisplaySize(120, 40)).toEqual({ width: 120, height: 40 });
+    expect(resolvePlayLoadingStageFileDisplaySize(24, 10)).toEqual({ width: 24, height: 10 });
   });
 
   test('cli: keeps RANDOM rank labels in selection rows', () => {

--- a/packages/player/src/cli/runner.ts
+++ b/packages/player/src/cli/runner.ts
@@ -7,6 +7,7 @@ import readline from 'node:readline';
 import { parseChartFile } from '@be-music/parser';
 import { renderJson, writeAudioFile } from '@be-music/audio-renderer';
 import { PlayerInterruptedError, type PlayerLoadProgress, type PlayerSummary } from '../index.ts';
+import { loadStageFileAnsiImage, type StageFileAnsiImage } from '../bga.ts';
 import { runNodeGameplayRuntime } from '../node/node-gameplay-runtime.ts';
 import { resolveDisplayedJudgeRankLabel, resolveDisplayedJudgeRankValue } from '../player-utils.ts';
 import {
@@ -110,6 +111,11 @@ interface PlayLoadingProgress {
   ratio: number;
   message: string;
   detail?: string;
+}
+
+interface PlayLoadingScreenRenderState {
+  initialized: boolean;
+  stageFileDrawn: boolean;
 }
 
 interface SelectChartInteractivelyOptions {
@@ -583,6 +589,11 @@ function resolveDirectoryStateFromResultAction(
 
 async function playChartOnce(chartPath: string, args: CliArgs): Promise<PlayedChartResult> {
   let resolvedHighSpeed = normalizeHighSpeedValue(args.highSpeed);
+  let playLoadingStageFileImage: StageFileAnsiImage | undefined;
+  const playLoadingScreenRenderState: PlayLoadingScreenRenderState = {
+    initialized: false,
+    stageFileDrawn: false,
+  };
   let resolvedChartMetadata:
     | {
         title?: string;
@@ -595,7 +606,11 @@ async function playChartOnce(chartPath: string, args: CliArgs): Promise<PlayedCh
     | undefined;
   const reportPlayLoadingProgress = process.stdout.isTTY
     ? (progress: PlayLoadingProgress): void => {
-        renderPlayLoadingProgress(chartPath, progress);
+        renderPlayLoadingProgress(chartPath, progress, {
+          columns: process.stdout.columns,
+          stageFileImage: playLoadingStageFileImage,
+          state: playLoadingScreenRenderState,
+        });
       }
     : undefined;
   const chartLoadingAbortCapture = beginLoadingAbortCapture();
@@ -608,6 +623,20 @@ async function playChartOnce(chartPath: string, args: CliArgs): Promise<PlayedCh
     json = await parseChartFile(chartPath, {
       signal: chartLoadingAbortCapture?.signal,
     });
+    if (process.stdout.isTTY && typeof json.metadata.stageFile === 'string' && json.metadata.stageFile.length > 0) {
+      reportPlayLoadingProgress?.({
+        ratio: 0.12,
+        message: 'Loading stage image...',
+        detail: json.metadata.stageFile.replaceAll('\\', '/'),
+      });
+      const stageFileDisplaySize = resolvePlayLoadingStageFileDisplaySize(process.stdout.columns, process.stdout.rows);
+      playLoadingStageFileImage = await loadStageFileAnsiImage(json, {
+        baseDir: dirname(chartPath),
+        width: stageFileDisplaySize.width,
+        height: stageFileDisplaySize.height,
+        signal: chartLoadingAbortCapture?.signal,
+      });
+    }
     reportPlayLoadingProgress?.({
       ratio: 0.16,
       message: 'Chart parsed.',
@@ -1170,24 +1199,178 @@ function renderChartLoadingProgress(rootDir: string, progress: ChartSummaryLoadi
   process.stdout.write(`\u001b[2J\u001b[H${lines.join('\n')}\u001b[J`);
 }
 
-function renderPlayLoadingProgress(chartPath: string, progress: PlayLoadingProgress): void {
-  const columns = process.stdout.columns ?? 80;
-  const lineWidth = Math.max(16, columns - 2);
+export function resolvePlayLoadingStageFileDisplaySize(
+  columns?: number,
+  rows?: number,
+): {
+  width: number;
+  height: number;
+} {
+  const safeColumns = Math.max(16, Math.floor(columns ?? 80));
+  const safeRows = Math.max(8, Math.floor(rows ?? 24));
+  return {
+    width: safeColumns,
+    height: safeRows,
+  };
+}
+
+export function createPlayLoadingProgressScreenLines(
+  chartPath: string,
+  progress: PlayLoadingProgress,
+  options: {
+    columns?: number;
+    stageFileImage?: StageFileAnsiImage;
+  } = {},
+): string[] {
+  const columns = options.columns ?? 80;
+  const lineWidth = Math.max(16, columns);
   const fileLabel = chartPath.replaceAll('\\', '/');
   const ratio = Math.max(0, Math.min(1, progress.ratio));
   const barWidth = Math.max(10, Math.min(48, lineWidth - 8));
   const filled = Math.max(0, Math.min(barWidth, Math.round(barWidth * ratio)));
   const bar = `[${'#'.repeat(filled)}${'-'.repeat(barWidth - filled)}] ${Math.round(ratio * 100)}%`;
-  const lines = [
+  const rawLines = [
     'Loading selected chart...',
-    truncateForDisplay(bar, lineWidth),
-    truncateForDisplay(`Step: ${progress.message}`, lineWidth),
-    truncateForDisplay(`File: ${fileLabel}`, lineWidth),
+    bar,
+    `Step: ${progress.message}`,
+    `File: ${fileLabel}`,
+    typeof progress.detail === 'string' && progress.detail.length > 0 ? `Detail: ${progress.detail}` : '',
   ];
-  if (typeof progress.detail === 'string' && progress.detail.length > 0) {
-    lines.push(truncateForDisplay(`Detail: ${progress.detail}`, lineWidth));
+  return rawLines.map((line, index) =>
+    options.stageFileImage
+      ? stylePlayLoadingOverlayLineOnImage(line, lineWidth, index, options.stageFileImage)
+      : stylePlayLoadingOverlayFallbackLine(line, lineWidth),
+  );
+}
+
+export function createPlayLoadingProgressScreenOutput(
+  chartPath: string,
+  progress: PlayLoadingProgress,
+  options: {
+    columns?: number;
+    stageFileImage?: StageFileAnsiImage;
+    resetScreen?: boolean;
+    includeStageFileImage?: boolean;
+  } = {},
+): string {
+  const overlayLines = createPlayLoadingProgressScreenLines(chartPath, progress, {
+    columns: options.columns,
+    stageFileImage: options.stageFileImage,
+  });
+  const imageBlock =
+    options.includeStageFileImage !== false && options.stageFileImage && options.stageFileImage.lines.length > 0
+      ? `${options.stageFileImage.lines.join('\n')}\u001b[H`
+      : '';
+  const prefix = options.resetScreen === false ? '\u001b[H' : '\u001b[2J\u001b[H';
+  return `${prefix}${imageBlock}${overlayLines.join('\n')}`;
+}
+
+function renderPlayLoadingProgress(
+  chartPath: string,
+  progress: PlayLoadingProgress,
+  options: {
+    columns?: number;
+    stageFileImage?: StageFileAnsiImage;
+    state: PlayLoadingScreenRenderState;
+  },
+): void {
+  const shouldRedrawStageFile = Boolean(options.stageFileImage) && !options.state.stageFileDrawn;
+  const shouldResetScreen = !options.state.initialized || shouldRedrawStageFile;
+  const output = createPlayLoadingProgressScreenOutput(chartPath, progress, {
+    columns: options.columns,
+    stageFileImage: options.stageFileImage,
+    resetScreen: shouldResetScreen,
+    includeStageFileImage: shouldRedrawStageFile,
+  });
+  process.stdout.write(output);
+  options.state.initialized = true;
+  if (options.stageFileImage) {
+    options.state.stageFileDrawn = true;
   }
-  process.stdout.write(`\u001b[2J\u001b[H${lines.join('\n')}\u001b[J`);
+}
+
+function stylePlayLoadingOverlayFallbackLine(text: string, lineWidth: number): string {
+  return `\u001b[38;2;255;255;255;48;2;0;0;0m${truncateForDisplay(text, lineWidth).padEnd(lineWidth, ' ')}\u001b[0m`;
+}
+
+function stylePlayLoadingOverlayLineOnImage(
+  text: string,
+  lineWidth: number,
+  rowIndex: number,
+  stageFileImage: StageFileAnsiImage,
+): string {
+  const content = truncateForDisplay(text, lineWidth).padEnd(lineWidth, ' ');
+  if (rowIndex >= stageFileImage.height) {
+    return stylePlayLoadingOverlayFallbackLine(content, lineWidth);
+  }
+
+  let line = '';
+  let currentStyle = '';
+  for (let index = 0; index < content.length; index += 1) {
+    const bg = getStageFilePixel(stageFileImage, rowIndex, index);
+    const fg = resolveOverlayTextColor(bg.r, bg.g, bg.b);
+    const nextStyle = `\u001b[38;2;${fg.r};${fg.g};${fg.b};48;2;${bg.r};${bg.g};${bg.b}m`;
+    if (nextStyle !== currentStyle) {
+      line += nextStyle;
+      currentStyle = nextStyle;
+    }
+    line += content[index];
+  }
+  if (currentStyle.length > 0) {
+    line += '\u001b[0m';
+  }
+  return line;
+}
+
+function getStageFilePixel(
+  stageFileImage: StageFileAnsiImage,
+  rowIndex: number,
+  columnIndex: number,
+): { r: number; g: number; b: number } {
+  const x = Math.max(0, Math.min(stageFileImage.width - 1, columnIndex));
+  const y = Math.max(0, Math.min(stageFileImage.height - 1, rowIndex));
+  const rgbOffset = (y * stageFileImage.width + x) * 3;
+  return {
+    r: stageFileImage.rgb[rgbOffset] ?? 0,
+    g: stageFileImage.rgb[rgbOffset + 1] ?? 0,
+    b: stageFileImage.rgb[rgbOffset + 2] ?? 0,
+  };
+}
+
+function resolveOverlayTextColor(r: number, g: number, b: number): { r: 0 | 255; g: 0 | 255; b: 0 | 255 } {
+  const whiteContrast = calculateContrastRatio(r, g, b, 255, 255, 255);
+  const blackContrast = calculateContrastRatio(r, g, b, 0, 0, 0);
+  return whiteContrast >= blackContrast ? { r: 255, g: 255, b: 255 } : { r: 0, g: 0, b: 0 };
+}
+
+function calculateContrastRatio(
+  backgroundR: number,
+  backgroundG: number,
+  backgroundB: number,
+  foregroundR: number,
+  foregroundG: number,
+  foregroundB: number,
+): number {
+  const backgroundLuminance = calculateRelativeLuminance(backgroundR, backgroundG, backgroundB);
+  const foregroundLuminance = calculateRelativeLuminance(foregroundR, foregroundG, foregroundB);
+  const lighter = Math.max(backgroundLuminance, foregroundLuminance);
+  const darker = Math.min(backgroundLuminance, foregroundLuminance);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function calculateRelativeLuminance(r: number, g: number, b: number): number {
+  const red = convertSrgbChannelToLinear(r);
+  const green = convertSrgbChannelToLinear(g);
+  const blue = convertSrgbChannelToLinear(b);
+  return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+}
+
+function convertSrgbChannelToLinear(value: number): number {
+  const normalized = Math.max(0, Math.min(255, value)) / 255;
+  if (normalized <= 0.04045) {
+    return normalized / 12.92;
+  }
+  return ((normalized + 0.055) / 1.055) ** 2.4;
 }
 
 async function selectChartInteractively(

--- a/packages/player/src/node/node-gameplay-runtime.test.ts
+++ b/packages/player/src/node/node-gameplay-runtime.test.ts
@@ -108,6 +108,16 @@ afterEach(() => {
 });
 
 describe('node gameplay runtime', () => {
+  test('passes source resolution condition to the gameplay worker in source runs', async () => {
+    const promise = runNodeGameplayRuntime(createOptions());
+    const workerExecArgv = workerState.lastWorkerOptions?.execArgv;
+
+    expect(workerExecArgv).toContain('--conditions=source');
+
+    getLastWorker().emit('message', { kind: 'result', summary: createSummary() });
+    await promise;
+  });
+
   test('creates input runtime and forwards input commands to the gameplay worker', async () => {
     const promise = runNodeGameplayRuntime(createOptions());
     const worker = getLastWorker();

--- a/packages/player/src/node/node-gameplay-runtime.ts
+++ b/packages/player/src/node/node-gameplay-runtime.ts
@@ -36,7 +36,7 @@ export async function runNodeGameplayRuntime(options: NodeGameplayRuntimeOptions
 
   const worker = new Worker(resolveNodeGameplayWorkerUrl(), {
     workerData: createWorkerInitData(options),
-    execArgv: process.execArgv,
+    execArgv: resolveNodeGameplayWorkerExecArgv(),
     env: resolveNodeGameplayWorkerEnv(),
   });
   const writeOutput = options.writeOutput ?? ((text: string) => process.stdout.write(text));
@@ -262,6 +262,16 @@ function resolveNodeGameplayWorkerUrl(): URL {
     import.meta.url.endsWith('.ts') ? './node-gameplay-worker.ts' : './node-gameplay-worker.js',
     import.meta.url,
   );
+}
+
+function resolveNodeGameplayWorkerExecArgv(): string[] {
+  if (!import.meta.url.endsWith('.ts')) {
+    return process.execArgv;
+  }
+  if (process.execArgv.includes('--conditions=source')) {
+    return process.execArgv;
+  }
+  return [...process.execArgv, '--conditions=source'];
 }
 
 function resolveNodeGameplayWorkerEnv(): NodeJS.ProcessEnv {

--- a/packages/player/src/node/node-ui-runtime.test.ts
+++ b/packages/player/src/node/node-ui-runtime.test.ts
@@ -133,12 +133,14 @@ describe('node ui runtime', () => {
     const runtime = await createNodeUiRuntime(createContext(uiSignals));
     const workerEnv = workerState.lastWorkerOptions?.env;
     const workerEnvObject = typeof workerEnv === 'object' ? (workerEnv as NodeJS.ProcessEnv) : undefined;
+    const workerExecArgv = workerState.lastWorkerOptions?.execArgv;
     const workerData = workerState.lastWorkerOptions?.workerData as
       | { stdinIsTTY?: boolean; stdoutIsTTY?: boolean }
       | undefined;
 
     expect(typeof workerEnv).toBe('object');
     expect(workerEnvObject?.TSX_TSCONFIG_PATH).toContain('tsconfig.typecheck.json');
+    expect(workerExecArgv).toContain('--conditions=source');
     expect(workerData).toMatchObject({
       stdinIsTTY: Boolean(process.stdin.isTTY),
       stdoutIsTTY: Boolean(process.stdout.isTTY),

--- a/packages/player/src/node/node-ui-runtime.ts
+++ b/packages/player/src/node/node-ui-runtime.ts
@@ -44,7 +44,7 @@ export interface NodeUiRuntime {
 export async function createNodeUiRuntime(options: NodeUiRuntimeOptions): Promise<NodeUiRuntime> {
   const worker = new Worker(resolveNodeUiWorkerUrl(), {
     workerData: createWorkerInitData(options),
-    execArgv: process.execArgv,
+    execArgv: resolveNodeUiWorkerExecArgv(),
     env: resolveNodeUiWorkerEnv(),
   });
   const workerReady = await waitForWorkerReady(worker, options.loadSignal, options.onBgaLoadProgress);
@@ -266,6 +266,16 @@ function createWorkerInitData(options: NodeUiRuntimeOptions): NodeUiWorkerInitDa
 
 function resolveNodeUiWorkerUrl(): URL {
   return new URL(import.meta.url.endsWith('.ts') ? './node-ui-worker.ts' : './node-ui-worker.js', import.meta.url);
+}
+
+function resolveNodeUiWorkerExecArgv(): string[] {
+  if (!import.meta.url.endsWith('.ts')) {
+    return process.execArgv;
+  }
+  if (process.execArgv.includes('--conditions=source')) {
+    return process.execArgv;
+  }
+  return [...process.execArgv, '--conditions=source'];
 }
 
 function resolveNodeUiWorkerEnv(): NodeJS.ProcessEnv {

--- a/packages/stringifier/package.json
+++ b/packages/stringifier/package.json
@@ -14,6 +14,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -11,6 +11,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },


### PR DESCRIPTION
## Summary
- show `#STAGEFILE` as a full-screen loading splash with image-backed overlay text
- keep `#STAGEFILE` loading-only and leave gameplay BGA black until a base cue is active
- make player worker source runs resolve workspace packages through `source` exports

## Verification
- `./node_modules/.bin/vitest run packages/parser/src/index.test.ts packages/player/src/bga.test.ts packages/player/src/cli.test.ts packages/player/src/node/node-gameplay-runtime.test.ts packages/player/src/node/node-ui-runtime.test.ts`
- `./node_modules/.bin/tsgo -p packages/player/tsconfig.typecheck.json --pretty`
- `./node_modules/.bin/tsgo -p packages/parser/tsconfig.typecheck.json --pretty`