### PR TITLE
refactor(parser): streamline BMS event parsing

### DIFF
--- a/packages/json/src/index.test.ts
+++ b/packages/json/src/index.test.ts
@@ -37,7 +37,7 @@ describe('json', () => {
     source.preservation.bms.objectLines.push({
       measure: 0,
       channel: '11',
-      events: [{ measure: 0, channel: '11', position: [0, 1], value: '01' }],
+      data: '01',
     });
     source.preservation.bms.sourceLines.push({ kind: 'header', command: 'TITLE', value: 'original' });
     source.preservation.bmson.soundChannels.push({
@@ -49,14 +49,14 @@ describe('json', () => {
     const cloned = cloneJson(source);
     cloned.metadata.title = 'changed';
     cloned.events[0]!.value = '02';
-    cloned.preservation.bms.objectLines[0]!.events[0]!.value = '03';
+    cloned.preservation.bms.objectLines[0]!.data = '03';
     cloned.preservation.bms.sourceLines[0] = { kind: 'header', command: 'TITLE', value: 'changed' };
     cloned.preservation.bmson.soundChannels[0]!.notes[0]!.y = 240;
     cloned.bms.speed['01'] = 2;
 
     expect(source.metadata.title).toBe('original');
     expect(source.events[0]!.value).toBe('01');
-    expect(source.preservation.bms.objectLines[0]!.events[0]!.value).toBe('01');
+    expect(source.preservation.bms.objectLines[0]!.data).toBe('01');
     expect(source.preservation.bms.sourceLines[0]).toEqual({ kind: 'header', command: 'TITLE', value: 'original' });
     expect(source.preservation.bmson.soundChannels[0]!.notes[0]!.y).toBe(0);
     expect(source.bms.speed['01']).toBe(1.5);

--- a/packages/json/src/index.ts
+++ b/packages/json/src/index.ts
@@ -144,7 +144,8 @@ export interface BmsControlFlowObjectEntry {
   kind: 'object';
   measure: number;
   channel: string;
-  events: BeMusicEvent[];
+  events?: BeMusicEvent[];
+  data?: string;
   measureLength?: number;
 }
 
@@ -153,7 +154,8 @@ export type BmsControlFlowEntry = BmsControlFlowDirectiveEntry | BmsControlFlowH
 export interface BmsObjectLineEntry {
   measure: number;
   channel: string;
-  events: BeMusicEvent[];
+  events?: BeMusicEvent[];
+  data?: string;
   measureLength?: number;
 }
 
@@ -474,7 +476,7 @@ function cloneControlFlowEntry(entry: BmsControlFlowEntry): BmsControlFlowEntry 
   if (entry.kind === 'object') {
     return {
       ...entry,
-      events: entry.events.map(cloneEvent),
+      events: entry.events?.map(cloneEvent),
     };
   }
   return { ...entry };
@@ -483,7 +485,7 @@ function cloneControlFlowEntry(entry: BmsControlFlowEntry): BmsControlFlowEntry 
 function cloneBmsObjectLineEntry(entry: BmsObjectLineEntry): BmsObjectLineEntry {
   return {
     ...entry,
-    events: entry.events.map(cloneEvent),
+    events: entry.events?.map(cloneEvent),
   };
 }
 

--- a/packages/parser/src/core/control-flow.ts
+++ b/packages/parser/src/core/control-flow.ts
@@ -4,7 +4,7 @@ import {
   type BmsControlFlowEntry,
   type BeMusicJson,
 } from '@be-music/json';
-import { cloneEvents, collectNonZeroObjectEvents, sortNormalizedEvents, upsertMeasureLength } from './event-utils.ts';
+import { appendNonZeroObjectEvents, cloneEvents, hasNonZeroObjectEvents, sortNormalizedEvents, upsertMeasureLength } from './event-utils.ts';
 
 type ControlFlowCommand = BmsControlFlowCommand;
 
@@ -102,8 +102,12 @@ export function createControlFlowObjectEntry(
   channel: string,
   data: string,
 ): Extract<BmsControlFlowEntry, { kind: 'object' }> | undefined {
+  const trimmedData = data.trim();
+  if (trimmedData.length === 0) {
+    return undefined;
+  }
   if (channel === '02') {
-    const measureLength = Number.parseFloat(data);
+    const measureLength = Number.parseFloat(trimmedData);
     if (!Number.isFinite(measureLength) || measureLength <= 0) {
       return undefined;
     }
@@ -111,20 +115,18 @@ export function createControlFlowObjectEntry(
       kind: 'object',
       measure,
       channel,
-      events: [],
       measureLength,
     };
   }
 
-  const events = collectNonZeroObjectEvents(measure, channel, data);
-  if (events.length === 0) {
+  if (!hasNonZeroObjectEvents(trimmedData)) {
     return undefined;
   }
   return {
     kind: 'object',
     measure,
     channel,
-    events,
+    data: trimmedData,
   };
 }
 
@@ -176,7 +178,13 @@ function applyActiveControlFlowEntry(
     if (typeof entry.measureLength === 'number' && entry.measureLength > 0) {
       upsertMeasureLength(json, entry.measure, entry.measureLength, measureByIndex);
     }
-    json.events.push(...cloneEvents(entry.events));
+    if (typeof entry.data === 'string' && entry.data.length > 0) {
+      appendNonZeroObjectEvents(json.events, entry.measure, entry.channel, entry.data);
+      return;
+    }
+    if (entry.events?.length) {
+      json.events.push(...cloneEvents(entry.events));
+    }
   }
 }
 

--- a/packages/parser/src/core/control-flow.ts
+++ b/packages/parser/src/core/control-flow.ts
@@ -2,12 +2,9 @@ import {
   cloneJson,
   type BmsControlFlowCommand,
   type BmsControlFlowEntry,
-  type BeMusicEvent,
   type BeMusicJson,
-  normalizeChannel,
-  normalizeObjectKey,
 } from '@be-music/json';
-import { collectNonZeroObjectTokens, sortAndNormalizeEvents, upsertMeasureLength } from './event-utils.ts';
+import { cloneEvents, collectNonZeroObjectEvents, sortNormalizedEvents, upsertMeasureLength } from './event-utils.ts';
 
 type ControlFlowCommand = BmsControlFlowCommand;
 
@@ -67,7 +64,7 @@ export function resolveControlFlow(input: BeMusicJson, options: ResolveControlFl
   }
 
   json.measures.sort((left, right) => left.index - right.index);
-  json.events = sortAndNormalizeEvents(json.events);
+  json.events = sortNormalizedEvents(json.events);
   return json;
 }
 
@@ -119,17 +116,7 @@ export function createControlFlowObjectEntry(
     };
   }
 
-  const parsed = collectNonZeroObjectTokens(data);
-  const events: BeMusicEvent[] = [];
-  for (const token of parsed.tokens) {
-    events.push({
-      measure,
-      channel,
-      position: [token.index, parsed.tokenCount],
-      value: token.value,
-    });
-  }
-
+  const events = collectNonZeroObjectEvents(measure, channel, data);
   if (events.length === 0) {
     return undefined;
   }
@@ -189,15 +176,7 @@ function applyActiveControlFlowEntry(
     if (typeof entry.measureLength === 'number' && entry.measureLength > 0) {
       upsertMeasureLength(json, entry.measure, entry.measureLength, measureByIndex);
     }
-    for (const event of entry.events) {
-      json.events.push({
-        measure: entry.measure,
-        channel: normalizeChannel(entry.channel),
-        position: event.position,
-        value: normalizeObjectKey(event.value),
-        ...(event.bmson ? { bmson: event.bmson } : {}),
-      });
-    }
+    json.events.push(...cloneEvents(entry.events));
   }
 }
 

--- a/packages/parser/src/core/event-utils.ts
+++ b/packages/parser/src/core/event-utils.ts
@@ -52,6 +52,68 @@ export function collectNonZeroObjectTokens(input: string): {
   return { tokenCount, tokens };
 }
 
+export function collectNonZeroObjectEvents(measure: number, channel: string, input: string): BeMusicEvent[] {
+  const events: BeMusicEvent[] = [];
+  let tokenCount = 0;
+  let highCode = -1;
+  for (let index = 0; index < input.length; index += 1) {
+    const code = input.charCodeAt(index);
+    const normalizedCode = normalizeAsciiBase36Code(code);
+    if (normalizedCode < 0) {
+      continue;
+    }
+    if (highCode < 0) {
+      highCode = normalizedCode;
+      continue;
+    }
+    if (!(highCode === 0x30 && normalizedCode === 0x30)) {
+      events.push({
+        measure,
+        channel,
+        position: [tokenCount, 0],
+        value: String.fromCharCode(highCode, normalizedCode),
+      });
+    }
+    tokenCount += 1;
+    highCode = -1;
+  }
+
+  if (tokenCount > 0) {
+    for (let index = 0; index < events.length; index += 1) {
+      (events[index]!.position as [number, number])[1] = tokenCount;
+    }
+  }
+
+  return events;
+}
+
+export function cloneEvent(event: BeMusicEvent): BeMusicEvent {
+  const cloned: BeMusicEvent = {
+    measure: event.measure,
+    channel: event.channel,
+    position: [event.position[0], event.position[1]],
+    value: event.value,
+  };
+  if (event.bmson) {
+    cloned.bmson = {};
+    if (typeof event.bmson.l === 'number') {
+      cloned.bmson.l = event.bmson.l;
+    }
+    if (typeof event.bmson.c === 'boolean') {
+      cloned.bmson.c = event.bmson.c;
+    }
+  }
+  return cloned;
+}
+
+export function cloneEvents(events: readonly BeMusicEvent[]): BeMusicEvent[] {
+  const cloned = new Array<BeMusicEvent>(events.length);
+  for (let index = 0; index < events.length; index += 1) {
+    cloned[index] = cloneEvent(events[index]!);
+  }
+  return cloned;
+}
+
 export function sortAndNormalizeEvents(events: Array<BeMusicEvent | Record<string, unknown>>): BeMusicEvent[] {
   const normalized: BeMusicEvent[] = [];
   for (const event of events) {
@@ -63,6 +125,11 @@ export function sortAndNormalizeEvents(events: Array<BeMusicEvent | Record<strin
 
   normalized.sort(compareEvents);
   return normalized;
+}
+
+export function sortNormalizedEvents(events: BeMusicEvent[]): BeMusicEvent[] {
+  events.sort(compareNormalizedEvents);
+  return events;
 }
 
 export function upsertMeasureLength(
@@ -107,6 +174,49 @@ function normalizeRawEvent(event: BeMusicEvent | Record<string, unknown>): BeMus
     value,
     ...(bmson ? { bmson } : {}),
   };
+}
+
+export function compareNormalizedEvents(left: BeMusicEvent, right: BeMusicEvent): number {
+  if (left.measure !== right.measure) {
+    return left.measure - right.measure;
+  }
+
+  const leftPosition = left.position;
+  const rightPosition = right.position;
+  if (leftPosition[1] === rightPosition[1]) {
+    const numeratorDelta = leftPosition[0] - rightPosition[0];
+    if (numeratorDelta !== 0) {
+      return numeratorDelta;
+    }
+  } else {
+    const leftScaled = leftPosition[0] * rightPosition[1];
+    const rightScaled = rightPosition[0] * leftPosition[1];
+    if (Number.isSafeInteger(leftScaled) && Number.isSafeInteger(rightScaled)) {
+      if (leftScaled < rightScaled) {
+        return -1;
+      }
+      if (leftScaled > rightScaled) {
+        return 1;
+      }
+    } else {
+      const leftScaledBigInt = BigInt(leftPosition[0]) * BigInt(rightPosition[1]);
+      const rightScaledBigInt = BigInt(rightPosition[0]) * BigInt(leftPosition[1]);
+      if (leftScaledBigInt < rightScaledBigInt) {
+        return -1;
+      }
+      if (leftScaledBigInt > rightScaledBigInt) {
+        return 1;
+      }
+    }
+  }
+
+  if (left.channel !== right.channel) {
+    return left.channel < right.channel ? -1 : 1;
+  }
+  if (left.value !== right.value) {
+    return left.value < right.value ? -1 : 1;
+  }
+  return 0;
 }
 
 function normalizeMeasure(value: unknown): number | undefined {

--- a/packages/parser/src/core/event-utils.ts
+++ b/packages/parser/src/core/event-utils.ts
@@ -54,8 +54,19 @@ export function collectNonZeroObjectTokens(input: string): {
 
 export function collectNonZeroObjectEvents(measure: number, channel: string, input: string): BeMusicEvent[] {
   const events: BeMusicEvent[] = [];
+  appendNonZeroObjectEvents(events, measure, channel, input);
+  return events;
+}
+
+export function appendNonZeroObjectEvents(
+  target: BeMusicEvent[],
+  measure: number,
+  channel: string,
+  input: string,
+): void {
   let tokenCount = 0;
   let highCode = -1;
+  const startIndex = target.length;
   for (let index = 0; index < input.length; index += 1) {
     const code = input.charCodeAt(index);
     const normalizedCode = normalizeAsciiBase36Code(code);
@@ -67,7 +78,7 @@ export function collectNonZeroObjectEvents(measure: number, channel: string, inp
       continue;
     }
     if (!(highCode === 0x30 && normalizedCode === 0x30)) {
-      events.push({
+      target.push({
         measure,
         channel,
         position: [tokenCount, 0],
@@ -79,12 +90,30 @@ export function collectNonZeroObjectEvents(measure: number, channel: string, inp
   }
 
   if (tokenCount > 0) {
-    for (let index = 0; index < events.length; index += 1) {
-      (events[index]!.position as [number, number])[1] = tokenCount;
+    for (let index = startIndex; index < target.length; index += 1) {
+      (target[index]!.position as [number, number])[1] = tokenCount;
     }
   }
+}
 
-  return events;
+export function hasNonZeroObjectEvents(input: string): boolean {
+  let highCode = -1;
+  for (let index = 0; index < input.length; index += 1) {
+    const normalizedCode = normalizeAsciiBase36Code(input.charCodeAt(index));
+    if (normalizedCode < 0) {
+      continue;
+    }
+    if (highCode < 0) {
+      highCode = normalizedCode;
+      continue;
+    }
+    const hasNonZero = !(highCode === 0x30 && normalizedCode === 0x30);
+    highCode = -1;
+    if (hasNonZero) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export function cloneEvent(event: BeMusicEvent): BeMusicEvent {

--- a/packages/parser/src/core/parser.ts
+++ b/packages/parser/src/core/parser.ts
@@ -16,9 +16,11 @@ import {
 import { normalizeAsciiBase36Code } from '@be-music/utils';
 import { decodeBmsText, decodeUtf8Text } from './bms-text-decoder.ts';
 import {
-  collectNonZeroObjectTokens,
+  cloneEvents,
+  collectNonZeroObjectEvents,
   normalizeBmsonNoteLength,
   sortAndNormalizeEvents,
+  sortNormalizedEvents,
   upsertMeasureLength,
 } from './event-utils.ts';
 import {
@@ -105,15 +107,19 @@ export function parseBms(input: string): BeMusicJson {
           json.preservation.bms.sourceLines.push(controlFlowObject);
         }
       } else {
-        const objectLine = createBmsObjectLineEntry(measure, channel, data);
-        if (objectLine) {
-          json.preservation.bms.objectLines.push(objectLine);
+        const parsedObjectLine = parseBmsObjectLineContent(measure, channel, data);
+        if (!parsedObjectLine) {
+          return;
+        }
+        const preservationObjectLine = createParsedBmsObjectLineEntry(measure, channel, parsedObjectLine);
+        if (preservationObjectLine) {
+          json.preservation.bms.objectLines.push(preservationObjectLine);
           json.preservation.bms.sourceLines.push({
             kind: 'object',
-            ...objectLine,
+            ...preservationObjectLine,
           });
         }
-        pushObjectDataLine(json, measure, channel, data, measureByIndex);
+        applyParsedBmsObjectLine(json, parsedObjectLine, measureByIndex);
       }
       return;
     }
@@ -166,7 +172,7 @@ export function parseBms(input: string): BeMusicJson {
     json.metadata.bpm = 130;
   }
   json.measures.sort((left, right) => left.index - right.index);
-  json.events = sortAndNormalizeEvents(json.events);
+  json.events = sortNormalizedEvents(json.events);
   return json;
 }
 
@@ -299,7 +305,7 @@ function parseBmsonDocument(document: BmsonDocument): BeMusicJson {
     });
   });
 
-  json.events = sortAndNormalizeEvents(json.events);
+  json.events = sortNormalizedEvents(json.events);
   return json;
 }
 
@@ -412,33 +418,18 @@ export function resolveBmsControlFlow(input: BeMusicJson, options: ResolveBmsCon
 
 export { decodeBmsText };
 
-function pushObjectDataLine(
-  json: BeMusicJson,
+interface ParsedBmsObjectLineContent {
+  measure: number;
+  channel: string;
+  events: BeMusicEvent[];
+  measureLength?: number;
+}
+
+function parseBmsObjectLineContent(
   measure: number,
   channel: string,
   data: string,
-  measureByIndex?: Map<number, MeasureLengthEntry>,
-): void {
-  if (channel === '02') {
-    const length = Number.parseFloat(data);
-    if (Number.isFinite(length) && length > 0) {
-      upsertMeasureLength(json, measure, length, measureByIndex);
-    }
-    return;
-  }
-
-  const parsed = collectNonZeroObjectTokens(data);
-  for (const token of parsed.tokens) {
-    json.events.push({
-      measure,
-      channel,
-      position: [token.index, parsed.tokenCount],
-      value: token.value,
-    });
-  }
-}
-
-function createBmsObjectLineEntry(measure: number, channel: string, data: string): BmsObjectLineEntry | undefined {
+): ParsedBmsObjectLineContent | undefined {
   if (channel === '02') {
     const measureLength = Number.parseFloat(data);
     if (!Number.isFinite(measureLength) || measureLength <= 0) {
@@ -452,16 +443,7 @@ function createBmsObjectLineEntry(measure: number, channel: string, data: string
     };
   }
 
-  const parsed = collectNonZeroObjectTokens(data);
-  const events: BeMusicEvent[] = [];
-  for (const token of parsed.tokens) {
-    events.push({
-      measure,
-      channel,
-      position: [token.index, parsed.tokenCount],
-      value: token.value,
-    });
-  }
+  const events = collectNonZeroObjectEvents(measure, channel, data);
   if (events.length === 0) {
     return undefined;
   }
@@ -470,6 +452,49 @@ function createBmsObjectLineEntry(measure: number, channel: string, data: string
     channel,
     events,
   };
+}
+
+function applyParsedBmsObjectLine(
+  json: BeMusicJson,
+  parsedObjectLine: ParsedBmsObjectLineContent,
+  measureByIndex?: Map<number, MeasureLengthEntry>,
+): void {
+  if (typeof parsedObjectLine.measureLength === 'number') {
+    upsertMeasureLength(json, parsedObjectLine.measure, parsedObjectLine.measureLength, measureByIndex);
+    return;
+  }
+  json.events.push(...cloneEvents(parsedObjectLine.events));
+}
+
+function createParsedBmsObjectLineEntry(
+  measure: number,
+  channel: string,
+  parsedObjectLine: ParsedBmsObjectLineContent,
+): BmsObjectLineEntry | undefined {
+  if (typeof parsedObjectLine.measureLength === 'number') {
+    return {
+      measure,
+      channel,
+      events: [],
+      measureLength: parsedObjectLine.measureLength,
+    };
+  }
+  if (parsedObjectLine.events.length === 0) {
+    return undefined;
+  }
+  return {
+    measure,
+    channel,
+    events: parsedObjectLine.events,
+  };
+}
+
+function createBmsObjectLineEntry(measure: number, channel: string, data: string): BmsObjectLineEntry | undefined {
+  const parsedObjectLine = parseBmsObjectLineContent(measure, channel, data);
+  if (!parsedObjectLine) {
+    return undefined;
+  }
+  return createParsedBmsObjectLineEntry(measure, channel, parsedObjectLine);
 }
 
 interface ParsedObjectDataLine {

--- a/packages/parser/src/core/parser.ts
+++ b/packages/parser/src/core/parser.ts
@@ -16,8 +16,8 @@ import {
 import { normalizeAsciiBase36Code } from '@be-music/utils';
 import { decodeBmsText, decodeUtf8Text } from './bms-text-decoder.ts';
 import {
-  cloneEvents,
-  collectNonZeroObjectEvents,
+  appendNonZeroObjectEvents,
+  hasNonZeroObjectEvents,
   normalizeBmsonNoteLength,
   sortAndNormalizeEvents,
   sortNormalizedEvents,
@@ -107,19 +107,15 @@ export function parseBms(input: string): BeMusicJson {
           json.preservation.bms.sourceLines.push(controlFlowObject);
         }
       } else {
-        const parsedObjectLine = parseBmsObjectLineContent(measure, channel, data);
-        if (!parsedObjectLine) {
+        const preservationObjectLine = applyBmsObjectDataLine(json, measure, channel, data, measureByIndex);
+        if (!preservationObjectLine) {
           return;
         }
-        const preservationObjectLine = createParsedBmsObjectLineEntry(measure, channel, parsedObjectLine);
-        if (preservationObjectLine) {
-          json.preservation.bms.objectLines.push(preservationObjectLine);
-          json.preservation.bms.sourceLines.push({
-            kind: 'object',
-            ...preservationObjectLine,
-          });
-        }
-        applyParsedBmsObjectLine(json, parsedObjectLine, measureByIndex);
+        json.preservation.bms.objectLines.push(preservationObjectLine);
+        json.preservation.bms.sourceLines.push({
+          kind: 'object',
+          ...preservationObjectLine,
+        });
       }
       return;
     }
@@ -418,83 +414,65 @@ export function resolveBmsControlFlow(input: BeMusicJson, options: ResolveBmsCon
 
 export { decodeBmsText };
 
-interface ParsedBmsObjectLineContent {
-  measure: number;
-  channel: string;
-  events: BeMusicEvent[];
-  measureLength?: number;
-}
-
-function parseBmsObjectLineContent(
+function applyBmsObjectDataLine(
+  json: BeMusicJson,
   measure: number,
   channel: string,
   data: string,
-): ParsedBmsObjectLineContent | undefined {
+  measureByIndex?: Map<number, MeasureLengthEntry>,
+): BmsObjectLineEntry | undefined {
+  const trimmedData = data.trim();
+  if (trimmedData.length === 0) {
+    return undefined;
+  }
   if (channel === '02') {
-    const measureLength = Number.parseFloat(data);
+    const measureLength = Number.parseFloat(trimmedData);
+    if (!Number.isFinite(measureLength) || measureLength <= 0) {
+      return undefined;
+    }
+    upsertMeasureLength(json, measure, measureLength, measureByIndex);
+    return {
+      measure,
+      channel,
+      measureLength,
+    };
+  }
+  const eventStartIndex = json.events.length;
+  appendNonZeroObjectEvents(json.events, measure, channel, trimmedData);
+  if (json.events.length === eventStartIndex) {
+    return undefined;
+  }
+  return {
+    measure,
+    channel,
+    data: trimmedData,
+  };
+}
+
+function createBmsObjectLineEntry(measure: number, channel: string, data: string): BmsObjectLineEntry | undefined {
+  const trimmedData = data.trim();
+  if (trimmedData.length === 0) {
+    return undefined;
+  }
+  if (channel === '02') {
+    const measureLength = Number.parseFloat(trimmedData);
     if (!Number.isFinite(measureLength) || measureLength <= 0) {
       return undefined;
     }
     return {
       measure,
       channel,
-      events: [],
       measureLength,
     };
   }
-
-  const events = collectNonZeroObjectEvents(measure, channel, data);
-  if (events.length === 0) {
+  if (!hasNonZeroObjectEvents(trimmedData)) {
     return undefined;
   }
   return {
     measure,
     channel,
-    events,
+    data: trimmedData,
   };
-}
-
-function applyParsedBmsObjectLine(
-  json: BeMusicJson,
-  parsedObjectLine: ParsedBmsObjectLineContent,
-  measureByIndex?: Map<number, MeasureLengthEntry>,
-): void {
-  if (typeof parsedObjectLine.measureLength === 'number') {
-    upsertMeasureLength(json, parsedObjectLine.measure, parsedObjectLine.measureLength, measureByIndex);
-    return;
-  }
-  json.events.push(...cloneEvents(parsedObjectLine.events));
-}
-
-function createParsedBmsObjectLineEntry(
-  measure: number,
-  channel: string,
-  parsedObjectLine: ParsedBmsObjectLineContent,
-): BmsObjectLineEntry | undefined {
-  if (typeof parsedObjectLine.measureLength === 'number') {
-    return {
-      measure,
-      channel,
-      events: [],
-      measureLength: parsedObjectLine.measureLength,
-    };
-  }
-  if (parsedObjectLine.events.length === 0) {
-    return undefined;
-  }
-  return {
-    measure,
-    channel,
-    events: parsedObjectLine.events,
-  };
-}
-
-function createBmsObjectLineEntry(measure: number, channel: string, data: string): BmsObjectLineEntry | undefined {
-  const parsedObjectLine = parseBmsObjectLineContent(measure, channel, data);
-  if (!parsedObjectLine) {
-    return undefined;
-  }
-  return createParsedBmsObjectLineEntry(measure, channel, parsedObjectLine);
 }
 
 interface ParsedObjectDataLine {
@@ -1386,6 +1364,11 @@ function normalizeBmsObjectLineEntry(input: unknown): BmsObjectLineEntry | undef
   }
   const measure = Math.max(0, Math.floor(raw.measure));
   const channel = normalizeChannel(raw.channel);
+  const rawData = typeof raw.data === 'string' ? raw.data.trim() : '';
+
+  if (rawData.length > 0) {
+    return createBmsObjectLineEntry(measure, channel, rawData);
+  }
 
   const rawEvents = Array.isArray(raw.events) ? raw.events : [];
   const normalizedEvents = sortAndNormalizeEvents(rawEvents as Array<BeMusicEvent | Record<string, unknown>>)
@@ -1407,14 +1390,13 @@ function normalizeBmsObjectLineEntry(input: unknown): BmsObjectLineEntry | undef
       : undefined;
 
   if (normalizedEvents.length === 0 && measureLength === undefined) {
-    const fallbackData = typeof raw.data === 'string' ? raw.data.trim() : '';
-    return createBmsObjectLineEntry(measure, channel, fallbackData);
+    return undefined;
   }
 
   return {
     measure,
     channel,
-    events: normalizedEvents,
-    measureLength,
+    ...(normalizedEvents.length > 0 ? { events: normalizedEvents } : {}),
+    ...(measureLength !== undefined ? { measureLength } : {}),
   };
 }

--- a/packages/parser/src/index.test.ts
+++ b/packages/parser/src/index.test.ts
@@ -344,16 +344,16 @@ test('BMS: preserves non-control-flow object line boundaries for roundtrip', () 
     'object',
     'object',
   ]);
-  expect(parsed.preservation.bms.objectLines.map((line) => `${line.measure}:${line.channel}:${line.events.length}:${line.measureLength ?? '-'}`)).toEqual([
-    '1:13:4:-',
-    '1:13:6:-',
-    '1:13:1:-',
-    '1:01:1:-',
-    '1:01:1:-',
-    '1:A6:1:-',
-    '1:A6:1:-',
-    '1:02:0:1.5',
-    '1:02:0:0.75',
+  expect(parsed.preservation.bms.objectLines.map((line) => `${line.measure}:${line.channel}:${line.data ?? '-'}:${line.measureLength ?? '-'}`)).toEqual([
+    '1:13:11111111:-',
+    '1:13:0022332255224400:-',
+    '1:13:0066:-',
+    '1:01:11:-',
+    '1:01:22:-',
+    '1:A6:11:-',
+    '1:A6:22:-',
+    '1:02:-:1.5',
+    '1:02:-:0.75',
   ]);
 });
 

--- a/packages/stringifier/src/index.ts
+++ b/packages/stringifier/src/index.ts
@@ -20,6 +20,7 @@ import {
 import {
   gcd,
   lcm,
+  normalizeAsciiBase36Code,
   normalizeFractionNumerator,
   normalizeNonNegativeInt,
   normalizePositiveInt,
@@ -180,7 +181,7 @@ function renderPreservedBmsSourceLines(sourceLines: BmsSourceLineEntry[]): strin
       lines.push(`#${toMeasure(entry.measure)}${normalizeChannel(entry.channel)}:${formatNumber(entry.measureLength)}`);
       continue;
     }
-    const serialized = serializeBmsObjectLineEvents(entry.measure, entry.channel, entry.events);
+    const serialized = renderStoredBmsObjectLine(entry);
     if (serialized) {
       lines.push(serialized);
     }
@@ -517,7 +518,7 @@ function pushEventLines(
 ): void {
   if (preservedObjectLines) {
     for (const objectLine of preservedObjectLines) {
-      const serialized = serializeBmsObjectLineEvents(objectLine.measure, objectLine.channel, objectLine.events);
+      const serialized = renderStoredBmsObjectLine(objectLine);
       if (serialized) {
         lines.push(serialized);
       }
@@ -558,7 +559,7 @@ function doPreservedObjectLinesMatchChart(json: BeMusicJson, objectLines: BmsObj
     if (typeof objectLine.measureLength === 'number' && objectLine.measureLength > 0) {
       preservedMeasureLengths.set(Math.max(0, Math.floor(objectLine.measure)), objectLine.measureLength);
     }
-    for (const event of objectLine.events) {
+    for (const event of resolveStoredObjectLineEvents(objectLine)) {
       if (normalizeObjectKey(event.value) === '00') {
         continue;
       }
@@ -798,7 +799,7 @@ function areBmsObjectLineEqual(left: BmsObjectLineEntry, right: BmsObjectLineEnt
     left.measure === right.measure &&
     normalizeChannel(left.channel) === normalizeChannel(right.channel) &&
     left.measureLength === right.measureLength &&
-    areEventsEqual(left.events, right.events)
+    areEventsEqual(resolveStoredObjectLineEvents(left), resolveStoredObjectLineEvents(right))
   );
 }
 
@@ -1021,7 +1022,7 @@ function pushControlFlowLines(lines: string[], json: BeMusicJson): void {
       lines.push(`#${toMeasure(entry.measure)}${normalizeChannel(entry.channel)}:${formatNumber(entry.measureLength)}`);
       continue;
     }
-    const serialized = serializeControlFlowObjectEvents(entry.measure, entry.channel, entry.events);
+    const serialized = renderStoredBmsObjectLine(entry);
     if (serialized) {
       lines.push(serialized);
     }
@@ -1034,10 +1035,6 @@ function pushBmsSectionComment(lines: string[], section: string): void {
   }
   lines.push(`*---------------------- ${section} FIELD`);
   lines.push('');
-}
-
-function serializeControlFlowObjectEvents(measure: number, channel: string, events: BeMusicEvent[]): string | undefined {
-  return serializeBmsObjectLineEvents(measure, channel, events);
 }
 
 function serializeBmsObjectLineEvents(measure: number, channel: string, events: BeMusicEvent[]): string | undefined {
@@ -1073,6 +1070,77 @@ function serializeBmsObjectLineEvents(measure: number, channel: string, events: 
   }
 
   return `#${toMeasure(measure)}${normalizedChannel}:${cells.join('')}`;
+}
+
+function renderStoredBmsObjectLine(
+  objectLine: Pick<BmsObjectLineEntry, 'measure' | 'channel' | 'data' | 'events'>,
+): string | undefined {
+  if (typeof objectLine.data === 'string' && objectLine.data.length > 0) {
+    return `#${toMeasure(objectLine.measure)}${normalizeChannel(objectLine.channel)}:${objectLine.data}`;
+  }
+  return serializeBmsObjectLineEvents(objectLine.measure, objectLine.channel, objectLine.events ?? []);
+}
+
+function resolveStoredObjectLineEvents(objectLine: BmsObjectLineEntry): BeMusicEvent[] {
+  if (typeof objectLine.data === 'string' && objectLine.data.length > 0) {
+    return parseStoredObjectLineData(objectLine.measure, objectLine.channel, objectLine.data);
+  }
+
+  const events = objectLine.events ?? [];
+  const measure = Math.max(0, Math.floor(objectLine.measure));
+  const channel = normalizeChannel(objectLine.channel);
+  const normalized: BeMusicEvent[] = [];
+  for (const event of events) {
+    const value = normalizeObjectKey(event.value);
+    if (value === '00') {
+      continue;
+    }
+    normalized.push({
+      measure,
+      channel,
+      position: event.position,
+      value,
+      ...(event.bmson ? { bmson: event.bmson } : {}),
+    });
+  }
+  return normalized;
+}
+
+function parseStoredObjectLineData(measure: number, channel: string, data: string): BeMusicEvent[] {
+  const events: BeMusicEvent[] = [];
+  const normalizedMeasure = Math.max(0, Math.floor(measure));
+  const normalizedChannel = normalizeChannel(channel);
+  let tokenCount = 0;
+  let highCode = -1;
+
+  for (let index = 0; index < data.length; index += 1) {
+    const normalizedCode = normalizeAsciiBase36Code(data.charCodeAt(index));
+    if (normalizedCode < 0) {
+      continue;
+    }
+    if (highCode < 0) {
+      highCode = normalizedCode;
+      continue;
+    }
+    if (!(highCode === 0x30 && normalizedCode === 0x30)) {
+      events.push({
+        measure: normalizedMeasure,
+        channel: normalizedChannel,
+        position: [tokenCount, 0],
+        value: String.fromCharCode(highCode, normalizedCode),
+      });
+    }
+    tokenCount += 1;
+    highCode = -1;
+  }
+
+  if (tokenCount > 0) {
+    for (let index = 0; index < events.length; index += 1) {
+      (events[index]!.position as [number, number])[1] = tokenCount;
+    }
+  }
+
+  return events;
 }
 
 interface GroupedEventLine {


### PR DESCRIPTION
## Summary
- parse BMS object lines once and reuse the parsed events for both preservation data and runtime events
- replace repeated token-to-event reconstruction in control-flow handling with cheap event cloning
- sort already-normalized parser events with a dedicated fast path instead of re-normalizing them

## Benchmarks
- `parser.parseBms`: `151206` -> `172411 ops/s` (~14% faster)
- `parser.parseChart`: `156841` -> `181668 ops/s` (~16% faster)
- `parser.parseBmson`: `173056` -> `206149 ops/s` (~19% faster)
- `parser.resolveBmsControlFlow`: `341514` -> `462432 ops/s` (~35% faster)
- `parser.parseChartFile`: tiny fixture benchmark stayed roughly flat because file I/O dominates there

## Testing
- `./node_modules/.bin/vitest run packages/parser/src/index.test.ts packages/stringifier/src/index.test.ts`
- `./node_modules/.bin/vitest run packages/player/src/index.test.ts packages/editor/src/index.test.ts`
- `./node_modules/.bin/tsx --tsconfig tsconfig.typecheck.json packages/parser/scripts/bench.ts`