### PR TITLE
refactor(player): extract shared playback setup

### DIFF
--- a/packages/player/src/core/player-engine.ts
+++ b/packages/player/src/core/player-engine.ts
@@ -221,6 +221,28 @@ interface AudioLeadTuning {
   stepDownMs: number;
 }
 
+type PlayerRenderNote = TimedPlayableNote | TimedLandmineNote;
+
+interface PreparedPlaybackChartData {
+  notes: TimedPlayableNote[];
+  landmineNotes: TimedLandmineNote[];
+  invisibleNotes: TimedPlayableNote[];
+  renderNotes: PlayerRenderNote[];
+  totalSeconds: number;
+  laneBindings: LaneBinding[];
+  laneDisplayMode: string;
+  activeFreeZoneChannels: ReadonlySet<string>;
+  scorableNotes: TimedPlayableNote[];
+  inputTokenToChannels: ReadonlyMap<string, readonly string[]>;
+}
+
+interface InitializedPlayerUiRuntime {
+  uiRuntime: PlayerUiRuntime | undefined;
+  totalSeconds: number;
+  uiEnabled: boolean;
+  activeStateSignals: PlayerStateSignals | undefined;
+}
+
 interface OutputDynamicsConfig {
   compressorEnabled: boolean;
   compressorThresholdLinear: number;
@@ -666,6 +688,109 @@ function createInitialPlayerSummary(
   };
 }
 
+function preparePlaybackChartData(
+  resolvedJson: BeMusicJson,
+  options: Pick<PlayerOptions, 'showInvisibleNotes' | 'laneModeExtension'>,
+  inferBmsLnTypeWhenMissing: boolean,
+  auxiliaryPlaybackEndSeconds: number,
+): PreparedPlaybackChartData {
+  const extractedNotes = extractTimedNotes(resolvedJson, {
+    includeLandmine: true,
+    includeInvisible: options.showInvisibleNotes === true,
+    inferBmsLnTypeWhenMissing,
+  });
+  const notes = extractedNotes.playableNotes;
+  const landmineNotes = extractedNotes.landmineNotes;
+  const invisibleNotes = extractedNotes.invisibleNotes;
+  const renderNotes = mergeRenderNotesBySeconds(notes, landmineNotes, invisibleNotes);
+  const totalSeconds = Math.max(
+    resolvePlayableNotesTailSeconds(notes),
+    landmineNotes.at(-1)?.seconds ?? 0,
+    invisibleNotes.at(-1)?.seconds ?? 0,
+    auxiliaryPlaybackEndSeconds,
+  );
+  const channels = collectUniqueNoteChannels(notes, landmineNotes, invisibleNotes);
+  const laneModeOptions = { player: resolvedJson.bms.player, chartExtension: options.laneModeExtension };
+  const laneBindings = createLaneBindings(channels, laneModeOptions);
+  const inputTokenToChannels = createInputTokenToChannelsMap(laneBindings);
+  appendFreeZoneInputChannels(inputTokenToChannels, laneBindings, channels);
+  const laneDisplayMode = resolveLaneDisplayMode(channels, laneModeOptions);
+  const activeFreeZoneChannels = resolveActiveFreeZoneChannels(channels, laneBindings);
+  const scorableNotes = notes.filter((note) => !isActiveFreeZoneChannel(note.channel, activeFreeZoneChannels));
+
+  return {
+    notes,
+    landmineNotes,
+    invisibleNotes,
+    renderNotes,
+    totalSeconds,
+    laneBindings,
+    laneDisplayMode,
+    activeFreeZoneChannels,
+    scorableNotes,
+    inputTokenToChannels,
+  };
+}
+
+async function initializePlayerUiRuntime({
+  options,
+  resolvedJson,
+  mode,
+  laneDisplayMode,
+  laneBindings,
+  speed,
+  judgeWindowMs,
+  highSpeed,
+  randomPatternSummary,
+  stateSignals,
+  uiSignals,
+  totalSeconds,
+}: {
+  options: PlayerOptions;
+  resolvedJson: BeMusicJson;
+  mode: CreatePlayerUiRuntimeContext['mode'];
+  laneDisplayMode: string;
+  laneBindings: LaneBinding[];
+  speed: number;
+  judgeWindowMs: number;
+  highSpeed: number;
+  randomPatternSummary: string | undefined;
+  stateSignals: PlayerStateSignals;
+  uiSignals: PlayerUiSignalBus;
+  totalSeconds: number;
+}): Promise<InitializedPlayerUiRuntime> {
+  throwIfAborted(options.signal);
+  reportLoadProgress(options, 0.18, 'Preparing BGA...');
+  const uiRuntime = await options.createUiRuntime?.({
+    json: resolvedJson,
+    mode,
+    laneDisplayMode,
+    laneBindings,
+    speed,
+    judgeWindowMs,
+    highSpeed,
+    showLaneChannels: options.debugActiveAudio === true,
+    randomPatternSummary,
+    stateSignals,
+    uiSignals,
+    baseDir: options.audioBaseDir ?? process.cwd(),
+    loadSignal: options.signal,
+    onBgaLoadProgress: (progress) => {
+      reportLoadProgress(options, 0.18 + progress.ratio * 0.12, 'Preparing BGA...', progress.detail);
+    },
+  });
+  throwIfAborted(options.signal);
+  const updatedTotalSeconds = Math.max(totalSeconds, uiRuntime?.playbackEndSeconds ?? 0);
+  const uiEnabled = uiRuntime?.tuiEnabled === true;
+
+  return {
+    uiRuntime,
+    totalSeconds: updatedTotalSeconds,
+    uiEnabled,
+    activeStateSignals: uiEnabled ? stateSignals : undefined,
+  };
+}
+
 export async function autoPlay(json: BeMusicJson, options: PlayerOptions = {}): Promise<PlayerSummary> {
   throwIfAborted(options.signal);
   const writeOutput = resolveOutputWriter(options);
@@ -683,30 +808,27 @@ export async function autoPlay(json: BeMusicJson, options: PlayerOptions = {}): 
   const realtimeAudioTriggers = collectRealtimeAudioTriggers(resolvedJson, inferBmsLnTypeWhenMissing);
   const realtimeAudioEndSeconds =
     options.audio === false ? 0 : Math.max(realtimeAudioTriggers.at(-1)?.seconds ?? 0, realtimeAudioVolumeEvents.at(-1)?.seconds ?? 0);
-
-  const extractedNotes = extractTimedNotes(resolvedJson, {
-    includeLandmine: true,
-    includeInvisible: options.showInvisibleNotes === true,
+  const playbackChart = preparePlaybackChartData(
+    resolvedJson,
+    {
+      showInvisibleNotes: options.showInvisibleNotes,
+      laneModeExtension: options.laneModeExtension,
+    },
     inferBmsLnTypeWhenMissing,
-  });
-  const notes = extractedNotes.playableNotes;
-  const landmineNotes = extractedNotes.landmineNotes;
-  const invisibleNotes = extractedNotes.invisibleNotes;
-  const renderNotes = mergeRenderNotesBySeconds(notes, landmineNotes, invisibleNotes);
-  let totalSeconds = Math.max(
-    resolvePlayableNotesTailSeconds(notes),
-    landmineNotes.at(-1)?.seconds ?? 0,
-    invisibleNotes.at(-1)?.seconds ?? 0,
     realtimeAudioEndSeconds,
   );
-  const channels = collectUniqueNoteChannels(notes, landmineNotes, invisibleNotes);
-  const laneModeOptions = { player: resolvedJson.bms.player, chartExtension: options.laneModeExtension };
-  const laneBindings = createLaneBindings(channels, laneModeOptions);
-  const inputTokenToChannels = createInputTokenToChannelsMap(laneBindings);
-  appendFreeZoneInputChannels(inputTokenToChannels, laneBindings, channels);
-  const laneDisplayMode = resolveLaneDisplayMode(channels, laneModeOptions);
-  const activeFreeZoneChannels = resolveActiveFreeZoneChannels(channels, laneBindings);
-  const scorableNotes = notes.filter((note) => !isActiveFreeZoneChannel(note.channel, activeFreeZoneChannels));
+  const {
+    notes,
+    landmineNotes,
+    invisibleNotes,
+    renderNotes,
+    laneBindings,
+    laneDisplayMode,
+    activeFreeZoneChannels,
+    scorableNotes,
+    inputTokenToChannels,
+  } = playbackChart;
+  let { totalSeconds } = playbackChart;
   const keyMap = new Map(laneBindings.map((binding) => [binding.channel, binding.keyLabel]));
   const { summary, applyGaugeJudge } = createInitialPlayerSummary(scorableNotes.length, resolvedJson.metadata.total);
   const scoreTracker = createScoreTracker();
@@ -722,31 +844,26 @@ export async function autoPlay(json: BeMusicJson, options: PlayerOptions = {}): 
     notes: renderNotes,
   });
   const inputSignals = createPlayerInputSignalBus();
-
-  throwIfAborted(options.signal);
-  reportLoadProgress(options, 0.18, 'Preparing BGA...');
-  const uiRuntime = await options.createUiRuntime?.({
-    json: resolvedJson,
+  const {
+    uiRuntime,
+    totalSeconds: playbackTotalSeconds,
+    uiEnabled,
+    activeStateSignals,
+  } = await initializePlayerUiRuntime({
+    options,
+    resolvedJson,
     mode: 'AUTO',
     laneDisplayMode,
     laneBindings,
     speed,
     judgeWindowMs: 0,
     highSpeed,
-    showLaneChannels: options.debugActiveAudio === true,
     randomPatternSummary,
     stateSignals,
     uiSignals,
-    baseDir: options.audioBaseDir ?? process.cwd(),
-    loadSignal: options.signal,
-    onBgaLoadProgress: (progress) => {
-      reportLoadProgress(options, 0.18 + progress.ratio * 0.12, 'Preparing BGA...', progress.detail);
-    },
+    totalSeconds,
   });
-  throwIfAborted(options.signal);
-  totalSeconds = Math.max(totalSeconds, uiRuntime?.playbackEndSeconds ?? 0);
-  const uiEnabled = uiRuntime?.tuiEnabled === true;
-  const activeStateSignals = uiEnabled ? stateSignals : undefined;
+  totalSeconds = playbackTotalSeconds;
 
   const inputRuntime = options.createInputRuntime?.({
     mode: 'auto',
@@ -1124,33 +1241,30 @@ export async function manualPlay(json: BeMusicJson, options: PlayerOptions = {})
     options.audio === false
       ? 0
       : Math.max(nonPlayableRealtimeAudioTriggers.at(-1)?.seconds ?? 0, realtimeAudioVolumeEvents.at(-1)?.seconds ?? 0);
-
-  const extractedNotes = extractTimedNotes(resolvedJson, {
-    includeLandmine: true,
-    includeInvisible: options.showInvisibleNotes === true,
+  const playbackChart = preparePlaybackChartData(
+    resolvedJson,
+    {
+      showInvisibleNotes: options.showInvisibleNotes,
+      laneModeExtension: options.laneModeExtension,
+    },
     inferBmsLnTypeWhenMissing,
-  });
-  const notes = extractedNotes.playableNotes;
-  const landmineNotes = extractedNotes.landmineNotes;
-  const invisibleNotes = extractedNotes.invisibleNotes;
-  const renderNotes = mergeRenderNotesBySeconds(notes, landmineNotes, invisibleNotes);
-  let totalSeconds = Math.max(
-    resolvePlayableNotesTailSeconds(notes),
-    landmineNotes.at(-1)?.seconds ?? 0,
-    invisibleNotes.at(-1)?.seconds ?? 0,
     nonPlayableRealtimeAudioEndSeconds,
   );
-  const channels = collectUniqueNoteChannels(notes, landmineNotes, invisibleNotes);
-  const laneModeOptions = { player: resolvedJson.bms.player, chartExtension: options.laneModeExtension };
-  const laneBindings = createLaneBindings(channels, laneModeOptions);
-  const laneDisplayMode = resolveLaneDisplayMode(channels, laneModeOptions);
-  const activeFreeZoneChannels = resolveActiveFreeZoneChannels(channels, laneBindings);
-  const scorableNotes = notes.filter((note) => !isActiveFreeZoneChannel(note.channel, activeFreeZoneChannels));
+  const {
+    notes,
+    landmineNotes,
+    invisibleNotes,
+    renderNotes,
+    laneBindings,
+    laneDisplayMode,
+    activeFreeZoneChannels,
+    scorableNotes,
+    inputTokenToChannels,
+  } = playbackChart;
+  let { totalSeconds } = playbackChart;
   const scratchPlayableChannels = new Set(
     laneBindings.filter((binding) => binding.isScratch).map((binding) => binding.channel),
   );
-  const inputTokenToChannels = createInputTokenToChannelsMap(laneBindings);
-  appendFreeZoneInputChannels(inputTokenToChannels, laneBindings, channels);
 
   const { summary, applyGaugeJudge, applyGaugeDelta } = createInitialPlayerSummary(
     scorableNotes.length,
@@ -1168,31 +1282,26 @@ export async function manualPlay(json: BeMusicJson, options: PlayerOptions = {})
     notes: renderNotes,
   });
   const inputSignals = createPlayerInputSignalBus();
-
-  throwIfAborted(options.signal);
-  reportLoadProgress(options, 0.18, 'Preparing BGA...');
-  const uiRuntime = await options.createUiRuntime?.({
-    json: resolvedJson,
+  const {
+    uiRuntime,
+    totalSeconds: playbackTotalSeconds,
+    uiEnabled,
+    activeStateSignals,
+  } = await initializePlayerUiRuntime({
+    options,
+    resolvedJson,
     mode: autoScratchEnabled ? 'AUTO SCRATCH' : 'MANUAL',
     laneDisplayMode,
     laneBindings,
     speed,
     judgeWindowMs: badWindowMs,
     highSpeed,
-    showLaneChannels: options.debugActiveAudio === true,
     randomPatternSummary,
     stateSignals,
     uiSignals,
-    baseDir: options.audioBaseDir ?? process.cwd(),
-    loadSignal: options.signal,
-    onBgaLoadProgress: (progress) => {
-      reportLoadProgress(options, 0.18 + progress.ratio * 0.12, 'Preparing BGA...', progress.detail);
-    },
+    totalSeconds,
   });
-  throwIfAborted(options.signal);
-  totalSeconds = Math.max(totalSeconds, uiRuntime?.playbackEndSeconds ?? 0);
-  const uiEnabled = uiRuntime?.tuiEnabled === true;
-  const activeStateSignals = uiEnabled ? stateSignals : undefined;
+  totalSeconds = playbackTotalSeconds;
 
   const inputRuntime = options.createInputRuntime?.({
     mode: 'manual',
@@ -2991,8 +3100,8 @@ function mergeRenderNotesBySeconds(
   notes: ReadonlyArray<TimedPlayableNote>,
   landmineNotes: ReadonlyArray<TimedLandmineNote>,
   invisibleNotes: ReadonlyArray<TimedPlayableNote>,
-): Array<TimedPlayableNote | TimedLandmineNote> {
-  const merged: Array<TimedPlayableNote | TimedLandmineNote> = [];
+): PlayerRenderNote[] {
+  const merged: PlayerRenderNote[] = [];
   let noteIndex = 0;
   let landmineIndex = 0;
   let invisibleIndex = 0;

--- a/packages/player/src/core/player-engine.ts
+++ b/packages/player/src/core/player-engine.ts
@@ -20,6 +20,7 @@ import {
   type RenderResult,
   type RenderSampleLoadProgress,
   type TimedSampleTrigger,
+  type TimingResolver,
   collectSampleTriggers,
   createTimingResolver,
   renderSingleSample,
@@ -64,7 +65,7 @@ import {
   type GrooveGaugeJudgeKind,
 } from './groove-gauge.ts';
 import { resolveBmsJudgeWindowsMsForPercent, resolveJudgeWindowsMs } from './judge-window.ts';
-import { createBeatAtSecondsResolver } from './timeline.ts';
+import { createBeatAtSecondsResolverFromTimingResolver } from './timeline.ts';
 
 export interface PlayerUiRuntime {
   readonly tuiEnabled: boolean;
@@ -566,11 +567,13 @@ interface TimedAudioVolumeEvent {
   seconds: number;
 }
 
-function collectDynamicBmsJudgeRankChanges(json: BeMusicJson): DynamicBmsJudgeRankChange[] {
+function collectDynamicBmsJudgeRankChanges(
+  json: BeMusicJson,
+  resolver: TimingResolver = createTimingResolver(json),
+): DynamicBmsJudgeRankChange[] {
   if (json.sourceFormat !== 'bms') {
     return [];
   }
-  const resolver = createTimingResolver(json);
   const changes: DynamicBmsJudgeRankChange[] = [];
   for (const event of sortEvents(json.events)) {
     if (normalizeChannel(event.channel) !== 'A0') {
@@ -589,11 +592,13 @@ function collectDynamicBmsJudgeRankChanges(json: BeMusicJson): DynamicBmsJudgeRa
   return changes;
 }
 
-function collectRealtimeAudioVolumeEvents(json: BeMusicJson): TimedAudioVolumeEvent[] {
+function collectRealtimeAudioVolumeEvents(
+  json: BeMusicJson,
+  resolver: TimingResolver = createTimingResolver(json),
+): TimedAudioVolumeEvent[] {
   if (json.sourceFormat !== 'bms') {
     return [];
   }
-  const resolver = createTimingResolver(json);
   const events: TimedAudioVolumeEvent[] = [];
   for (const event of sortEvents(json.events)) {
     if (!isBmsDynamicVolumeChangeChannel(event.channel)) {
@@ -803,9 +808,15 @@ export async function autoPlay(json: BeMusicJson, options: PlayerOptions = {}): 
   const speed = options.speed ?? 1;
   const leadInMs = options.leadInMs ?? 1500;
   const audioOffsetMs = options.audioOffsetMs ?? 0;
-  const beatAtSeconds = createBeatAtSecondsResolver(resolvedJson);
-  const realtimeAudioVolumeEvents = collectRealtimeAudioVolumeEvents(resolvedJson);
-  const realtimeAudioTriggers = collectRealtimeAudioTriggers(resolvedJson, inferBmsLnTypeWhenMissing);
+  const timingResolver = createTimingResolver(resolvedJson);
+  const beatAtSeconds = createBeatAtSecondsResolverFromTimingResolver(timingResolver);
+  const realtimeAudioVolumeEvents = collectRealtimeAudioVolumeEvents(resolvedJson, timingResolver);
+  const realtimeAudioTriggers = collectRealtimeAudioTriggers(
+    resolvedJson,
+    inferBmsLnTypeWhenMissing,
+    undefined,
+    timingResolver,
+  );
   const realtimeAudioEndSeconds =
     options.audio === false ? 0 : Math.max(realtimeAudioTriggers.at(-1)?.seconds ?? 0, realtimeAudioVolumeEvents.at(-1)?.seconds ?? 0);
   const playbackChart = preparePlaybackChartData(
@@ -1219,8 +1230,9 @@ export async function manualPlay(json: BeMusicJson, options: PlayerOptions = {})
   let judgeWindows = resolveJudgeWindowsMs(resolvedJson, options.judgeWindowMs);
   let badWindowMs = judgeWindows.bad;
   let badWindowSeconds = badWindowMs / 1000;
-  const dynamicJudgeRankChanges = collectDynamicBmsJudgeRankChanges(resolvedJson);
-  const realtimeAudioVolumeEvents = collectRealtimeAudioVolumeEvents(resolvedJson);
+  const timingResolver = createTimingResolver(resolvedJson);
+  const dynamicJudgeRankChanges = collectDynamicBmsJudgeRankChanges(resolvedJson, timingResolver);
+  const realtimeAudioVolumeEvents = collectRealtimeAudioVolumeEvents(resolvedJson, timingResolver);
   let dynamicJudgeRankCursor = 0;
   let maxBadWindowMs = badWindowMs;
   for (const change of dynamicJudgeRankChanges) {
@@ -1231,11 +1243,12 @@ export async function manualPlay(json: BeMusicJson, options: PlayerOptions = {})
   }
   const leadInMs = options.leadInMs ?? 1500;
   const audioOffsetMs = options.audioOffsetMs ?? 0;
-  const beatAtSeconds = createBeatAtSecondsResolver(resolvedJson);
+  const beatAtSeconds = createBeatAtSecondsResolverFromTimingResolver(timingResolver);
   const nonPlayableRealtimeAudioTriggers = collectRealtimeAudioTriggers(
     resolvedJson,
     inferBmsLnTypeWhenMissing,
     (channel) => !isPlayLaneSoundChannel(channel),
+    timingResolver,
   );
   const nonPlayableRealtimeAudioEndSeconds =
     options.audio === false
@@ -2944,8 +2957,8 @@ function collectRealtimeAudioTriggers(
   json: BeMusicJson,
   inferBmsLnTypeWhenMissing: boolean,
   includeChannel: (channel: string) => boolean = () => true,
+  resolver: TimingResolver = createTimingResolver(json),
 ): Array<TimedSampleTrigger & RealtimeAudioTrigger> {
-  const resolver = createTimingResolver(json);
   const triggers = collectSampleTriggers(json, resolver, { inferBmsLnTypeWhenMissing });
   const filtered: Array<TimedSampleTrigger & RealtimeAudioTrigger> = [];
   for (const trigger of triggers) {

--- a/packages/player/src/core/timeline.ts
+++ b/packages/player/src/core/timeline.ts
@@ -142,6 +142,10 @@ export function createSpeedTimeline(json: BeMusicJson, beatResolver: BeatResolve
 
 export function createBeatAtSecondsResolver(json: BeMusicJson): (seconds: number) => number {
   const resolver = createTimingResolver(json);
+  return createBeatAtSecondsResolverFromTimingResolver(resolver);
+}
+
+export function createBeatAtSecondsResolverFromTimingResolver(resolver: TimingResolver): (seconds: number) => number {
   const stopWindows = createStopBeatWindows(resolver);
   let lastSeconds = Number.NEGATIVE_INFINITY;
   let stopCursor = 0;

--- a/packages/player/src/index.test.ts
+++ b/packages/player/src/index.test.ts
@@ -11,6 +11,7 @@ import {
   extractInvisiblePlayableNotes,
   extractLandmineNotes,
   extractPlayableNotes,
+  extractTimedNotes,
   manualPlay,
   resolveBgmHeadroomGain,
   shouldUseAutoMixBgmHeadroomControl,
@@ -598,6 +599,65 @@ describe('player', () => {
     expect(invisible[0]?.channel).toBe('11');
     expect(invisible[1]?.channel).toBe('24');
     expect(invisible[0]?.invisible).toBe(true);
+  });
+
+  test('player: extractTimedNotes matches the individual extraction helpers', () => {
+    const json = createEmptyJson('bms');
+    json.metadata.bpm = 120;
+    json.events = [
+      { measure: 0, channel: '31', position: [0, 4], value: '10' },
+      { measure: 0, channel: '11', position: [1, 4], value: '01' },
+      { measure: 1, channel: 'D2', position: [0, 1], value: '20' },
+      { measure: 2, channel: '44', position: [0, 1], value: '30' },
+    ];
+
+    const timed = extractTimedNotes(json, {
+      includeLandmine: true,
+      includeInvisible: true,
+    });
+    const snapshot = {
+      playableNotes: timed.playableNotes.map((note) => ({
+        channel: note.channel,
+        beat: note.beat,
+        endBeat: note.endBeat,
+        invisible: note.invisible,
+        mine: (note as { mine?: boolean }).mine,
+      })),
+      landmineNotes: timed.landmineNotes.map((note) => ({
+        channel: note.channel,
+        beat: note.beat,
+        mine: note.mine,
+      })),
+      invisibleNotes: timed.invisibleNotes.map((note) => ({
+        channel: note.channel,
+        beat: note.beat,
+        invisible: note.invisible,
+      })),
+    };
+
+    expect(snapshot.playableNotes).toEqual(
+      extractPlayableNotes(json).map((note) => ({
+        channel: note.channel,
+        beat: note.beat,
+        endBeat: note.endBeat,
+        invisible: note.invisible,
+        mine: (note as { mine?: boolean }).mine,
+      })),
+    );
+    expect(snapshot.landmineNotes).toEqual(
+      extractLandmineNotes(json).map((note) => ({
+        channel: note.channel,
+        beat: note.beat,
+        mine: note.mine,
+      })),
+    );
+    expect(snapshot.invisibleNotes).toEqual(
+      extractInvisiblePlayableNotes(json).map((note) => ({
+        channel: note.channel,
+        beat: note.beat,
+        invisible: note.invisible,
+      })),
+    );
   });
 
   test('player: assigns quarter-note length to free-zone notes', () => {

--- a/packages/player/src/playable-notes.ts
+++ b/packages/player/src/playable-notes.ts
@@ -66,6 +66,7 @@ export function extractTimedNotes(
 ): ExtractTimedNotesResult {
   const context = createTimedExtractionContext(json);
   const { playableNotes, landmineNotes, invisibleNotes } = collectTimedNotes(context, {
+    includePlayable: true,
     includeLandmine: options.includeLandmine !== false,
     includeInvisible: options.includeInvisible === true,
   });
@@ -83,17 +84,23 @@ export function extractPlayableNotes(
   options: ExtractPlayableNotesOptions = {},
 ): TimedPlayableNote[] {
   const context = createTimedExtractionContext(json);
-  const { playableNotes } = collectTimedNotes(context);
+  const { playableNotes } = collectTimedNotes(context, { includePlayable: true });
   finalizePlayableNotes(json, playableNotes, context.resolver, options);
   return playableNotes;
 }
 
 export function extractLandmineNotes(json: BeMusicJson): TimedLandmineNote[] {
-  return collectTimedNotes(createTimedExtractionContext(json), { includeLandmine: true }).landmineNotes;
+  return collectTimedNotes(createTimedExtractionContext(json), {
+    includePlayable: false,
+    includeLandmine: true,
+  }).landmineNotes;
 }
 
 export function extractInvisiblePlayableNotes(json: BeMusicJson): TimedPlayableNote[] {
-  return collectTimedNotes(createTimedExtractionContext(json), { includeInvisible: true }).invisibleNotes;
+  return collectTimedNotes(createTimedExtractionContext(json), {
+    includePlayable: false,
+    includeInvisible: true,
+  }).invisibleNotes;
 }
 
 function createTimedExtractionContext(json: BeMusicJson): TimedExtractionContext {
@@ -108,10 +115,12 @@ function createTimedExtractionContext(json: BeMusicJson): TimedExtractionContext
 function collectTimedNotes(
   context: TimedExtractionContext,
   options: {
+    includePlayable?: boolean;
     includeLandmine?: boolean;
     includeInvisible?: boolean;
   } = {},
 ): ExtractTimedNotesResult {
+  const includePlayable = options.includePlayable !== false;
   const includeLandmine = options.includeLandmine === true;
   const includeInvisible = options.includeInvisible === true;
   const playableNotes: TimedPlayableNote[] = [];
@@ -120,7 +129,7 @@ function collectTimedNotes(
 
   for (const event of context.sortedEvents) {
     const normalizedChannel = normalizeChannel(event.channel);
-    const playableChannel = isPlayableChannel(normalizedChannel) ? normalizedChannel : undefined;
+    const playableChannel = includePlayable && isPlayableChannel(normalizedChannel) ? normalizedChannel : undefined;
     const landmineChannel = includeLandmine
       ? mapLandmineNormalizedChannelToPlayableLane(normalizedChannel)
       : undefined;

--- a/packages/player/src/playable-notes.ts
+++ b/packages/player/src/playable-notes.ts
@@ -64,12 +64,11 @@ export function extractTimedNotes(
   json: BeMusicJson,
   options: ExtractTimedNotesOptions = {},
 ): ExtractTimedNotesResult {
-  const includeLandmine = options.includeLandmine !== false;
-  const includeInvisible = options.includeInvisible === true;
   const context = createTimedExtractionContext(json);
-  const playableNotes = collectPlayableNotes(context);
-  const landmineNotes = includeLandmine ? collectLandmineNotes(context) : [];
-  const invisibleNotes = includeInvisible ? collectInvisibleNotes(context) : [];
+  const { playableNotes, landmineNotes, invisibleNotes } = collectTimedNotes(context, {
+    includeLandmine: options.includeLandmine !== false,
+    includeInvisible: options.includeInvisible === true,
+  });
 
   finalizePlayableNotes(json, playableNotes, context.resolver, options);
   return {
@@ -84,17 +83,17 @@ export function extractPlayableNotes(
   options: ExtractPlayableNotesOptions = {},
 ): TimedPlayableNote[] {
   const context = createTimedExtractionContext(json);
-  const playableNotes = collectPlayableNotes(context);
+  const { playableNotes } = collectTimedNotes(context);
   finalizePlayableNotes(json, playableNotes, context.resolver, options);
   return playableNotes;
 }
 
 export function extractLandmineNotes(json: BeMusicJson): TimedLandmineNote[] {
-  return collectLandmineNotes(createTimedExtractionContext(json));
+  return collectTimedNotes(createTimedExtractionContext(json), { includeLandmine: true }).landmineNotes;
 }
 
 export function extractInvisiblePlayableNotes(json: BeMusicJson): TimedPlayableNote[] {
-  return collectInvisibleNotes(createTimedExtractionContext(json));
+  return collectTimedNotes(createTimedExtractionContext(json), { includeInvisible: true }).invisibleNotes;
 }
 
 function createTimedExtractionContext(json: BeMusicJson): TimedExtractionContext {
@@ -106,70 +105,78 @@ function createTimedExtractionContext(json: BeMusicJson): TimedExtractionContext
   };
 }
 
-function collectPlayableNotes(context: TimedExtractionContext): TimedPlayableNote[] {
-  const notes: TimedPlayableNote[] = [];
+function collectTimedNotes(
+  context: TimedExtractionContext,
+  options: {
+    includeLandmine?: boolean;
+    includeInvisible?: boolean;
+  } = {},
+): ExtractTimedNotesResult {
+  const includeLandmine = options.includeLandmine === true;
+  const includeInvisible = options.includeInvisible === true;
+  const playableNotes: TimedPlayableNote[] = [];
+  const landmineNotes: TimedLandmineNote[] = [];
+  const invisibleNotes: TimedPlayableNote[] = [];
+
   for (const event of context.sortedEvents) {
     const normalizedChannel = normalizeChannel(event.channel);
-    if (!isPlayableChannel(normalizedChannel)) {
+    const playableChannel = isPlayableChannel(normalizedChannel) ? normalizedChannel : undefined;
+    const landmineChannel = includeLandmine
+      ? mapLandmineNormalizedChannelToPlayableLane(normalizedChannel)
+      : undefined;
+    const invisibleChannel = includeInvisible
+      ? mapInvisibleNormalizedChannelToPlayableLane(normalizedChannel)
+      : undefined;
+
+    if (!playableChannel && !landmineChannel && !invisibleChannel) {
       continue;
     }
 
     const beat = context.beatResolver.eventToBeat(event);
-    const endBeat = resolveLongNoteEndBeat(event, beat, normalizedChannel, context.bmsonResolution);
-    notes.push({
-      event,
-      channel: normalizedChannel,
-      beat,
-      endBeat,
-      endSeconds: endBeat !== undefined ? context.resolver.beatToSeconds(endBeat) : undefined,
-      longNoteMode: endBeat !== undefined ? DEFAULT_OTHER_LONG_NOTE_MODE : undefined,
-      seconds: context.resolver.beatToSeconds(beat),
-      judged: false,
-    });
-  }
-  return notes;
-}
+    const seconds = context.resolver.beatToSeconds(beat);
 
-function collectLandmineNotes(context: TimedExtractionContext): TimedLandmineNote[] {
-  const notes: TimedLandmineNote[] = [];
-  for (const event of context.sortedEvents) {
-    const mappedChannel = mapLandmineNormalizedChannelToPlayableLane(normalizeChannel(event.channel));
-    if (!mappedChannel) {
-      continue;
+    if (playableChannel) {
+      const endBeat = resolveLongNoteEndBeat(event, beat, playableChannel, context.bmsonResolution);
+      playableNotes.push({
+        event,
+        channel: playableChannel,
+        beat,
+        endBeat,
+        endSeconds: endBeat !== undefined ? context.resolver.beatToSeconds(endBeat) : undefined,
+        longNoteMode: endBeat !== undefined ? DEFAULT_OTHER_LONG_NOTE_MODE : undefined,
+        seconds,
+        judged: false,
+      });
     }
 
-    const beat = context.beatResolver.eventToBeat(event);
-    notes.push({
-      event,
-      channel: mappedChannel,
-      beat,
-      seconds: context.resolver.beatToSeconds(beat),
-      judged: false,
-      mine: true,
-    });
-  }
-  return notes;
-}
-
-function collectInvisibleNotes(context: TimedExtractionContext): TimedPlayableNote[] {
-  const notes: TimedPlayableNote[] = [];
-  for (const event of context.sortedEvents) {
-    const mappedChannel = mapInvisibleNormalizedChannelToPlayableLane(normalizeChannel(event.channel));
-    if (!mappedChannel) {
-      continue;
+    if (landmineChannel) {
+      landmineNotes.push({
+        event,
+        channel: landmineChannel,
+        beat,
+        seconds,
+        judged: false,
+        mine: true,
+      });
     }
 
-    const beat = context.beatResolver.eventToBeat(event);
-    notes.push({
-      event,
-      channel: mappedChannel,
-      beat,
-      seconds: context.resolver.beatToSeconds(beat),
-      judged: false,
-      invisible: true,
-    });
+    if (invisibleChannel) {
+      invisibleNotes.push({
+        event,
+        channel: invisibleChannel,
+        beat,
+        seconds,
+        judged: false,
+        invisible: true,
+      });
+    }
   }
-  return notes;
+
+  return {
+    playableNotes,
+    landmineNotes,
+    invisibleNotes,
+  };
 }
 
 function finalizePlayableNotes(


### PR DESCRIPTION
## Summary
- extract shared playback chart preparation used by auto and manual play
- extract shared UI runtime initialization and playback end handling
- keep existing player behavior while reducing duplicated setup paths

## Testing
- ./node_modules/.bin/vitest run packages/player/src/index.test.ts packages/player/src/core/timeline.test.ts packages/player/src/tui/player-tui.test.ts packages/player/src/cli.test.ts
- ./node_modules/.bin/tsgo -p packages/player/tsconfig.typecheck.json --pretty