### PR TITLE
feat(player): add optional kitty graphics BGA rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ pnpm run editor export chart.json chart.bms
 
 - `04` (base) と `07` (layer) を合成して描画します。
 - layer の黒 (`#000000`) は透過色として扱います。
+- `--kitty-graphics` 指定時のみ、kitty graphics protocol 対応端末で gameplay BGA と `#STAGEFILE` loading 画面を画像として表示します。未指定時は ANSI 描画です。
 - BGA はウィンドウリサイズ時に再計算して表示サイズを更新します。
 - 動画 BGA は `@uwx/libav.js-fat` でデコードします。
   - 対応コーデック: `mpeg1video`, `h264`

--- a/packages/player/src/bga.test.ts
+++ b/packages/player/src/bga.test.ts
@@ -5,7 +5,7 @@ import { createEmptyJson } from '../../json/src/index.ts';
 import { describe, expect, test, vi } from 'vitest';
 import { encode as encodeBmp } from 'fast-bmp';
 import { encode as encodePng } from 'fast-png';
-import { BgaAnsiRenderer, createBgaAnsiRenderer, loadStageFileAnsiLines } from './bga.ts';
+import { BgaAnsiRenderer, createBgaAnsiRenderer, loadStageFileAnsiImage, loadStageFileAnsiLines } from './bga.ts';
 
 vi.mock('./bga-video.ts', () => ({
   decodeVideoFramesStream: vi.fn(async (videoPath: string, onFrame: (frame: unknown) => void) => {
@@ -99,6 +99,35 @@ describe('player bga', () => {
       expect(pixels[10]?.[20]).toEqual({ r: 0, g: 0, b: 255 });
       expect(pixels[0]?.[0]).toEqual({ r: 0, g: 0, b: 255 });
       expect(pixels[19]?.[39]).toEqual({ r: 0, g: 0, b: 255 });
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  test('player bga: prepares kitty graphics data for STAGEFILE splash images', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'be-music-stagefile-kitty-'));
+    try {
+      await writePng(join(baseDir, 'stage.png'), 64, 256, () => ({ r: 0, g: 0, b: 255, a: 255 }));
+
+      const json = createEmptyJson('bms');
+      json.metadata.bpm = 120;
+      json.metadata.stageFile = 'stage.png';
+
+      const image = await loadStageFileAnsiImage(json, {
+        baseDir,
+        width: 40,
+        height: 20,
+      });
+
+      expect(image?.kittyImage).toEqual(
+        expect.objectContaining({
+          pixelWidth: 160,
+          pixelHeight: 80,
+          cellWidth: 40,
+          cellHeight: 20,
+        }),
+      );
+      expect(image?.kittyImage?.rgb.length).toBe(160 * 80 * 3);
     } finally {
       await rm(baseDir, { recursive: true, force: true });
     }

--- a/packages/player/src/bga.ts
+++ b/packages/player/src/bga.ts
@@ -24,6 +24,7 @@ const MAX_NORMAL_BGA_COMPOSITE_LAYERS = NORMAL_BGA_COMPOSITE_LAYER_ORDER.length;
 const DEFAULT_BGA_ASCII_WIDTH = 34;
 const DEFAULT_BGA_ASCII_HEIGHT = 20;
 const DEFAULT_POOR_BGA_DISPLAY_SECONDS = 2;
+const KITTY_GRAPHICS_PIXEL_SCALE = 4;
 const TRANSPARENT_ALPHA_THRESHOLD = 16;
 const VIDEO_BLACK_BORDER_THRESHOLD = 8;
 const ANSI_RESET = '\u001b[0m';
@@ -109,6 +110,24 @@ export interface StageFileAnsiImage {
   height: number;
   rgb: Uint8Array;
   lines: string[];
+  kittyImage?: StageFileKittyImage;
+}
+
+export interface StageFileKittyImage {
+  pixelWidth: number;
+  pixelHeight: number;
+  cellWidth: number;
+  cellHeight: number;
+  rgb: Uint8Array;
+}
+
+export interface BgaKittyImage {
+  pixelWidth: number;
+  pixelHeight: number;
+  cellWidth: number;
+  cellHeight: number;
+  rgb: Uint8Array;
+  token: string;
 }
 
 export async function loadStageFileAnsiImage(
@@ -133,11 +152,13 @@ export async function loadStageFileAnsiImage(
     return undefined;
   }
   const filledFrame = fillAnsiFrameBackground(selected.frame, 0, 0, 0);
+  const kittyFrame = buildStageFileKittyImage(stageFileSourceFrame, displaySize.width, displaySize.height);
   return {
     width: filledFrame.width,
     height: filledFrame.height,
     rgb: filledFrame.rgb,
     lines: composeAnsiLines(filledFrame.rgb, filledFrame.opaqueMask, filledFrame.width, filledFrame.height),
+    kittyImage: kittyFrame,
   };
 }
 
@@ -217,6 +238,8 @@ export class BgaAnsiRenderer {
 
   private cachedLines?: string[];
 
+  private cachedKittyImage?: BgaKittyImage;
+
   private blackBackgroundLines: string[];
 
   private poorActiveUntilSeconds = Number.NEGATIVE_INFINITY;
@@ -272,6 +295,7 @@ export class BgaAnsiRenderer {
     this.cachedPoorActive = false;
     this.cachedComposite = undefined;
     this.cachedLines = undefined;
+    this.cachedKittyImage = undefined;
   }
 
   clearPoor(): void {
@@ -282,6 +306,7 @@ export class BgaAnsiRenderer {
     this.cachedPoorActive = false;
     this.cachedComposite = undefined;
     this.cachedLines = undefined;
+    this.cachedKittyImage = undefined;
   }
 
   setDisplaySize(width: number, height: number): void {
@@ -310,6 +335,64 @@ export class BgaAnsiRenderer {
     return this.cachedLines;
   }
 
+  getKittyImage(currentSeconds: number): BgaKittyImage {
+    const state = this.resolveActiveState(currentSeconds);
+    const pixelWidth = Math.max(1, this.displayWidth * KITTY_GRAPHICS_PIXEL_SCALE);
+    const pixelHeight = Math.max(1, this.displayHeight * KITTY_GRAPHICS_PIXEL_SCALE);
+    const baseSelection = resolveFrameSelection(
+      this.baseSourceFramesByKey,
+      this.missingBaseSourceFrame,
+      state.baseKey,
+      state.baseSeconds,
+    );
+    const layerSelection = resolveFrameSelection(
+      this.layerSourceFramesByKey,
+      this.missingLayerSourceFrame,
+      state.layerKey,
+      state.layerSeconds,
+    );
+    const layer2Selection = resolveFrameSelection(
+      this.layer2SourceFramesByKey,
+      this.missingLayerSourceFrame,
+      state.layer2Key,
+      state.layer2Seconds,
+    );
+    const poorSelection = state.poorActive
+      ? resolveFrameSelection(this.poorSourceFramesByKey, this.missingPoorSourceFrame, state.poorKey, state.poorSeconds)
+      : { frame: undefined, index: -1 };
+    const token =
+      `${pixelWidth}x${pixelHeight}:` +
+      `${state.baseKey}:${baseSelection.index}:` +
+      `${state.layerKey}:${layerSelection.index}:` +
+      `${state.layer2Key}:${layer2Selection.index}:` +
+      `${state.poorActive ? '1' : '0'}:${state.poorKey}:${poorSelection.index}`;
+    if (this.cachedKittyImage?.token === token) {
+      return this.cachedKittyImage;
+    }
+
+    const composite =
+      state.poorActive && poorSelection.frame
+        ? mergeCompositeFrames(resizeAnsiFrame(poorSelection.frame, pixelWidth, pixelHeight))
+        : mergeCompositeFrames(
+            ...[baseSelection.frame, layerSelection.frame, layer2Selection.frame]
+              .slice(0, MAX_NORMAL_BGA_COMPOSITE_LAYERS)
+              .map((frame) => (frame ? resizeAnsiFrame(frame, pixelWidth, pixelHeight) : undefined)),
+          );
+    const filledFrame = composite
+      ? fillAnsiFrameBackground(composite, 0, 0, 0)
+      : createSolidAnsiFrame(1, 1, 0, 0, 0, 1);
+    const image = {
+      pixelWidth: filledFrame.width,
+      pixelHeight: filledFrame.height,
+      cellWidth: this.displayWidth,
+      cellHeight: this.displayHeight,
+      rgb: filledFrame.rgb,
+      token,
+    };
+    this.cachedKittyImage = image;
+    return image;
+  }
+
   private rebuildFrames(): void {
     this.baseFramesByKey = resizeFrameSourceMap(this.baseSourceFramesByKey, this.displayWidth, this.displayHeight);
     this.poorFramesByKey = resizeFrameSourceMap(this.poorSourceFramesByKey, this.displayWidth, this.displayHeight);
@@ -334,51 +417,43 @@ export class BgaAnsiRenderer {
     this.cachedPoorActive = false;
     this.cachedComposite = undefined;
     this.cachedLines = undefined;
+    this.cachedKittyImage = undefined;
   }
 
   private refreshComposite(currentSeconds: number): void {
-    const baseCue = findActiveCue(this.baseTimeline, currentSeconds);
-    const layerCue = findActiveCue(this.layerTimeline, currentSeconds);
-    const layer2Cue = findActiveCue(this.layer2Timeline, currentSeconds);
-
-    const baseKey = baseCue?.key ?? '';
-    const layerKey = layerCue?.key ?? '';
-    const layer2Key = layer2Cue?.key ?? '';
-    const baseSeconds = baseCue ? Math.max(0, currentSeconds - baseCue.seconds) : Math.max(0, currentSeconds);
-    const layerSeconds = layerCue ? Math.max(0, currentSeconds - layerCue.seconds) : 0;
-    const layer2Seconds = layer2Cue ? Math.max(0, currentSeconds - layer2Cue.seconds) : 0;
-
-    const baseSelection = this.resolveBaseFrame(baseKey, baseSeconds);
-    const layerSelection = this.resolveLayerFrame(layerKey, layerSeconds);
-    const layer2Selection = this.resolveLayer2Frame(layer2Key, layer2Seconds);
-    const poorActive = currentSeconds < this.poorActiveUntilSeconds;
-    const poorSelection = poorActive ? this.resolvePoorFrame(currentSeconds) : { key: '', index: -1, frame: undefined };
+    const state = this.resolveActiveState(currentSeconds);
+    const baseSelection = this.resolveBaseFrame(state.baseKey, state.baseSeconds);
+    const layerSelection = this.resolveLayerFrame(state.layerKey, state.layerSeconds);
+    const layer2Selection = this.resolveLayer2Frame(state.layer2Key, state.layer2Seconds);
+    const poorSelection = state.poorActive
+      ? resolveFrameSelection(this.poorFramesByKey, this.missingPoorFrame, state.poorKey, state.poorSeconds)
+      : { frame: undefined, index: -1 };
 
     if (
-      this.cachedBaseKey === baseKey &&
-      this.cachedLayerKey === layerKey &&
-      this.cachedLayer2Key === layer2Key &&
-      this.cachedPoorKey === poorSelection.key &&
+      this.cachedBaseKey === state.baseKey &&
+      this.cachedLayerKey === state.layerKey &&
+      this.cachedLayer2Key === state.layer2Key &&
+      this.cachedPoorKey === state.poorKey &&
       this.cachedBaseFrameIndex === baseSelection.index &&
       this.cachedLayerFrameIndex === layerSelection.index &&
       this.cachedLayer2FrameIndex === layer2Selection.index &&
       this.cachedPoorFrameIndex === poorSelection.index &&
-      this.cachedPoorActive === poorActive
+      this.cachedPoorActive === state.poorActive
     ) {
       return;
     }
 
-    this.cachedBaseKey = baseKey;
-    this.cachedLayerKey = layerKey;
-    this.cachedLayer2Key = layer2Key;
-    this.cachedPoorKey = poorSelection.key;
+    this.cachedBaseKey = state.baseKey;
+    this.cachedLayerKey = state.layerKey;
+    this.cachedLayer2Key = state.layer2Key;
+    this.cachedPoorKey = state.poorKey;
     this.cachedBaseFrameIndex = baseSelection.index;
     this.cachedLayerFrameIndex = layerSelection.index;
     this.cachedLayer2FrameIndex = layer2Selection.index;
     this.cachedPoorFrameIndex = poorSelection.index;
-    this.cachedPoorActive = poorActive;
+    this.cachedPoorActive = state.poorActive;
     this.cachedComposite =
-      poorActive && poorSelection.frame
+      state.poorActive && poorSelection.frame
         ? mergeCompositeFrames(poorSelection.frame)
         : mergeCompositeFrames(
             ...[baseSelection.frame, layerSelection.frame, layer2Selection.frame].slice(
@@ -387,59 +462,48 @@ export class BgaAnsiRenderer {
             ),
           );
     this.cachedLines = undefined;
+    this.cachedKittyImage = undefined;
+  }
+
+  private resolveActiveState(currentSeconds: number): {
+    baseKey: string;
+    layerKey: string;
+    layer2Key: string;
+    poorKey: string;
+    baseSeconds: number;
+    layerSeconds: number;
+    layer2Seconds: number;
+    poorSeconds: number;
+    poorActive: boolean;
+  } {
+    const baseCue = findActiveCue(this.baseTimeline, currentSeconds);
+    const layerCue = findActiveCue(this.layerTimeline, currentSeconds);
+    const layer2Cue = findActiveCue(this.layer2Timeline, currentSeconds);
+    const poorCue = findActiveCue(this.poorTimeline, currentSeconds);
+    const poorActive = currentSeconds < this.poorActiveUntilSeconds;
+    return {
+      baseKey: baseCue?.key ?? '',
+      layerKey: layerCue?.key ?? '',
+      layer2Key: layer2Cue?.key ?? '',
+      poorKey: poorActive ? this.resolvePoorKey(poorCue, currentSeconds) ?? '' : '',
+      baseSeconds: baseCue ? Math.max(0, currentSeconds - baseCue.seconds) : Math.max(0, currentSeconds),
+      layerSeconds: layerCue ? Math.max(0, currentSeconds - layerCue.seconds) : 0,
+      layer2Seconds: layer2Cue ? Math.max(0, currentSeconds - layer2Cue.seconds) : 0,
+      poorSeconds: poorCue ? Math.max(0, currentSeconds - poorCue.seconds) : Math.max(0, currentSeconds),
+      poorActive,
+    };
   }
 
   private resolveBaseFrame(baseKey: string, seconds: number): FrameSelection {
-    if (!baseKey) {
-      return {
-        frame: undefined,
-        index: -1,
-      };
-    }
-    const source = this.baseFramesByKey.get(baseKey) ?? createStaticFrameSource(this.missingBaseFrame);
-    return selectFrameFromSource(source, seconds);
+    return resolveFrameSelection(this.baseFramesByKey, this.missingBaseFrame, baseKey, seconds);
   }
 
   private resolveLayerFrame(layerKey: string, seconds: number): FrameSelection {
-    if (!layerKey) {
-      return {
-        frame: undefined,
-        index: -1,
-      };
-    }
-    const source = this.layerFramesByKey.get(layerKey) ?? createStaticFrameSource(this.missingLayerFrame);
-    return selectFrameFromSource(source, seconds);
+    return resolveFrameSelection(this.layerFramesByKey, this.missingLayerFrame, layerKey, seconds);
   }
 
   private resolveLayer2Frame(layer2Key: string, seconds: number): FrameSelection {
-    if (!layer2Key) {
-      return {
-        frame: undefined,
-        index: -1,
-      };
-    }
-    const source = this.layer2FramesByKey.get(layer2Key) ?? createStaticFrameSource(this.missingLayerFrame);
-    return selectFrameFromSource(source, seconds);
-  }
-
-  private resolvePoorFrame(currentSeconds: number): { key: string; frame?: AnsiFrame; index: number } {
-    const poorCue = findActiveCue(this.poorTimeline, currentSeconds);
-    const poorKey = this.resolvePoorKey(poorCue, currentSeconds);
-    if (!poorKey) {
-      return {
-        key: '',
-        frame: undefined,
-        index: -1,
-      };
-    }
-    const source = this.poorFramesByKey.get(poorKey) ?? createStaticFrameSource(this.missingPoorFrame);
-    const seconds = poorCue ? Math.max(0, currentSeconds - poorCue.seconds) : Math.max(0, currentSeconds);
-    const selected = selectFrameFromSource(source, seconds);
-    return {
-      key: poorKey,
-      frame: selected.frame,
-      index: selected.index,
-    };
+    return resolveFrameSelection(this.layer2FramesByKey, this.missingLayerFrame, layer2Key, seconds);
   }
 
   private resolvePoorKey(poorCue: BgaCue | undefined, currentSeconds: number): string | undefined {
@@ -667,6 +731,43 @@ function createStaticFrameSource(frame: AnsiFrame): FrameSource {
   return {
     kind: 'static',
     frame,
+  };
+}
+
+function resolveFrameSelection(
+  sourceFramesByKey: ReadonlyMap<string, FrameSource>,
+  missingFrame: AnsiFrame,
+  key: string,
+  seconds: number,
+): FrameSelection {
+  if (!key) {
+    return {
+      frame: undefined,
+      index: -1,
+    };
+  }
+  const source = sourceFramesByKey.get(key) ?? createStaticFrameSource(missingFrame);
+  return selectFrameFromSource(source, seconds);
+}
+
+function buildStageFileKittyImage(
+  source: FrameSource,
+  cellWidth: number,
+  cellHeight: number,
+): StageFileKittyImage | undefined {
+  const pixelWidth = Math.max(1, Math.floor(cellWidth) * KITTY_GRAPHICS_PIXEL_SCALE);
+  const pixelHeight = Math.max(1, Math.floor(cellHeight) * KITTY_GRAPHICS_PIXEL_SCALE);
+  const frame = selectFrameFromSource(resizeFrameSourceCover(source, pixelWidth, pixelHeight), 0).frame;
+  if (!frame) {
+    return undefined;
+  }
+  const filledFrame = fillAnsiFrameBackground(frame, 0, 0, 0);
+  return {
+    pixelWidth: filledFrame.width,
+    pixelHeight: filledFrame.height,
+    cellWidth: Math.max(1, Math.floor(cellWidth)),
+    cellHeight: Math.max(1, Math.floor(cellHeight)),
+    rgb: filledFrame.rgb,
   };
 }
 

--- a/packages/player/src/cli.test.ts
+++ b/packages/player/src/cli.test.ts
@@ -42,6 +42,12 @@ describe('player cli', () => {
     expect(parsed.inferBmsLnTypeWhenMissing).toBe(true);
   });
 
+  test('cli: keeps kitty graphics disabled by default and enables it explicitly', () => {
+    expect(parseArgs(['chart.bms']).kittyGraphics).toBe(false);
+    expect(parseArgs(['chart.bms', '--kitty-graphics']).kittyGraphics).toBe(true);
+    expect(parseArgs(['chart.bms', '--kitty-graphics', '--no-kitty-graphics']).kittyGraphics).toBe(false);
+  });
+
   test('cli: last explicit mode flag wins', () => {
     const parsedAuto = parseArgs(['chart.bms', '--auto-scratch', '--auto']);
     expect(resolvePlayModeFromArgs(parsedAuto)).toBe('auto');
@@ -194,6 +200,37 @@ describe('player cli', () => {
 
     expect(output).toContain('\u001b[2J\u001b[HANSI_STAGE_LINE_1\nANSI_STAGE_LINE_2\u001b[H');
     expect(output).toContain('Loading selected chart...');
+  });
+
+  test('cli: emits kitty graphics stagefile output when requested', () => {
+    const output = createPlayLoadingProgressScreenOutput(
+      '/charts/stagefile-test.bms',
+      {
+        ratio: 0.5,
+        message: 'Preparing audio...',
+      },
+      {
+        columns: 48,
+        useKittyGraphics: true,
+        stageFileImage: {
+          width: 48,
+          height: 2,
+          rgb: new Uint8Array(48 * 2 * 3),
+          lines: ['ANSI_STAGE_LINE_1', 'ANSI_STAGE_LINE_2'],
+          kittyImage: {
+            pixelWidth: 4,
+            pixelHeight: 2,
+            cellWidth: 48,
+            cellHeight: 2,
+            rgb: new Uint8Array(4 * 2 * 3),
+          },
+        },
+      },
+    );
+
+    expect(output).toContain('\u001b_Ga=T,t=d,f=24,s=4,v=2,c=48,r=2,i=7331,q=2,p=1,z=-1,C=1,m=0;');
+    expect(output).toContain('Loading selected chart...');
+    expect(output).not.toContain('ANSI_STAGE_LINE_1');
   });
 
   test('cli: updates loading overlay without redrawing the STAGEFILE background', () => {

--- a/packages/player/src/cli/chart-preview.test.ts
+++ b/packages/player/src/cli/chart-preview.test.ts
@@ -333,12 +333,21 @@ describe('player chart preview', () => {
   });
 });
 
-async function waitForMockCall(mock: { mock: { calls: unknown[][] } }): Promise<void> {
-  for (let attempt = 0; attempt < 20; attempt += 1) {
+async function waitForMockCall(
+  mock: { mock: { calls: unknown[][] } },
+  options: {
+    timeoutMs?: number;
+    intervalMs?: number;
+  } = {},
+): Promise<void> {
+  const timeoutMs = Math.max(10, Math.floor(options.timeoutMs ?? 1_000));
+  const intervalMs = Math.max(1, Math.floor(options.intervalMs ?? 10));
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
     if (mock.mock.calls.length > 0) {
       return;
     }
-    await delay(0);
+    await delay(intervalMs);
   }
-  throw new Error('mock was not called');
+  throw new Error(`mock was not called within ${timeoutMs}ms`);
 }

--- a/packages/player/src/cli/chart-selection.test.ts
+++ b/packages/player/src/cli/chart-selection.test.ts
@@ -1,0 +1,29 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, test } from 'vitest';
+import { listChartFiles } from './chart-selection.ts';
+
+const tempDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirectories.splice(0, tempDirectories.length).map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe('chart selection', () => {
+  test('listChartFiles: recursively includes .bmson files', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'be-music-chart-selection-'));
+    tempDirectories.push(rootDir);
+
+    await mkdir(join(rootDir, 'nested'));
+    await writeFile(join(rootDir, 'alpha.bms'), '');
+    await writeFile(join(rootDir, 'nested', 'beta.bmson'), '');
+    await writeFile(join(rootDir, 'nested', 'ignore.txt'), '');
+
+    const files = await listChartFiles(rootDir);
+
+    expect(files).toEqual([join(rootDir, 'alpha.bms'), join(rootDir, 'nested', 'beta.bmson')]);
+  });
+});

--- a/packages/player/src/cli/chart-selection.ts
+++ b/packages/player/src/cli/chart-selection.ts
@@ -75,7 +75,7 @@ export interface ListChartFilesOptions {
   signal?: AbortSignal;
 }
 
-const SELECTABLE_CHART_EXTENSIONS = new Set(['.bms', '.bme', '.bml', '.pms']);
+const SELECTABLE_CHART_EXTENSIONS = new Set(['.bms', '.bme', '.bml', '.pms', '.bmson']);
 let buildChartSelectionEntriesWorker = createBuildChartSelectionEntriesWorker();
 
 export async function listChartFiles(rootDir: string, options: ListChartFilesOptions = {}): Promise<string[]> {

--- a/packages/player/src/cli/runner.ts
+++ b/packages/player/src/cli/runner.ts
@@ -11,6 +11,11 @@ import { PlayerInterruptedError, type PlayerLoadProgress, type PlayerSummary } f
 import { loadStageFileAnsiImage, type StageFileAnsiImage } from '../bga.ts';
 import { runNodeGameplayRuntime } from '../node/node-gameplay-runtime.ts';
 import {
+  buildKittyGraphicsDeleteImageSequence,
+  buildKittyGraphicsRenderSequence,
+  supportsKittyGraphicsProtocol,
+} from '../tui/kitty-graphics.ts';
+import {
   resolveDisplayedJudgeRankLabel,
   resolveDisplayedJudgeRankValue,
   resolveDisplayedPlayLevelValue,
@@ -86,6 +91,7 @@ interface CliArgs {
   input?: string;
   auto: boolean;
   autoScratch: boolean;
+  kittyGraphics: boolean;
   inferBmsLnTypeWhenMissing: boolean;
   showInvisibleNotes: boolean;
   compressor: boolean;
@@ -126,6 +132,7 @@ interface PlayLoadingProgress {
 interface PlayLoadingScreenRenderState {
   initialized: boolean;
   stageFileDrawn: boolean;
+  stageFileKittyVisible: boolean;
 }
 
 interface SelectChartInteractivelyOptions {
@@ -212,6 +219,8 @@ interface ResultScreenOptions {
 type ResultScreenExitAction = Exclude<ResultScreenAction, 'replay'>;
 const SONG_SELECT_PREVIEW_SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'] as const;
 const SONG_SELECT_PREVIEW_SPINNER_INTERVAL_MS = 80;
+const DIRECTORY_CHART_EXTENSIONS_LABEL = '.bms, .bme, .bml, .pms, .bmson';
+const PLAY_LOADING_STAGEFILE_KITTY_IMAGE_ID = 7_331;
 
 export async function main(): Promise<void> {
   const rawArgs = process.argv.slice(2);
@@ -313,7 +322,9 @@ async function runDirectoryInput(
     startupLoadingAbortCapture?.dispose();
   }
   if (candidates.length === 0) {
-    process.stdout.write(`No chart files found in directory: ${rootDir}\n`);
+    process.stdout.write(
+      `No chart files found in directory: ${rootDir} (searched for ${DIRECTORY_CHART_EXTENSIONS_LABEL})\n`,
+    );
     process.exitCode = 1;
     return persistedConfig;
   }
@@ -619,9 +630,12 @@ function resolveDirectoryStateFromResultAction(
 async function playChartOnce(chartPath: string, args: CliArgs): Promise<PlayedChartResult> {
   let resolvedHighSpeed = normalizeHighSpeedValue(args.highSpeed);
   let playLoadingStageFileImage: StageFileAnsiImage | undefined;
+  const useKittyGraphicsForStageFile =
+    args.kittyGraphics === true && Boolean(process.stdout.isTTY) && supportsKittyGraphicsProtocol(process.env);
   const playLoadingScreenRenderState: PlayLoadingScreenRenderState = {
     initialized: false,
     stageFileDrawn: false,
+    stageFileKittyVisible: false,
   };
   let resolvedChartMetadata:
     | {
@@ -638,6 +652,7 @@ async function playChartOnce(chartPath: string, args: CliArgs): Promise<PlayedCh
         renderPlayLoadingProgress(chartPath, progress, {
           columns: process.stdout.columns,
           stageFileImage: playLoadingStageFileImage,
+          useKittyGraphics: useKittyGraphicsForStageFile,
           state: playLoadingScreenRenderState,
         });
       }
@@ -732,6 +747,7 @@ async function playChartOnce(chartPath: string, args: CliArgs): Promise<PlayedCh
       return extension.length > 0 ? extension : undefined;
     })(),
     tui: args.tui,
+    kittyGraphics: args.kittyGraphics,
   };
 
   let summary: PlayerSummary;
@@ -764,7 +780,10 @@ async function playChartOnce(chartPath: string, args: CliArgs): Promise<PlayedCh
               });
             }
           : undefined,
-        onLoadComplete: disposePlaybackLoadingAbortCapture,
+        onLoadComplete: () => {
+          clearPlayLoadingStageFileImage(playLoadingScreenRenderState);
+          disposePlaybackLoadingAbortCapture();
+        },
         onResolvedChart: (metadata) => {
           resolvedChartMetadata = metadata;
         },
@@ -776,6 +795,7 @@ async function playChartOnce(chartPath: string, args: CliArgs): Promise<PlayedCh
         throw new PlayerInterruptedError(cancelReason);
       }
       if (error instanceof PlayerInterruptedError && error.reason === 'restart') {
+        playLoadingScreenRenderState.stageFileDrawn = false;
         reportPlayLoadingProgress?.({
           ratio: 0.34,
           message: 'Restarting playback...',
@@ -784,6 +804,7 @@ async function playChartOnce(chartPath: string, args: CliArgs): Promise<PlayedCh
       }
       throw error;
     } finally {
+      clearPlayLoadingStageFileImage(playLoadingScreenRenderState);
       disposePlaybackLoadingAbortCapture();
       args.highSpeed = resolvedHighSpeed;
     }
@@ -833,6 +854,7 @@ export function parseArgs(rawArgs: string[]): CliArgs {
   const args: CliArgs = {
     auto: false,
     autoScratch: false,
+    kittyGraphics: false,
     inferBmsLnTypeWhenMissing: false,
     showInvisibleNotes: false,
     compressor: false,
@@ -1047,6 +1069,14 @@ export function parseArgs(rawArgs: string[]): CliArgs {
       args.tui = true;
       continue;
     }
+    if (token === '--kitty-graphics') {
+      args.kittyGraphics = true;
+      continue;
+    }
+    if (token === '--no-kitty-graphics') {
+      args.kittyGraphics = false;
+      continue;
+    }
     positional.push(token);
   }
 
@@ -1090,6 +1120,7 @@ function printUsage(): void {
       '  --audio / --no-audio      Enable or disable in-game audio playback (default: on)',
       '                           Audio backend: node-web-audio-api (fixed)',
       '  --tui / --no-tui          Enable or disable TUI play screen (default: on in TTY)',
+      '  --kitty-graphics          Enable Kitty graphics protocol BGA rendering when supported (default: off)',
       '',
       'Advanced tuning:',
       '  --show-invisible-notes    Show invisible channels (31-39/41-49) in TUI as green notes',
@@ -1286,6 +1317,7 @@ export function createPlayLoadingProgressScreenOutput(
   options: {
     columns?: number;
     stageFileImage?: StageFileAnsiImage;
+    useKittyGraphics?: boolean;
     resetScreen?: boolean;
     includeStageFileImage?: boolean;
   } = {},
@@ -1294,10 +1326,10 @@ export function createPlayLoadingProgressScreenOutput(
     columns: options.columns,
     stageFileImage: options.stageFileImage,
   });
-  const imageBlock =
-    options.includeStageFileImage !== false && options.stageFileImage && options.stageFileImage.lines.length > 0
-      ? `${options.stageFileImage.lines.join('\n')}\u001b[H`
-      : '';
+  const imageBlock = resolvePlayLoadingStageFileBlock(options.stageFileImage, {
+    includeStageFileImage: options.includeStageFileImage,
+    useKittyGraphics: options.useKittyGraphics,
+  });
   const prefix = options.resetScreen === false ? '\u001b[H' : '\u001b[2J\u001b[H';
   return `${prefix}${imageBlock}${overlayLines.join('\n')}`;
 }
@@ -1308,6 +1340,7 @@ function renderPlayLoadingProgress(
   options: {
     columns?: number;
     stageFileImage?: StageFileAnsiImage;
+    useKittyGraphics?: boolean;
     state: PlayLoadingScreenRenderState;
   },
 ): void {
@@ -1316,6 +1349,7 @@ function renderPlayLoadingProgress(
   const output = createPlayLoadingProgressScreenOutput(chartPath, progress, {
     columns: options.columns,
     stageFileImage: options.stageFileImage,
+    useKittyGraphics: options.useKittyGraphics,
     resetScreen: shouldResetScreen,
     includeStageFileImage: shouldRedrawStageFile,
   });
@@ -1323,7 +1357,43 @@ function renderPlayLoadingProgress(
   options.state.initialized = true;
   if (options.stageFileImage) {
     options.state.stageFileDrawn = true;
+    options.state.stageFileKittyVisible = options.useKittyGraphics === true && options.stageFileImage.kittyImage !== undefined;
   }
+}
+
+function resolvePlayLoadingStageFileBlock(
+  stageFileImage: StageFileAnsiImage | undefined,
+  options: {
+    includeStageFileImage?: boolean;
+    useKittyGraphics?: boolean;
+  },
+): string {
+  if (options.includeStageFileImage === false || !stageFileImage) {
+    return '';
+  }
+  if (options.useKittyGraphics === true && stageFileImage.kittyImage) {
+    return (
+      buildKittyGraphicsRenderSequence({
+        imageId: PLAY_LOADING_STAGEFILE_KITTY_IMAGE_ID,
+        placementId: 1,
+        row: 1,
+        column: 1,
+        image: stageFileImage.kittyImage,
+        zIndex: -1,
+        doNotMoveCursor: true,
+      }) +
+      '\u001b[H'
+    );
+  }
+  return stageFileImage.lines.length > 0 ? `${stageFileImage.lines.join('\n')}\u001b[H` : '';
+}
+
+function clearPlayLoadingStageFileImage(state: PlayLoadingScreenRenderState): void {
+  if (!state.stageFileKittyVisible) {
+    return;
+  }
+  process.stdout.write(buildKittyGraphicsDeleteImageSequence(PLAY_LOADING_STAGEFILE_KITTY_IMAGE_ID));
+  state.stageFileKittyVisible = false;
 }
 
 function stylePlayLoadingOverlayFallbackLine(text: string, lineWidth: number): string {

--- a/packages/player/src/node/node-gameplay-runtime.ts
+++ b/packages/player/src/node/node-gameplay-runtime.ts
@@ -199,6 +199,7 @@ async function handleUiInit(
       showLaneChannels: message.runtime.showLaneChannels,
       randomPatternSummary: message.runtime.randomPatternSummary,
       baseDir: message.runtime.baseDir,
+      kittyGraphics: message.runtime.kittyGraphics,
       initialPaused: message.runtime.initialPaused,
       initialJudgeCombo: message.runtime.initialJudgeCombo,
       loadSignal: runtimeStore.loadSignal,

--- a/packages/player/src/node/node-gameplay-worker-protocol.ts
+++ b/packages/player/src/node/node-gameplay-worker-protocol.ts
@@ -37,6 +37,7 @@ export interface NodeGameplayWorkerPlayOptions {
   audioLeadStepDownMs?: number;
   laneModeExtension?: string;
   tui?: boolean;
+  kittyGraphics?: boolean;
 }
 
 export interface NodeGameplayWorkerInitData {
@@ -57,6 +58,7 @@ export interface NodeGameplayUiRuntimeInit {
   showLaneChannels: boolean;
   randomPatternSummary?: string;
   baseDir: string;
+  kittyGraphics?: boolean;
   initialFrame: PlayerUiFramePayload;
   initialPaused: boolean;
   initialJudgeCombo: PlayerJudgeComboSignalState;

--- a/packages/player/src/node/node-gameplay-worker.ts
+++ b/packages/player/src/node/node-gameplay-worker.ts
@@ -376,6 +376,7 @@ function serializeUiRuntimeInit(context: CreatePlayerUiRuntimeContext): NodeGame
     showLaneChannels: context.showLaneChannels,
     randomPatternSummary: context.randomPatternSummary,
     baseDir: context.baseDir,
+    kittyGraphics: initData.playOptions.kittyGraphics === true,
     initialFrame: context.uiSignals.getFrame(),
     initialPaused: context.stateSignals.paused(),
     initialJudgeCombo: context.stateSignals.getJudgeCombo(),

--- a/packages/player/src/node/node-ui-runtime.ts
+++ b/packages/player/src/node/node-ui-runtime.ts
@@ -23,6 +23,7 @@ export interface NodeUiRuntimeOptions {
   highSpeed: number;
   showLaneChannels?: boolean;
   randomPatternSummary?: string;
+  kittyGraphics?: boolean;
   stateSignals?: PlayerStateSignals;
   uiSignals?: PlayerUiSignalBus;
   baseDir: string;
@@ -255,6 +256,7 @@ function createWorkerInitData(options: NodeUiRuntimeOptions): NodeUiWorkerInitDa
     showLaneChannels: options.showLaneChannels,
     randomPatternSummary: options.randomPatternSummary,
     baseDir: options.baseDir,
+    kittyGraphics: options.kittyGraphics,
     stdinIsTTY: Boolean(process.stdin.isTTY),
     stdoutIsTTY: Boolean(process.stdout.isTTY),
     initialPaused: options.initialPaused ?? options.stateSignals?.paused() ?? false,

--- a/packages/player/src/node/node-ui-worker-protocol.ts
+++ b/packages/player/src/node/node-ui-worker-protocol.ts
@@ -15,6 +15,7 @@ export interface NodeUiWorkerInitData {
   showLaneChannels?: boolean;
   randomPatternSummary?: string;
   baseDir: string;
+  kittyGraphics?: boolean;
   stdinIsTTY: boolean;
   stdoutIsTTY: boolean;
   initialPaused: boolean;

--- a/packages/player/src/node/node-ui-worker.ts
+++ b/packages/player/src/node/node-ui-worker.ts
@@ -18,6 +18,7 @@ import {
 } from '../utils.ts';
 import type { PlayerUiCommand, PlayerUiFramePayload } from '../core/ui-signal-bus.ts';
 import { PlayerTui } from '../tui.ts';
+import { supportsKittyGraphicsProtocol } from '../tui/kitty-graphics.ts';
 import { estimateBgaAnsiDisplaySize as resolveBgaDisplaySize, resolveLaneWidths } from '../tui/layout.ts';
 import { createDeferredUiFlush } from './deferred-ui-flush.ts';
 import { createUiWorkerFrameState } from './ui-worker-frame-state.ts';
@@ -108,6 +109,8 @@ async function bootstrap(): Promise<void> {
     splitAfterIndex,
     stdinIsTTY: initData.stdinIsTTY,
     stdoutIsTTY: initData.stdoutIsTTY,
+    terminalImageProtocol:
+      initData.kittyGraphics === true && supportsKittyGraphicsProtocol(process.env) ? 'kitty' : 'none',
   });
 
   if (!tui.isSupported()) {
@@ -115,6 +118,8 @@ async function bootstrap(): Promise<void> {
     process.exit(0);
     return;
   }
+
+  const useKittyGraphicsForBga = tui.usesKittyGraphicsForBga();
 
   const initialBgaSize = estimateBgaAnsiDisplaySize(initData.laneBindings);
   const bgaRenderer = await createBgaAnsiRenderer(initData.json, {
@@ -145,8 +150,6 @@ async function bootstrap(): Promise<void> {
     bgaRenderer?.setDisplaySize(size.width, size.height);
   };
 
-  let terminalColumns: number | undefined;
-  let terminalRows: number | undefined;
   const frameState = createUiWorkerFrameState({
     initialPaused: initData.initialPaused,
     initialHighSpeed: initData.highSpeed,
@@ -161,8 +164,6 @@ async function bootstrap(): Promise<void> {
       tui.setJudgeComboState(state);
     },
     applyTerminalSize: (columns, rows) => {
-      terminalColumns = columns;
-      terminalRows = rows;
       tui.setTerminalSize(columns, rows);
     },
     syncFrameLayout: (frame, columns, rows) => {
@@ -208,7 +209,8 @@ async function bootstrap(): Promise<void> {
     if (frame && latestFrame) {
       tui.render({
         ...latestFrame,
-        bgaAnsiLines: bgaRenderer?.getAnsiLines(latestFrame.currentSeconds),
+        bgaAnsiLines: useKittyGraphicsForBga ? undefined : bgaRenderer?.getAnsiLines(latestFrame.currentSeconds),
+        bgaKittyImage: useKittyGraphicsForBga ? bgaRenderer?.getKittyImage(latestFrame.currentSeconds) : undefined,
       });
     }
   });

--- a/packages/player/src/tui.test.ts
+++ b/packages/player/src/tui.test.ts
@@ -214,6 +214,148 @@ describe('player tui', () => {
     tui.stop();
   });
 
+  test('tui: renders BGA with kitty graphics protocol when enabled', () => {
+    mockTerminal({ columns: 120, rows: 32 });
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((() => true) as typeof process.stdout.write);
+    const tui = new PlayerTui({
+      mode: 'MANUAL',
+      laneDisplayMode: '7 KEY',
+      title: 'Test Song',
+      lanes: [
+        { channel: '16', key: 'A', isScratch: true },
+        { channel: '11', key: 'S' },
+        { channel: '12', key: 'D' },
+      ],
+      speed: 1,
+      highSpeed: 1,
+      judgeWindowMs: 16.67,
+      stdinIsTTY: true,
+      stdoutIsTTY: true,
+      terminalImageProtocol: 'kitty',
+    });
+
+    tui.start();
+    writeSpy.mockClear();
+
+    tui.render({
+      currentBeat: 0,
+      currentSeconds: 0,
+      totalSeconds: 120,
+      summary: {
+        total: 100,
+        perfect: 0,
+        fast: 0,
+        slow: 0,
+        great: 0,
+        good: 0,
+        bad: 0,
+        poor: 0,
+        exScore: 0,
+        score: 0,
+      },
+      notes: [],
+      bgaKittyImage: {
+        pixelWidth: 2,
+        pixelHeight: 2,
+        cellWidth: 4,
+        cellHeight: 2,
+        rgb: new Uint8Array([255, 0, 0, 0, 0, 0, 0, 255, 0, 0, 0, 255]),
+        token: 'frame-1',
+      },
+    });
+
+    const renderOutput = String(writeSpy.mock.calls.at(-1)?.[0] ?? '');
+    expect(renderOutput).toContain('\u001b_Ga=T,t=d,f=24,s=2,v=2,c=4,r=2,i=1337,q=2,p=1,z=-1,C=1,m=0;');
+
+    writeSpy.mockClear();
+    tui.render({
+      currentBeat: 0.5,
+      currentSeconds: 0.5,
+      totalSeconds: 120,
+      summary: {
+        total: 100,
+        perfect: 0,
+        fast: 0,
+        slow: 0,
+        great: 0,
+        good: 0,
+        bad: 0,
+        poor: 0,
+        exScore: 0,
+        score: 0,
+      },
+      notes: [],
+      bgaKittyImage: {
+        pixelWidth: 2,
+        pixelHeight: 2,
+        cellWidth: 4,
+        cellHeight: 2,
+        rgb: new Uint8Array([255, 0, 0, 0, 0, 0, 0, 255, 0, 0, 0, 255]),
+        token: 'frame-1',
+      },
+    });
+
+    const rerenderOutput = String(writeSpy.mock.calls.at(-1)?.[0] ?? '');
+    expect(rerenderOutput).not.toContain('\u001b_Ga=T,t=d,f=24');
+
+    tui.stop();
+  });
+
+  test('tui: clears kitty BGA image on stop', () => {
+    mockTerminal({ columns: 120, rows: 32 });
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((() => true) as typeof process.stdout.write);
+    const tui = new PlayerTui({
+      mode: 'MANUAL',
+      laneDisplayMode: '7 KEY',
+      title: 'Test Song',
+      lanes: [
+        { channel: '16', key: 'A', isScratch: true },
+        { channel: '11', key: 'S' },
+        { channel: '12', key: 'D' },
+      ],
+      speed: 1,
+      highSpeed: 1,
+      judgeWindowMs: 16.67,
+      stdinIsTTY: true,
+      stdoutIsTTY: true,
+      terminalImageProtocol: 'kitty',
+    });
+
+    tui.start();
+    tui.render({
+      currentBeat: 0,
+      currentSeconds: 0,
+      totalSeconds: 120,
+      summary: {
+        total: 100,
+        perfect: 0,
+        fast: 0,
+        slow: 0,
+        great: 0,
+        good: 0,
+        bad: 0,
+        poor: 0,
+        exScore: 0,
+        score: 0,
+      },
+      notes: [],
+      bgaKittyImage: {
+        pixelWidth: 1,
+        pixelHeight: 1,
+        cellWidth: 4,
+        cellHeight: 2,
+        rgb: new Uint8Array([0, 0, 0]),
+        token: 'frame-1',
+      },
+    });
+
+    writeSpy.mockClear();
+    tui.stop();
+
+    const stopOutput = String(writeSpy.mock.calls.at(-1)?.[0] ?? '');
+    expect(stopOutput).toContain('\u001b_Ga=d,d=I,i=1337,q=2\u001b\\');
+  });
+
   test('tui: estimates BGA size from the actual lane block layout', () => {
     const laneWidths = resolveLaneWidths([
       { isScratch: true },

--- a/packages/player/src/tui/kitty-graphics.ts
+++ b/packages/player/src/tui/kitty-graphics.ts
@@ -1,0 +1,90 @@
+const KITTY_GRAPHICS_ESCAPE_PREFIX = '\u001b_G';
+const KITTY_GRAPHICS_ESCAPE_SUFFIX = '\u001b\\';
+const DEFAULT_BASE64_CHUNK_SIZE = 4096;
+
+export interface KittyGraphicsImage {
+  pixelWidth: number;
+  pixelHeight: number;
+  cellWidth: number;
+  cellHeight: number;
+  rgb: Uint8Array;
+}
+
+export function supportsKittyGraphicsProtocol(env: NodeJS.ProcessEnv = process.env): boolean {
+  const term = env.TERM?.toLowerCase() ?? '';
+  const termProgram = env.TERM_PROGRAM?.toLowerCase() ?? '';
+  return (
+    typeof env.KITTY_WINDOW_ID === 'string' ||
+    term.includes('kitty') ||
+    term.includes('ghostty') ||
+    termProgram === 'ghostty'
+  );
+}
+
+export function buildKittyGraphicsDeleteImageSequence(imageId: number): string {
+  const safeImageId = Math.max(1, Math.floor(imageId));
+  return `${KITTY_GRAPHICS_ESCAPE_PREFIX}a=d,d=I,i=${safeImageId},q=2${KITTY_GRAPHICS_ESCAPE_SUFFIX}`;
+}
+
+export function buildKittyGraphicsRenderSequence(options: {
+  imageId: number;
+  placementId?: number;
+  row: number;
+  column: number;
+  image: KittyGraphicsImage;
+  zIndex?: number;
+  doNotMoveCursor?: boolean;
+  chunkSize?: number;
+}): string {
+  const safeImageId = Math.max(1, Math.floor(options.imageId));
+  const safePlacementId =
+    typeof options.placementId === 'number' && Number.isFinite(options.placementId)
+      ? Math.max(1, Math.floor(options.placementId))
+      : undefined;
+  const safeRow = Math.max(1, Math.floor(options.row));
+  const safeColumn = Math.max(1, Math.floor(options.column));
+  const safePixelWidth = Math.max(1, Math.floor(options.image.pixelWidth));
+  const safePixelHeight = Math.max(1, Math.floor(options.image.pixelHeight));
+  const safeCellWidth = Math.max(1, Math.floor(options.image.cellWidth));
+  const safeCellHeight = Math.max(1, Math.floor(options.image.cellHeight));
+  const zIndex =
+    typeof options.zIndex === 'number' && Number.isFinite(options.zIndex) ? Math.floor(options.zIndex) : undefined;
+  const base64 = Buffer.from(options.image.rgb).toString('base64');
+  const chunkSize = Math.max(256, Math.floor(options.chunkSize ?? DEFAULT_BASE64_CHUNK_SIZE));
+  const chunks = splitBase64IntoChunks(base64, chunkSize);
+  const parameters = [
+    'a=T',
+    't=d',
+    'f=24',
+    `s=${safePixelWidth}`,
+    `v=${safePixelHeight}`,
+    `c=${safeCellWidth}`,
+    `r=${safeCellHeight}`,
+    `i=${safeImageId}`,
+    'q=2',
+    safePlacementId ? `p=${safePlacementId}` : '',
+    zIndex !== undefined ? `z=${zIndex}` : '',
+    options.doNotMoveCursor === true ? 'C=1' : '',
+  ]
+    .filter((value) => value.length > 0)
+    .join(',');
+  const commands = chunks
+    .map((chunk, index) => {
+      const more = index + 1 < chunks.length ? 1 : 0;
+      const prefix = index === 0 ? `${parameters},m=${more}` : `m=${more}`;
+      return `${KITTY_GRAPHICS_ESCAPE_PREFIX}${prefix};${chunk}${KITTY_GRAPHICS_ESCAPE_SUFFIX}`;
+    })
+    .join('');
+  return `\u001b[${safeRow};${safeColumn}H${commands}`;
+}
+
+function splitBase64IntoChunks(base64: string, chunkSize: number): string[] {
+  if (base64.length <= 0) {
+    return [''];
+  }
+  const chunks: string[] = [];
+  for (let index = 0; index < base64.length; index += chunkSize) {
+    chunks.push(base64.slice(index, index + chunkSize));
+  }
+  return chunks;
+}

--- a/packages/player/src/tui/tui.ts
+++ b/packages/player/src/tui/tui.ts
@@ -1,9 +1,11 @@
 import { effect, effectScope } from 'alien-signals';
 import type { BeMusicPlayLevel } from '@be-music/json';
 import { clamp } from '@be-music/utils';
+import type { BgaKittyImage } from '../bga.ts';
 import type { PlayerSummary } from '../index.ts';
 import { formatSeconds, resolveAltModifierLabel } from '../utils.ts';
 import type { PlayerStateSignals } from '../state-signals.ts';
+import { buildKittyGraphicsDeleteImageSequence, buildKittyGraphicsRenderSequence } from './kitty-graphics.ts';
 import { findStackableRowIndex } from './lane-stacking.ts';
 import { normalizeHighSpeed, resolveAnimatedHighSpeedValue, resolveVisibleBeatsForTuiGrid } from './high-speed.ts';
 import {
@@ -50,6 +52,7 @@ interface TuiOptions {
   stateSignals?: PlayerStateSignals;
   stdinIsTTY?: boolean;
   stdoutIsTTY?: boolean;
+  terminalImageProtocol?: 'kitty' | 'none';
 }
 
 interface TuiNote {
@@ -73,6 +76,7 @@ interface TuiFrame {
   activeAudioFiles?: string[];
   activeAudioVoiceCount?: number;
   bgaAnsiLines?: string[];
+  bgaKittyImage?: BgaKittyImage;
 }
 
 interface MeasureTimelinePoint {
@@ -136,6 +140,7 @@ const INVISIBLE_NOTE_HEAD_SYMBOL = '◯';
 const INVISIBLE_LONG_NOTE_BODY_SYMBOL = '□';
 const INVISIBLE_LONG_NOTE_TAIL_SYMBOL = '◇';
 const ANSI_RESET = '\u001b[0m';
+const KITTY_BGA_IMAGE_ID = 1_337;
 const SCORE_COUNTUP_MIN_PER_SEC = 4000;
 const SCORE_COUNTUP_DISTANCE_FACTOR = 6;
 const HIGH_SPEED_TRANSITION_MS = 180;
@@ -210,6 +215,8 @@ export class PlayerTui {
 
   private readonly stateSignals?: PlayerStateSignals;
 
+  private readonly terminalImageProtocol: 'kitty' | 'none';
+
   private readonly laneIndex = new Map<string, number>();
 
   private readonly laneChannels: string[];
@@ -276,6 +283,10 @@ export class PlayerTui {
 
   private lastRenderedBeat = Number.NaN;
 
+  private lastKittyBgaToken = '';
+
+  private kittyBgaVisible = false;
+
   constructor(options: TuiOptions) {
     const initialHighSpeed = normalizeHighSpeed(options.highSpeed);
     options.highSpeed = initialHighSpeed;
@@ -289,6 +300,7 @@ export class PlayerTui {
     this.supported = Boolean(
       (options.stdoutIsTTY ?? process.stdout.isTTY) && (options.stdinIsTTY ?? process.stdin.isTTY),
     );
+    this.terminalImageProtocol = options.terminalImageProtocol ?? 'none';
     const laneWidths = resolveLaneWidths(options.lanes);
     options.lanes.forEach((lane, index) => {
       this.laneIndex.set(lane.channel, index);
@@ -325,12 +337,18 @@ export class PlayerTui {
     return this.supported;
   }
 
+  usesKittyGraphicsForBga(): boolean {
+    return this.terminalImageProtocol === 'kitty';
+  }
+
   start(): void {
     if (!this.supported || this.active) {
       return;
     }
     this.active = true;
     this.needsFullRefresh = false;
+    this.lastKittyBgaToken = '';
+    this.kittyBgaVisible = false;
     process.stdout.write('\u001b[?1049h\u001b[2J\u001b[H\u001b[?25l');
   }
 
@@ -361,7 +379,10 @@ export class PlayerTui {
     this.smoothedFps = Number.NaN;
     this.lastFrameRenderedAtMs = 0;
     this.lastRenderedBeat = Number.NaN;
-    process.stdout.write('\u001b[0m\u001b[?25h\u001b[?1049l');
+    const clearKittyBga = this.kittyBgaVisible ? buildKittyGraphicsDeleteImageSequence(KITTY_BGA_IMAGE_ID) : '';
+    this.lastKittyBgaToken = '';
+    this.kittyBgaVisible = false;
+    process.stdout.write(`${clearKittyBga}\u001b[0m\u001b[?25h\u001b[?1049l`);
   }
 
   setLatestJudge(value: string, channel?: string): void {
@@ -771,7 +792,25 @@ export class PlayerTui {
       playfieldIndicatorEndIndex,
       hasLaneSplit(this.options.splitAfterIndex, this.laneWidths.length),
     );
-    lines.push(...renderLaneBlockWithBga(laneLinesWithProgress, frame.bgaAnsiLines));
+    const laneBlockStartRow = lines.length + 1;
+    let kittyBgaPlacement:
+      | {
+          row: number;
+          column: number;
+          image: BgaKittyImage;
+        }
+      | undefined;
+    if (this.terminalImageProtocol === 'kitty' && frame.bgaKittyImage) {
+      const renderedKittyBga = renderLaneBlockWithKittyPadding(laneLinesWithProgress, frame.bgaKittyImage.cellWidth);
+      lines.push(...renderedKittyBga.lines);
+      kittyBgaPlacement = {
+        row: laneBlockStartRow,
+        column: renderedKittyBga.column,
+        image: frame.bgaKittyImage,
+      };
+    } else {
+      lines.push(...renderLaneBlockWithBga(laneLinesWithProgress, frame.bgaAnsiLines));
+    }
     lines.push('');
     lines.push(formatGrooveGaugeLine(frame.summary, calculateLaneBlockVisibleWidth(this.laneWidths, this.options.splitAfterIndex ?? -1)));
     lines.push('');
@@ -787,7 +826,29 @@ export class PlayerTui {
         paddedLines.push(' '.repeat(columns));
       }
     }
-    process.stdout.write(`${this.needsFullRefresh ? '\u001b[2J' : ''}\u001b[H${paddedLines.join('\n')}`);
+    const needsFullRefresh = this.needsFullRefresh;
+    let overlaySequence = '';
+    if (kittyBgaPlacement) {
+      const kittyToken = `${kittyBgaPlacement.image.token}:${kittyBgaPlacement.row}:${kittyBgaPlacement.column}`;
+      if (needsFullRefresh || this.lastKittyBgaToken !== kittyToken) {
+        overlaySequence = buildKittyGraphicsRenderSequence({
+          imageId: KITTY_BGA_IMAGE_ID,
+          placementId: 1,
+          row: kittyBgaPlacement.row,
+          column: kittyBgaPlacement.column,
+          image: kittyBgaPlacement.image,
+          zIndex: -1,
+          doNotMoveCursor: true,
+        });
+        this.lastKittyBgaToken = kittyToken;
+        this.kittyBgaVisible = true;
+      }
+    } else if (this.kittyBgaVisible) {
+      overlaySequence = buildKittyGraphicsDeleteImageSequence(KITTY_BGA_IMAGE_ID);
+      this.lastKittyBgaToken = '';
+      this.kittyBgaVisible = false;
+    }
+    process.stdout.write(`${needsFullRefresh ? '\u001b[2J' : ''}\u001b[H${paddedLines.join('\n')}${overlaySequence}`);
     this.previousFrameLineCount = lines.length;
     this.needsFullRefresh = false;
     this.lastRenderedBeat = frame.currentBeat;
@@ -1932,6 +1993,22 @@ function renderLaneBlockWithBga(laneLines: string[], bgaAnsiLines?: string[]): s
   );
   const emptyBgaLine = renderBgaLineWithScopedBlackBackground(' '.repeat(bgaWidth), bgaWidth);
   return laneLines.map((laneLine, index) => `${laneLine}   ${normalizedBgaLines[index] ?? emptyBgaLine}`);
+}
+
+function renderLaneBlockWithKittyPadding(
+  laneLines: string[],
+  bgaWidth: number,
+): {
+  lines: string[];
+  column: number;
+} {
+  const safeBgaWidth = Math.max(1, Math.floor(bgaWidth));
+  const laneBlockWidth = Math.max(1, ...laneLines.map((line) => visibleWidth(line)));
+  const emptyBgaLine = renderBgaLineWithScopedBlackBackground(' '.repeat(safeBgaWidth), safeBgaWidth);
+  return {
+    lines: laneLines.map((laneLine) => `${padVisibleWidth(laneLine, laneBlockWidth)}   ${emptyBgaLine}`),
+    column: laneBlockWidth + 4,
+  };
 }
 
 function renderLaneLinesWithProgressIndicators(


### PR DESCRIPTION
## Summary
- add `--kitty-graphics` as an opt-in flag while keeping ANSI rendering as the default
- render gameplay BGA and loading `#STAGEFILE` images through the Kitty graphics protocol when enabled
- keep loading text visible and reduce Kitty BGA flicker by rendering images behind the text overlay without deleting them on each update
- include `.bmson` in directory chart discovery and add regression coverage for the new rendering paths

## Testing
- `mise exec -- pnpm --filter @be-music/player typecheck`
- `mise exec -- pnpm vitest run packages/player/src/bga.test.ts packages/player/src/cli.test.ts packages/player/src/cli/chart-selection.test.ts packages/player/src/tui.test.ts packages/player/src/node/node-ui-runtime.test.ts`
