### PR TITLE
refactor(player): adopt alien-signals for selection and UI state

### DIFF
--- a/packages/player/src/cli/runner.ts
+++ b/packages/player/src/cli/runner.ts
@@ -62,6 +62,7 @@ import {
   type ChartSelectionEntry,
   type ChartSummaryLoadingProgress,
 } from './chart-selection.ts';
+import { createChartFocusKey, createSongSelectState, getEntryFocusKey } from './song-select-state.ts';
 import { createChartPreviewController, formatSongSelectAudioBackendLabel } from './chart-preview.ts';
 
 export {
@@ -1413,53 +1414,6 @@ function formatSongSelectDifficultyFilterLabel(value: SongSelectDifficultyFilter
   return typeof value === 'number' ? String(value) : 'ALL';
 }
 
-function filterChartSelectionEntries(
-  entries: readonly ChartSelectionEntry[],
-  difficultyFilter: SongSelectDifficultyFilter | undefined,
-): ChartSelectionEntry[] {
-  if (typeof difficultyFilter !== 'number') {
-    return [...entries];
-  }
-
-  const filtered: ChartSelectionEntry[] = [];
-  let pendingGroup: Extract<ChartSelectionEntry, { kind: 'group' }> | undefined;
-  let groupHasVisibleCharts = false;
-  let hasVisibleCharts = false;
-
-  const flushPendingGroup = (): void => {
-    if (pendingGroup && groupHasVisibleCharts) {
-      filtered.push(pendingGroup);
-    }
-    pendingGroup = undefined;
-    groupHasVisibleCharts = false;
-  };
-
-  for (const entry of entries) {
-    if (entry.kind === 'random') {
-      continue;
-    }
-    if (entry.kind === 'group') {
-      flushPendingGroup();
-      pendingGroup = entry;
-      continue;
-    }
-    if (entry.difficulty !== difficultyFilter) {
-      continue;
-    }
-    if (pendingGroup && !groupHasVisibleCharts) {
-      filtered.push(pendingGroup);
-      groupHasVisibleCharts = true;
-    }
-    filtered.push(entry);
-    hasVisibleCharts = true;
-  }
-
-  if (hasVisibleCharts) {
-    filtered.unshift({ kind: 'random', label: '[Random] Select a chart randomly' });
-  }
-  return filtered;
-}
-
 async function selectChartInteractively(
   rootDir: string,
   files: string[],
@@ -1479,65 +1433,18 @@ async function selectChartInteractively(
   let wasSpinnerVisible = false;
 
   const inputCapture = beginRawInputCapture();
-  let difficultyFilter = options.initialDifficultyFilter;
-  let playMode: PlayMode = options.initialPlayMode ?? 'manual';
-  let highSpeed = normalizeHighSpeedValue(options.initialHighSpeed);
-  let selectedIndex = 0;
-
-  const resolveSelectionView = () => {
-    const entries = filterChartSelectionEntries(allEntries, difficultyFilter);
-    const selectableIndexes = entries.flatMap((entry, index) => (entry.kind === 'group' ? [] : [index]));
-    const chartIndexes = entries.flatMap((entry, index) => (entry.kind === 'chart' ? [index] : []));
-    const selectableIndexByEntryIndex = new Map<number, number>();
-    const chartIndexByEntryIndex = new Map<number, number>();
-    for (let index = 0; index < selectableIndexes.length; index += 1) {
-      selectableIndexByEntryIndex.set(selectableIndexes[index]!, index);
-    }
-    for (let index = 0; index < chartIndexes.length; index += 1) {
-      chartIndexByEntryIndex.set(chartIndexes[index]!, index);
-    }
-    return {
-      entries,
-      selectableIndexes,
-      chartIndexes,
-      chartCount: chartIndexes.length,
-      chartFiles: entries.flatMap((entry) => (entry.kind === 'chart' ? [entry.filePath] : [])),
-      selectableIndexByEntryIndex,
-      chartIndexByEntryIndex,
-    };
-  };
-
-  const ensureSelectedIndex = (preferredFocusKey?: string): void => {
-    const view = resolveSelectionView();
-    if (view.entries.length === 0) {
-      selectedIndex = 0;
-      return;
-    }
-    const clampedIndex = Math.max(0, Math.min(selectedIndex, view.entries.length - 1));
-    selectedIndex = clampedIndex;
-    if (view.selectableIndexes.length === 0) {
-      return;
-    }
-    const focusKey = preferredFocusKey ?? getEntryFocusKey(view.entries[selectedIndex]);
-    if (focusKey) {
-      const found = view.selectableIndexes.find((index) => getEntryFocusKey(view.entries[index]) === focusKey);
-      if (typeof found === 'number') {
-        selectedIndex = found;
-        return;
-      }
-    }
-    if (!view.selectableIndexByEntryIndex.has(selectedIndex)) {
-      selectedIndex = view.selectableIndexes[0]!;
-    }
-  };
-
-  ensureSelectedIndex(options.initialFocusKey);
+  const songSelectState = createSongSelectState(allEntries, {
+    initialDifficultyFilter: options.initialDifficultyFilter,
+    initialPlayMode: options.initialPlayMode,
+    initialHighSpeed: options.initialHighSpeed,
+    initialFocusKey: options.initialFocusKey,
+  });
 
   process.stdout.write('\u001b[?25l');
 
   const syncPreview = (): void => {
-    const view = resolveSelectionView();
-    const entry = view.entries[selectedIndex];
+    const view = songSelectState.view();
+    const entry = view.entries[songSelectState.selectedIndex()];
     if (entry?.kind === 'chart') {
       previewController?.focus({
         filePath: entry.filePath,
@@ -1554,7 +1461,7 @@ async function selectChartInteractively(
   };
 
   const render = (): void => {
-    const view = resolveSelectionView();
+    const view = songSelectState.view();
     const columns = process.stdout.columns ?? 80;
     const listRows = listRowsForViewport();
     const numberWidth = String(Math.max(1, view.chartCount)).length;
@@ -1562,7 +1469,7 @@ async function selectChartInteractively(
     const itemLabelWidth = Math.max(8, lineWidth - numberWidth - 4);
     const columnLayout = createSelectionColumnLayout(itemLabelWidth, view.entries);
 
-    const { start, end } = resolveVisibleEntryRange(selectedIndex, view.entries.length, listRows);
+    const { start, end } = resolveVisibleEntryRange(songSelectState.selectedIndex(), view.entries.length, listRows);
 
     const lines: string[] = [];
     lines.push(
@@ -1570,7 +1477,7 @@ async function selectChartInteractively(
     );
     lines.push(truncateForDisplay(`Directory: ${rootDir}`, lineWidth));
     lines.push(
-      `Mode: ${formatPlayModeLabel(playMode)}  HIGH-SPEED: x${formatHighSpeedLabel(highSpeed)}  DIFFICULTY: ${formatSongSelectDifficultyFilterLabel(difficultyFilter)}`,
+      `Mode: ${formatPlayModeLabel(songSelectState.playMode())}  HIGH-SPEED: x${formatHighSpeedLabel(songSelectState.highSpeed())}  DIFFICULTY: ${formatSongSelectDifficultyFilterLabel(songSelectState.difficultyFilter())}`,
     );
     lines.push(
       `Audio backend: ${formatSongSelectAudioBackendLabel(options.audio, previewController?.getActiveBackend())}`,
@@ -1587,13 +1494,13 @@ async function selectChartInteractively(
 
     for (let index = start; index < end; index += 1) {
       const entry = view.entries[index];
-      const marker = index === selectedIndex ? '>' : ' ';
+      const marker = index === songSelectState.selectedIndex() ? '>' : ' ';
       const chartNumber = view.chartIndexByEntryIndex.get(index);
       const number =
         typeof chartNumber === 'number' ? String(chartNumber + 1).padStart(numberWidth, ' ') : ' '.repeat(numberWidth);
       let displayEntry = entry;
       if (
-        index === selectedIndex &&
+        index === songSelectState.selectedIndex() &&
         entry.kind === 'chart' &&
         previewController?.getRenderingFilePath() === entry.filePath
       ) {
@@ -1604,7 +1511,7 @@ async function selectChartInteractively(
       }
       const label = truncateForDisplay(formatSelectionEntryLabel(displayEntry, columnLayout), itemLabelWidth);
       const line = `${marker} ${number} ${label}`;
-      if (index === selectedIndex) {
+      if (index === songSelectState.selectedIndex()) {
         lines.push(`\u001b[7m${line.padEnd(lineWidth, ' ')}\u001b[0m`);
       } else {
         lines.push(line);
@@ -1612,11 +1519,11 @@ async function selectChartInteractively(
     }
 
     lines.push('');
-    const selectedChartIndex = view.chartIndexByEntryIndex.get(selectedIndex);
+    const selectedChartIndex = view.chartIndexByEntryIndex.get(songSelectState.selectedIndex());
     if (typeof selectedChartIndex === 'number') {
       lines.push(`${selectedChartIndex + 1}/${view.chartCount}`);
     } else if (view.chartCount > 0) {
-      const selectedEntry = view.entries[selectedIndex];
+      const selectedEntry = view.entries[songSelectState.selectedIndex()];
       lines.push(selectedEntry?.kind === 'random' ? `RANDOM/${view.chartCount}` : `0/${view.chartCount}`);
     } else {
       lines.push('0/0');
@@ -1627,8 +1534,8 @@ async function selectChartInteractively(
   return new Promise<SelectChartInteractivelyResult>((resolvePromise) => {
     let finished = false;
     const isSelectedEntryPreviewRendering = (): boolean => {
-      const view = resolveSelectionView();
-      const selectedEntry = view.entries[selectedIndex];
+      const view = songSelectState.view();
+      const selectedEntry = view.entries[songSelectState.selectedIndex()];
       if (!previewController || selectedEntry?.kind !== 'chart') {
         return false;
       }
@@ -1672,33 +1579,35 @@ async function selectChartInteractively(
     };
 
     const moveSelection = (delta: number): void => {
-      const view = resolveSelectionView();
+      const view = songSelectState.view();
       if (view.selectableIndexes.length === 0) {
         return;
       }
-      const currentSelectableIndex = view.selectableIndexByEntryIndex.get(selectedIndex) ?? 0;
+      const currentSelectableIndex = view.selectableIndexByEntryIndex.get(songSelectState.selectedIndex()) ?? 0;
       const nextSelectableIndex = resolveCircularSelectableIndex(
         currentSelectableIndex,
         delta,
         view.selectableIndexes.length,
       );
-      selectedIndex = view.selectableIndexes[nextSelectableIndex]!;
+      songSelectState.selectedIndex(view.selectableIndexes[nextSelectableIndex]!);
       syncPreview();
       render();
     };
 
     const moveSelectionByPage = (direction: SongSelectPageDirection): void => {
-      const view = resolveSelectionView();
+      const view = songSelectState.view();
       if (view.selectableIndexes.length === 0) {
         return;
       }
       const pageSize = listRowsForViewport();
-      selectedIndex = resolvePageSelectableIndex(
-        view.selectableIndexes,
-        selectedIndex,
-        view.entries.length,
-        pageSize,
-        direction,
+      songSelectState.selectedIndex(
+        resolvePageSelectableIndex(
+          view.selectableIndexes,
+          songSelectState.selectedIndex(),
+          view.entries.length,
+          pageSize,
+          direction,
+        ),
       );
       syncPreview();
       render();
@@ -1707,9 +1616,9 @@ async function selectChartInteractively(
     const onKeyPress = (chunk: string | undefined, key: readline.Key): void => {
       const nextDifficultyFilter = resolveSongSelectDifficultyFilter(chunk);
       if (nextDifficultyFilter !== undefined) {
-        const focusKey = getEntryFocusKey(resolveSelectionView().entries[selectedIndex]);
-        difficultyFilter = nextDifficultyFilter ?? undefined;
-        ensureSelectedIndex(focusKey);
+        const focusKey = getEntryFocusKey(songSelectState.view().entries[songSelectState.selectedIndex()]);
+        songSelectState.difficultyFilter(nextDifficultyFilter ?? undefined);
+        songSelectState.ensureSelectedIndex(focusKey);
         syncPreview();
         render();
         return;
@@ -1717,13 +1626,13 @@ async function selectChartInteractively(
 
       const action = resolveSongSelectNavigationAction(chunk, key);
       if (action === 'ctrl-c') {
-        const view = resolveSelectionView();
+        const view = songSelectState.view();
         cleanup({
           reason: 'ctrl-c',
-          focusKey: getEntryFocusKey(view.entries[selectedIndex]),
-          playMode,
-          highSpeed,
-          difficultyFilter,
+          focusKey: getEntryFocusKey(view.entries[songSelectState.selectedIndex()]),
+          playMode: songSelectState.playMode(),
+          highSpeed: songSelectState.highSpeed(),
+          difficultyFilter: songSelectState.difficultyFilter(),
         });
         return;
       }
@@ -1744,37 +1653,37 @@ async function selectChartInteractively(
         return;
       }
       if (action === 'first') {
-        const view = resolveSelectionView();
+        const view = songSelectState.view();
         if (view.selectableIndexes.length === 0) {
           return;
         }
-        selectedIndex = view.selectableIndexes[0]!;
+        songSelectState.selectedIndex(view.selectableIndexes[0]!);
         syncPreview();
         render();
         return;
       }
       if (action === 'last') {
-        const view = resolveSelectionView();
+        const view = songSelectState.view();
         if (view.selectableIndexes.length === 0) {
           return;
         }
-        selectedIndex = view.selectableIndexes[view.selectableIndexes.length - 1]!;
+        songSelectState.selectedIndex(view.selectableIndexes[view.selectableIndexes.length - 1]!);
         syncPreview();
         render();
         return;
       }
       if (action === 'confirm') {
-        const view = resolveSelectionView();
-        const selectedEntry = view.entries[selectedIndex];
+        const view = songSelectState.view();
+        const selectedEntry = view.entries[songSelectState.selectedIndex()];
         if (selectedEntry?.kind === 'random') {
           const randomIndex = Math.floor(Math.random() * view.chartFiles.length);
           cleanup({
             reason: 'selected',
             selectedPath: view.chartFiles[randomIndex],
             focusKey: getEntryFocusKey(selectedEntry),
-            playMode,
-            highSpeed,
-            difficultyFilter,
+            playMode: songSelectState.playMode(),
+            highSpeed: songSelectState.highSpeed(),
+            difficultyFilter: songSelectState.difficultyFilter(),
           });
           return;
         }
@@ -1783,37 +1692,37 @@ async function selectChartInteractively(
             reason: 'selected',
             selectedPath: selectedEntry.filePath,
             focusKey: getEntryFocusKey(selectedEntry),
-            playMode,
-            highSpeed,
-            difficultyFilter,
+            playMode: songSelectState.playMode(),
+            highSpeed: songSelectState.highSpeed(),
+            difficultyFilter: songSelectState.difficultyFilter(),
           });
           return;
         }
         return;
       }
       if (action === 'toggle-auto') {
-        playMode = cyclePlayMode(playMode);
+        songSelectState.playMode(cyclePlayMode(songSelectState.playMode()));
         render();
         return;
       }
       if (action === 'increase-high-speed') {
-        highSpeed = increaseHighSpeed(highSpeed);
+        songSelectState.highSpeed(increaseHighSpeed(songSelectState.highSpeed()));
         render();
         return;
       }
       if (action === 'decrease-high-speed') {
-        highSpeed = decreaseHighSpeed(highSpeed);
+        songSelectState.highSpeed(decreaseHighSpeed(songSelectState.highSpeed()));
         render();
         return;
       }
       if (action === 'escape') {
-        const view = resolveSelectionView();
+        const view = songSelectState.view();
         cleanup({
           reason: 'escape',
-          focusKey: getEntryFocusKey(view.entries[selectedIndex]),
-          playMode,
-          highSpeed,
-          difficultyFilter,
+          focusKey: getEntryFocusKey(view.entries[songSelectState.selectedIndex()]),
+          playMode: songSelectState.playMode(),
+          highSpeed: songSelectState.highSpeed(),
+          difficultyFilter: songSelectState.difficultyFilter(),
         });
       }
     };
@@ -1823,23 +1732,6 @@ async function selectChartInteractively(
     syncPreview();
     render();
   });
-}
-
-function getEntryFocusKey(entry: ChartSelectionEntry | undefined): string | undefined {
-  if (!entry) {
-    return undefined;
-  }
-  if (entry.kind === 'random') {
-    return 'random';
-  }
-  if (entry.kind === 'chart') {
-    return createChartFocusKey(entry.filePath);
-  }
-  return undefined;
-}
-
-function createChartFocusKey(filePath: string): string {
-  return `chart:${filePath}`;
 }
 
 function resolveChartFileFromFocusKey(focusKey: string | undefined): string | undefined {

--- a/packages/player/src/cli/song-select-state.test.ts
+++ b/packages/player/src/cli/song-select-state.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'vitest';
+import type { ChartSelectionEntry } from './chart-selection.ts';
+import {
+  createChartFocusKey,
+  createSongSelectState,
+  filterChartSelectionEntries,
+  getEntryFocusKey,
+} from './song-select-state.ts';
+
+const SAMPLE_ENTRIES: ChartSelectionEntry[] = [
+  { kind: 'group', label: 'Alpha' },
+  { kind: 'chart', filePath: '/charts/a.bms', fileLabel: 'a.bms', difficulty: 1 },
+  { kind: 'chart', filePath: '/charts/b.bms', fileLabel: 'b.bms', difficulty: 2 },
+  { kind: 'group', label: 'Beta' },
+  { kind: 'chart', filePath: '/charts/c.bms', fileLabel: 'c.bms', difficulty: 2 },
+];
+
+describe('song select state', () => {
+  test('prepends random only when the difficulty filter leaves visible charts', () => {
+    expect(filterChartSelectionEntries(SAMPLE_ENTRIES, 2).map((entry) => entry.kind)).toEqual([
+      'random',
+      'group',
+      'chart',
+      'group',
+      'chart',
+    ]);
+    expect(filterChartSelectionEntries(SAMPLE_ENTRIES, 5)).toEqual([]);
+  });
+
+  test('retains chart focus across derived view updates', () => {
+    const state = createSongSelectState(SAMPLE_ENTRIES, {
+      initialFocusKey: createChartFocusKey('/charts/b.bms'),
+      initialDifficultyFilter: 2,
+    });
+
+    let view = state.view();
+    expect(getEntryFocusKey(view.entries[state.selectedIndex()])).toBe('chart:/charts/b.bms');
+
+    state.difficultyFilter(undefined);
+    state.ensureSelectedIndex('chart:/charts/b.bms');
+    view = state.view();
+    expect(getEntryFocusKey(view.entries[state.selectedIndex()])).toBe('chart:/charts/b.bms');
+  });
+
+  test('keeps the current entry index when the focused chart disappears but the slot stays selectable', () => {
+    const state = createSongSelectState(SAMPLE_ENTRIES, {
+      initialFocusKey: createChartFocusKey('/charts/b.bms'),
+    });
+
+    state.difficultyFilter(1);
+    state.ensureSelectedIndex('chart:/charts/b.bms');
+
+    const view = state.view();
+    expect(getEntryFocusKey(view.entries[state.selectedIndex()])).toBe('chart:/charts/a.bms');
+  });
+});

--- a/packages/player/src/cli/song-select-state.ts
+++ b/packages/player/src/cli/song-select-state.ts
@@ -1,0 +1,160 @@
+import { computed, signal } from 'alien-signals';
+import type { ChartSelectionEntry } from './chart-selection.ts';
+import type { PlayMode } from './config.ts';
+import { normalizeHighSpeedValue } from './config.ts';
+import type { SongSelectDifficultyFilter } from './song-select-navigation.ts';
+
+type WritableSignal<T> = {
+  (): T;
+  (value: T): void;
+};
+
+export interface SongSelectViewState {
+  entries: ChartSelectionEntry[];
+  selectableIndexes: number[];
+  chartIndexes: number[];
+  chartCount: number;
+  chartFiles: string[];
+  selectableIndexByEntryIndex: Map<number, number>;
+  chartIndexByEntryIndex: Map<number, number>;
+}
+
+export interface SongSelectState {
+  readonly difficultyFilter: WritableSignal<SongSelectDifficultyFilter | undefined>;
+  readonly playMode: WritableSignal<PlayMode>;
+  readonly highSpeed: WritableSignal<number>;
+  readonly selectedIndex: WritableSignal<number>;
+  readonly view: () => SongSelectViewState;
+  ensureSelectedIndex: (preferredFocusKey?: string) => void;
+}
+
+export interface CreateSongSelectStateOptions {
+  initialDifficultyFilter?: SongSelectDifficultyFilter;
+  initialPlayMode?: PlayMode;
+  initialHighSpeed?: number;
+  initialFocusKey?: string;
+}
+
+export function createSongSelectState(
+  allEntries: ChartSelectionEntry[],
+  options: CreateSongSelectStateOptions = {},
+): SongSelectState {
+  const difficultyFilter = signal<SongSelectDifficultyFilter | undefined>(options.initialDifficultyFilter);
+  const playMode = signal<PlayMode>(options.initialPlayMode ?? 'manual');
+  const highSpeed = signal(normalizeHighSpeedValue(options.initialHighSpeed));
+  const selectedIndex = signal(0);
+
+  const view = computed(() => {
+    const entries = filterChartSelectionEntries(allEntries, difficultyFilter());
+    const selectableIndexes = entries.flatMap((entry, index) => (entry.kind === 'group' ? [] : [index]));
+    const chartIndexes = entries.flatMap((entry, index) => (entry.kind === 'chart' ? [index] : []));
+    const selectableIndexByEntryIndex = new Map<number, number>();
+    const chartIndexByEntryIndex = new Map<number, number>();
+    for (let index = 0; index < selectableIndexes.length; index += 1) {
+      selectableIndexByEntryIndex.set(selectableIndexes[index]!, index);
+    }
+    for (let index = 0; index < chartIndexes.length; index += 1) {
+      chartIndexByEntryIndex.set(chartIndexes[index]!, index);
+    }
+    return {
+      entries,
+      selectableIndexes,
+      chartIndexes,
+      chartCount: chartIndexes.length,
+      chartFiles: entries.flatMap((entry) => (entry.kind === 'chart' ? [entry.filePath] : [])),
+      selectableIndexByEntryIndex,
+      chartIndexByEntryIndex,
+    } satisfies SongSelectViewState;
+  });
+
+  const ensureSelectedIndex = (preferredFocusKey?: string): void => {
+    const resolvedView = view();
+    if (resolvedView.entries.length === 0) {
+      selectedIndex(0);
+      return;
+    }
+    let nextSelectedIndex = Math.max(0, Math.min(selectedIndex(), resolvedView.entries.length - 1));
+    const focusKey = preferredFocusKey ?? getEntryFocusKey(resolvedView.entries[nextSelectedIndex]);
+    if (focusKey) {
+      const found = resolvedView.selectableIndexes.find(
+        (index) => getEntryFocusKey(resolvedView.entries[index]) === focusKey,
+      );
+      if (typeof found === 'number') {
+        selectedIndex(found);
+        return;
+      }
+    }
+    if (
+      resolvedView.selectableIndexes.length > 0 &&
+      !resolvedView.selectableIndexByEntryIndex.has(nextSelectedIndex)
+    ) {
+      nextSelectedIndex = resolvedView.selectableIndexes[0]!;
+    }
+    selectedIndex(nextSelectedIndex);
+  };
+
+  ensureSelectedIndex(options.initialFocusKey);
+
+  return {
+    difficultyFilter,
+    playMode,
+    highSpeed,
+    selectedIndex,
+    view,
+    ensureSelectedIndex,
+  };
+}
+
+export function filterChartSelectionEntries(
+  entries: readonly ChartSelectionEntry[],
+  difficultyFilter: SongSelectDifficultyFilter | undefined,
+): ChartSelectionEntry[] {
+  if (typeof difficultyFilter !== 'number') {
+    return [...entries];
+  }
+
+  const filtered: ChartSelectionEntry[] = [];
+  let pendingGroup: Extract<ChartSelectionEntry, { kind: 'group' }> | undefined;
+  let hasVisibleCharts = false;
+
+  for (const entry of entries) {
+    if (entry.kind === 'random') {
+      continue;
+    }
+    if (entry.kind === 'group') {
+      pendingGroup = entry;
+      continue;
+    }
+    if (entry.difficulty !== difficultyFilter) {
+      continue;
+    }
+    if (pendingGroup) {
+      filtered.push(pendingGroup);
+      pendingGroup = undefined;
+    }
+    filtered.push(entry);
+    hasVisibleCharts = true;
+  }
+
+  if (hasVisibleCharts) {
+    filtered.unshift({ kind: 'random', label: '[Random] Select a chart randomly' });
+  }
+  return filtered;
+}
+
+export function getEntryFocusKey(entry: ChartSelectionEntry | undefined): string | undefined {
+  if (!entry) {
+    return undefined;
+  }
+  if (entry.kind === 'random') {
+    return 'random';
+  }
+  if (entry.kind === 'chart') {
+    return createChartFocusKey(entry.filePath);
+  }
+  return undefined;
+}
+
+export function createChartFocusKey(filePath: string): string {
+  return `chart:${filePath}`;
+}

--- a/packages/player/src/node/node-ui-worker.ts
+++ b/packages/player/src/node/node-ui-worker.ts
@@ -20,6 +20,7 @@ import type { PlayerUiCommand, PlayerUiFramePayload } from '../core/ui-signal-bu
 import { PlayerTui } from '../tui.ts';
 import { estimateBgaAnsiDisplaySize as resolveBgaDisplaySize, resolveLaneWidths } from '../tui/layout.ts';
 import { createDeferredUiFlush } from './deferred-ui-flush.ts';
+import { createUiWorkerFrameState } from './ui-worker-frame-state.ts';
 import type {
   NodeUiWorkerInboundMessage,
   NodeUiWorkerInitData,
@@ -108,9 +109,6 @@ async function bootstrap(): Promise<void> {
     stdinIsTTY: initData.stdinIsTTY,
     stdoutIsTTY: initData.stdoutIsTTY,
   });
-  tui.setPaused(initData.initialPaused);
-  tui.setLatestJudge(initData.initialJudgeCombo.judge, initData.initialJudgeCombo.channel);
-  tui.setCombo(initData.initialJudgeCombo.combo, initData.initialJudgeCombo.channel);
 
   if (!tui.isSupported()) {
     postWorkerMessage({ kind: 'unsupported' });
@@ -135,16 +133,45 @@ async function bootstrap(): Promise<void> {
     },
   });
 
-  let latestFrame: PlayerUiFramePayload | undefined;
   const queuedCommands: PlayerUiCommand[] = [];
   let bridgePort: MessagePort | undefined;
-  let terminalColumns: number | undefined;
-  let terminalRows: number | undefined;
 
-  const syncBgaDisplaySize = (frame: PlayerUiFramePayload | undefined): void => {
-    const size = estimateBgaAnsiDisplaySize(initData.laneBindings, terminalColumns, terminalRows, frame);
+  const syncBgaDisplaySize = (
+    frame: PlayerUiFramePayload | undefined,
+    columns: number | undefined,
+    rows: number | undefined,
+  ): void => {
+    const size = estimateBgaAnsiDisplaySize(initData.laneBindings, columns, rows, frame);
     bgaRenderer?.setDisplaySize(size.width, size.height);
   };
+
+  let terminalColumns: number | undefined;
+  let terminalRows: number | undefined;
+  const frameState = createUiWorkerFrameState({
+    initialPaused: initData.initialPaused,
+    initialHighSpeed: initData.highSpeed,
+    initialJudgeCombo: initData.initialJudgeCombo,
+    applyPaused: (value) => {
+      tui.setPaused(value);
+    },
+    applyHighSpeed: (value) => {
+      tui.setHighSpeed(value);
+    },
+    applyJudgeCombo: (state) => {
+      tui.setJudgeComboState(state);
+    },
+    applyTerminalSize: (columns, rows) => {
+      terminalColumns = columns;
+      terminalRows = rows;
+      tui.setTerminalSize(columns, rows);
+    },
+    syncFrameLayout: (frame, columns, rows) => {
+      syncBgaDisplaySize(frame, columns, rows);
+    },
+    requestFrameRender: () => {
+      deferredUiFlush.markFrameDirty();
+    },
+  });
 
   const deferredUiFlush = createDeferredUiFlush(({ commands, frame }) => {
     if (commands) {
@@ -177,8 +204,8 @@ async function bootstrap(): Promise<void> {
       }
     }
 
+    const latestFrame = frameState.getFrame();
     if (frame && latestFrame) {
-      syncBgaDisplaySize(latestFrame);
       tui.render({
         ...latestFrame,
         bgaAnsiLines: bgaRenderer?.getAnsiLines(latestFrame.currentSeconds),
@@ -192,9 +219,7 @@ async function bootstrap(): Promise<void> {
       return true;
     }
     if (message.kind === 'frame') {
-      latestFrame = message.frame;
-      syncBgaDisplaySize(latestFrame);
-      deferredUiFlush.markFrameDirty();
+      frameState.setFrame(message.frame);
       return true;
     }
     if (message.kind === 'commands') {
@@ -203,39 +228,25 @@ async function bootstrap(): Promise<void> {
       return true;
     }
     if (message.kind === 'set-paused') {
-      tui.setPaused(message.value);
-      if (latestFrame) {
-        deferredUiFlush.markFrameDirty();
-      }
+      frameState.setPaused(message.value);
       return true;
     }
     if (message.kind === 'set-high-speed') {
-      tui.setHighSpeed(message.value);
-      if (latestFrame) {
-        deferredUiFlush.markFrameDirty();
-      }
+      frameState.setHighSpeed(message.value);
       return true;
     }
     if (message.kind === 'set-judge-combo') {
-      tui.setLatestJudge(message.state.judge, message.state.channel);
-      tui.setCombo(message.state.combo, message.state.channel);
-      if (latestFrame) {
-        deferredUiFlush.markFrameDirty();
-      }
+      frameState.setJudgeCombo(message.state);
       return true;
     }
     if (message.kind === 'trigger-poor') {
       bgaRenderer?.triggerPoor(message.seconds);
-      if (latestFrame) {
-        deferredUiFlush.markFrameDirty();
-      }
+      frameState.invalidateFrame();
       return true;
     }
     if (message.kind === 'clear-poor') {
       bgaRenderer?.clearPoor();
-      if (latestFrame) {
-        deferredUiFlush.markFrameDirty();
-      }
+      frameState.invalidateFrame();
       return true;
     }
     return false;
@@ -257,6 +268,7 @@ async function bootstrap(): Promise<void> {
       return;
     }
     if (message.kind === 'dispose') {
+      frameState.dispose();
       deferredUiFlush.dispose();
       bridgePort?.close();
       tui.stop();
@@ -269,13 +281,7 @@ async function bootstrap(): Promise<void> {
       return;
     }
 
-    tui.setTerminalSize(message.columns, message.rows);
-    terminalColumns = message.columns;
-    terminalRows = message.rows;
-    syncBgaDisplaySize(latestFrame);
-    if (latestFrame) {
-      deferredUiFlush.markFrameDirty();
-    }
+    frameState.setTerminalSize(message.columns, message.rows);
   };
 
   port.on('message', handleControlMessage);

--- a/packages/player/src/node/ui-worker-frame-state.test.ts
+++ b/packages/player/src/node/ui-worker-frame-state.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test, vi } from 'vitest';
+import { createUiWorkerFrameState } from './ui-worker-frame-state.ts';
+
+describe('ui worker frame state', () => {
+  test('applies reactive HUD updates and rerenders frame layout on changes', () => {
+    const applyPaused = vi.fn();
+    const applyHighSpeed = vi.fn();
+    const applyJudgeCombo = vi.fn();
+    const applyTerminalSize = vi.fn();
+    const syncFrameLayout = vi.fn();
+    const requestFrameRender = vi.fn();
+    const frameState = createUiWorkerFrameState({
+      initialPaused: false,
+      initialHighSpeed: 1,
+      initialJudgeCombo: {
+        judge: 'READY',
+        combo: 0,
+        updatedAtMs: 0,
+      },
+      applyPaused,
+      applyHighSpeed,
+      applyJudgeCombo,
+      applyTerminalSize,
+      syncFrameLayout,
+      requestFrameRender,
+    });
+
+    expect(applyPaused).toHaveBeenLastCalledWith(false);
+    expect(applyHighSpeed).toHaveBeenLastCalledWith(1);
+    expect(applyJudgeCombo).toHaveBeenLastCalledWith({
+      judge: 'READY',
+      combo: 0,
+      updatedAtMs: 0,
+    });
+    expect(syncFrameLayout).toHaveBeenLastCalledWith(undefined, undefined, undefined);
+    expect(requestFrameRender).toHaveBeenCalledTimes(0);
+
+    const frame = {
+      currentBeat: 2,
+      currentSeconds: 1.5,
+      totalSeconds: 120,
+      summary: {
+        total: 100,
+        perfect: 0,
+        fast: 0,
+        slow: 0,
+        great: 0,
+        good: 0,
+        bad: 0,
+        poor: 0,
+        exScore: 0,
+        score: 0,
+      },
+      notes: [],
+    };
+    frameState.setFrame(frame);
+    expect(syncFrameLayout).toHaveBeenLastCalledWith(frame, undefined, undefined);
+    expect(requestFrameRender).toHaveBeenCalledTimes(1);
+
+    frameState.setPaused(true);
+    frameState.setHighSpeed(1.5);
+    frameState.setJudgeCombo({
+      judge: 'GREAT',
+      combo: 12,
+      channel: '11',
+      updatedAtMs: 1234,
+    });
+    expect(applyPaused).toHaveBeenLastCalledWith(true);
+    expect(applyHighSpeed).toHaveBeenLastCalledWith(1.5);
+    expect(applyJudgeCombo).toHaveBeenLastCalledWith({
+      judge: 'GREAT',
+      combo: 12,
+      channel: '11',
+      updatedAtMs: 1234,
+    });
+
+    frameState.setTerminalSize(120, 32);
+    expect(applyTerminalSize).toHaveBeenLastCalledWith(120, 32);
+    expect(syncFrameLayout).toHaveBeenLastCalledWith(frame, 120, 32);
+    expect(requestFrameRender).toHaveBeenCalledTimes(2);
+
+    frameState.invalidateFrame();
+    expect(requestFrameRender).toHaveBeenCalledTimes(3);
+
+    frameState.dispose();
+  });
+
+  test('deduplicates equivalent state writes', () => {
+    const applyPaused = vi.fn();
+    const applyHighSpeed = vi.fn();
+    const applyJudgeCombo = vi.fn();
+    const applyTerminalSize = vi.fn();
+    const syncFrameLayout = vi.fn();
+    const requestFrameRender = vi.fn();
+    const frameState = createUiWorkerFrameState({
+      initialPaused: false,
+      initialHighSpeed: 1,
+      initialJudgeCombo: {
+        judge: 'READY',
+        combo: 0,
+        updatedAtMs: 0,
+      },
+      applyPaused,
+      applyHighSpeed,
+      applyJudgeCombo,
+      applyTerminalSize,
+      syncFrameLayout,
+      requestFrameRender,
+    });
+
+    applyPaused.mockClear();
+    applyHighSpeed.mockClear();
+    applyJudgeCombo.mockClear();
+    applyTerminalSize.mockClear();
+    syncFrameLayout.mockClear();
+
+    frameState.setPaused(false);
+    frameState.setHighSpeed(1);
+    frameState.setJudgeCombo({
+      judge: 'READY',
+      combo: 0,
+      updatedAtMs: 0,
+    });
+    frameState.setTerminalSize(undefined, undefined);
+
+    expect(applyPaused).not.toHaveBeenCalled();
+    expect(applyHighSpeed).not.toHaveBeenCalled();
+    expect(applyJudgeCombo).not.toHaveBeenCalled();
+    expect(applyTerminalSize).not.toHaveBeenCalled();
+    expect(syncFrameLayout).not.toHaveBeenCalled();
+    expect(requestFrameRender).not.toHaveBeenCalled();
+
+    frameState.dispose();
+  });
+});

--- a/packages/player/src/node/ui-worker-frame-state.ts
+++ b/packages/player/src/node/ui-worker-frame-state.ts
@@ -1,0 +1,128 @@
+import { effect, effectScope, signal } from 'alien-signals';
+import type { PlayerUiFramePayload } from '../core/ui-signal-bus.ts';
+import type { PlayerJudgeComboSignalState } from '../state-signals.ts';
+
+type WritableSignal<T> = {
+  (): T;
+  (value: T): void;
+};
+
+interface TerminalSizeState {
+  columns: number | undefined;
+  rows: number | undefined;
+}
+
+export interface CreateUiWorkerFrameStateOptions {
+  initialPaused: boolean;
+  initialHighSpeed: number;
+  initialJudgeCombo: PlayerJudgeComboSignalState;
+  applyPaused: (value: boolean) => void;
+  applyHighSpeed: (value: number) => void;
+  applyJudgeCombo: (state: Readonly<PlayerJudgeComboSignalState>) => void;
+  applyTerminalSize: (columns: number | undefined, rows: number | undefined) => void;
+  syncFrameLayout: (
+    frame: PlayerUiFramePayload | undefined,
+    columns: number | undefined,
+    rows: number | undefined,
+  ) => void;
+  requestFrameRender: () => void;
+}
+
+export interface UiWorkerFrameState {
+  getFrame: () => PlayerUiFramePayload | undefined;
+  setFrame: (frame: PlayerUiFramePayload) => void;
+  setPaused: (value: boolean) => void;
+  setHighSpeed: (value: number) => void;
+  setJudgeCombo: (state: PlayerJudgeComboSignalState) => void;
+  setTerminalSize: (columns: number | undefined, rows: number | undefined) => void;
+  invalidateFrame: () => void;
+  dispose: () => void;
+}
+
+export function createUiWorkerFrameState(options: CreateUiWorkerFrameStateOptions): UiWorkerFrameState {
+  const frame = signal<PlayerUiFramePayload | undefined>(undefined);
+  const paused = signal(options.initialPaused);
+  const highSpeed = signal(options.initialHighSpeed);
+  const judgeCombo = signal(options.initialJudgeCombo);
+  const terminalSize = signal<TerminalSizeState>({
+    columns: undefined,
+    rows: undefined,
+  });
+  const refreshTick = signal(0);
+
+  const stopEffects = effectScope(() => {
+    effect(() => {
+      options.applyPaused(paused());
+    });
+    effect(() => {
+      options.applyHighSpeed(highSpeed());
+    });
+    effect(() => {
+      options.applyJudgeCombo(judgeCombo());
+    });
+    effect(() => {
+      const size = terminalSize();
+      options.applyTerminalSize(size.columns, size.rows);
+    });
+    effect(() => {
+      const currentFrame = frame();
+      const size = terminalSize();
+      refreshTick();
+      options.syncFrameLayout(currentFrame, size.columns, size.rows);
+      if (currentFrame) {
+        options.requestFrameRender();
+      }
+    });
+  });
+
+  const updateSignal = <T>(target: WritableSignal<T>, next: T, equals: (left: T, right: T) => boolean): void => {
+    const current = target();
+    if (equals(current, next)) {
+      return;
+    }
+    target(next);
+  };
+
+  return {
+    getFrame: () => frame(),
+    setFrame: (nextFrame) => {
+      frame(nextFrame);
+    },
+    setPaused: (value) => {
+      updateSignal(paused, value, (left, right) => left === right);
+    },
+    setHighSpeed: (value) => {
+      updateSignal(highSpeed, value, (left, right) => Math.abs(left - right) < 1e-9);
+    },
+    setJudgeCombo: (state) => {
+      const nextState: PlayerJudgeComboSignalState = {
+        judge: state.judge,
+        combo: state.combo,
+        channel: state.channel,
+        updatedAtMs: state.updatedAtMs,
+      };
+      updateSignal(
+        judgeCombo,
+        nextState,
+        (left, right) =>
+          left.judge === right.judge &&
+          left.combo === right.combo &&
+          left.channel === right.channel &&
+          left.updatedAtMs === right.updatedAtMs,
+      );
+    },
+    setTerminalSize: (columns, rows) => {
+      updateSignal(
+        terminalSize,
+        { columns, rows },
+        (left, right) => left.columns === right.columns && left.rows === right.rows,
+      );
+    },
+    invalidateFrame: () => {
+      refreshTick(refreshTick() + 1);
+    },
+    dispose: () => {
+      stopEffects();
+    },
+  };
+}

--- a/packages/player/src/tui.test.ts
+++ b/packages/player/src/tui.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import { formatMeasureSignature, resolveAnimatedHighSpeedValue, resolveVisibleBeatsForTuiGrid } from './tui.ts';
 import { PlayerTui } from './tui.ts';
+import { createPlayerStateSignals } from './state-signals.ts';
 import { estimateBgaAnsiDisplaySize, resolveLaneWidths } from './tui/layout.ts';
 
 const STDOUT_IS_TTY_DESCRIPTOR = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
@@ -94,6 +95,69 @@ describe('player tui', () => {
     });
 
     expect(tui.isSupported()).toBe(true);
+  });
+
+  test('tui: reacts to alien-signals driven HUD state updates', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    mockTerminal({ columns: 120, rows: 32 });
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((() => true) as typeof process.stdout.write);
+    const stateSignals = createPlayerStateSignals(1);
+    const tui = new PlayerTui({
+      mode: 'MANUAL',
+      laneDisplayMode: '7 KEY',
+      title: 'Test Song',
+      lanes: [
+        { channel: '16', key: 'A', isScratch: true },
+        { channel: '11', key: 'S' },
+        { channel: '12', key: 'D' },
+      ],
+      speed: 1,
+      highSpeed: 1,
+      judgeWindowMs: 16.67,
+      stateSignals,
+      stdinIsTTY: true,
+      stdoutIsTTY: true,
+    });
+    const frame: Parameters<PlayerTui['render']>[0] = {
+      currentBeat: 0,
+      currentSeconds: 0,
+      totalSeconds: 120,
+      summary: {
+        total: 100,
+        perfect: 0,
+        fast: 0,
+        slow: 0,
+        great: 0,
+        good: 0,
+        bad: 0,
+        poor: 0,
+        exScore: 0,
+        score: 0,
+      },
+      notes: [],
+    };
+
+    tui.start();
+    vi.setSystemTime(100);
+    stateSignals.publishJudgeCombo('GREAT', 12, '11');
+    stateSignals.setPaused(true);
+    tui.render(frame);
+
+    let output = String(writeSpy.mock.calls.at(-1)?.[0] ?? '');
+    expect(output).toContain('PAUSE');
+
+    stateSignals.setPaused(false);
+    stateSignals.setHighSpeed(1.5);
+    vi.setSystemTime(350);
+    tui.render(frame);
+
+    output = String(writeSpy.mock.calls.at(-1)?.[0] ?? '');
+    expect(output).toContain('HS x1.5');
+    expect(output).toContain('GREAT');
+    expect(output).toContain('12');
+
+    tui.stop();
   });
 
   test('tui: clears and relayouts the frame after terminal resize', () => {

--- a/packages/player/src/tui/tui.ts
+++ b/packages/player/src/tui/tui.ts
@@ -1,3 +1,4 @@
+import { effect, effectScope } from 'alien-signals';
 import type { BeMusicPlayLevel } from '@be-music/json';
 import { clamp } from '@be-music/utils';
 import type { PlayerSummary } from '../index.ts';
@@ -275,12 +276,6 @@ export class PlayerTui {
 
   private lastRenderedBeat = Number.NaN;
 
-  private lastSignalPaused?: boolean;
-
-  private lastSignalHighSpeed?: number;
-
-  private lastSignalJudgeComboTick = Number.NaN;
-
   constructor(options: TuiOptions) {
     const initialHighSpeed = normalizeHighSpeed(options.highSpeed);
     options.highSpeed = initialHighSpeed;
@@ -307,10 +302,23 @@ export class PlayerTui {
       this.freeZoneChannelToScratchChannel.set('27', '26');
       this.freeZoneSourceChannels.add('27');
     }
-    this.lastSignalPaused = this.paused;
-    this.lastSignalHighSpeed = this.targetHighSpeed;
-    this.lastSignalJudgeComboTick = Number.NaN;
-    this.syncStateSignals();
+    if (this.stateSignals) {
+      effectScope(() => {
+        effect(() => {
+          this.setPaused(this.stateSignals?.paused() ?? false);
+        });
+        effect(() => {
+          this.setHighSpeed(normalizeHighSpeed(this.stateSignals?.highSpeed() ?? this.targetHighSpeed));
+        });
+        effect(() => {
+          this.stateSignals?.judgeComboTick();
+          const judgeComboState = this.stateSignals?.getJudgeCombo();
+          if (judgeComboState) {
+            this.setJudgeComboState(judgeComboState);
+          }
+        });
+      });
+    }
   }
 
   isSupported(): boolean {
@@ -373,6 +381,14 @@ export class PlayerTui {
     }
   }
 
+  setJudgeComboState(state: Readonly<{ judge: string; combo: number; channel?: string; updatedAtMs: number }>): void {
+    for (const display of this.resolveJudgeComboTargets(state.channel)) {
+      display.latestJudge = state.judge;
+      display.combo = state.combo;
+      display.updatedAtMs = state.updatedAtMs;
+    }
+  }
+
   setPaused(value: boolean): void {
     this.paused = value;
   }
@@ -427,47 +443,10 @@ export class PlayerTui {
     this.needsFullRefresh = true;
   }
 
-  private syncStateSignals(): void {
-    const stateSignals = this.stateSignals;
-    if (!stateSignals) {
-      return;
-    }
-
-    const paused = stateSignals.paused();
-    if (this.lastSignalPaused !== paused) {
-      this.lastSignalPaused = paused;
-      this.setPaused(paused);
-    }
-
-    const highSpeed = normalizeHighSpeed(stateSignals.highSpeed());
-    if (this.lastSignalHighSpeed === undefined || Math.abs(this.lastSignalHighSpeed - highSpeed) > 1e-9) {
-      this.lastSignalHighSpeed = highSpeed;
-      this.setHighSpeed(highSpeed);
-    }
-
-    const judgeComboTick = stateSignals.judgeComboTick();
-    if (judgeComboTick === this.lastSignalJudgeComboTick) {
-      return;
-    }
-    this.lastSignalJudgeComboTick = judgeComboTick;
-    this.applyJudgeComboSignalState(stateSignals.getJudgeCombo());
-  }
-
-  private applyJudgeComboSignalState(
-    state: Readonly<{ judge: string; combo: number; channel?: string; updatedAtMs: number }>,
-  ): void {
-    for (const display of this.resolveJudgeComboTargets(state.channel)) {
-      display.latestJudge = state.judge;
-      display.combo = state.combo;
-      display.updatedAtMs = state.updatedAtMs;
-    }
-  }
-
   render(frame: TuiFrame): void {
     if (!this.active) {
       return;
     }
-    this.syncStateSignals();
 
     const terminalRows = this.terminalRows ?? process.stdout.rows;
     const debugLineCount = frame.activeAudioFiles === undefined && frame.activeAudioVoiceCount === undefined ? 0 : 1;


### PR DESCRIPTION
## Summary
- move song select state and derived filtering into an alien-signals based helper
- centralize UI worker dirty tracking and HUD updates with reactive frame state
- bind TUI HUD updates to player state signals and cover the new behavior with tests

## Testing
- ./node_modules/.bin/vitest run packages/player/src/cli/song-select-state.test.ts packages/player/src/node/ui-worker-frame-state.test.ts packages/player/src/tui.test.ts packages/player/src/node/node-ui-runtime.test.ts packages/player/src/cli.test.ts