### PR TITLE
perf(player): reduce rendering hot path overhead

### DIFF
--- a/packages/player/src/bga.ts
+++ b/packages/player/src/bga.ts
@@ -910,6 +910,9 @@ function mergeCompositeFrames(...sourceFrames: Array<AnsiFrame | undefined>): Co
   if (frames.length === 0) {
     return undefined;
   }
+  if (frames.length === 1) {
+    return frames[0];
+  }
 
   let canvasWidth = 0;
   let canvasHeight = 0;

--- a/packages/player/src/cli/runner.ts
+++ b/packages/player/src/cli/runner.ts
@@ -1501,6 +1501,13 @@ async function selectChartInteractively(
   let previewSpinnerFrame = 0;
   let previewSpinnerTimer: NodeJS.Timeout | undefined;
   let wasSpinnerVisible = false;
+  let cachedColumnLayoutEntries: readonly ChartSelectionEntry[] | undefined;
+  let cachedColumnLayoutWidth = -1;
+  let cachedColumnLayout: ReturnType<typeof createSelectionColumnLayout> | undefined;
+  let cachedColumnHeaderLayout: ReturnType<typeof createSelectionColumnLayout> | undefined;
+  let cachedColumnHeader = '';
+  let cachedEntryLabelsLayout: ReturnType<typeof createSelectionColumnLayout> | undefined;
+  let cachedEntryLabels = new WeakMap<ChartSelectionEntry, string>();
 
   const inputCapture = beginRawInputCapture();
   const songSelectState = createSongSelectState(allEntries, {
@@ -1530,6 +1537,53 @@ async function selectChartInteractively(
     return Math.max(5, rows - 8);
   };
 
+  const resolveSelectionColumnLayout = (
+    entries: readonly ChartSelectionEntry[],
+    itemLabelWidth: number,
+  ): ReturnType<typeof createSelectionColumnLayout> => {
+    if (
+      cachedColumnLayout &&
+      cachedColumnLayoutEntries === entries &&
+      cachedColumnLayoutWidth === itemLabelWidth
+    ) {
+      return cachedColumnLayout;
+    }
+    cachedColumnLayout = createSelectionColumnLayout(itemLabelWidth, entries);
+    cachedColumnLayoutEntries = entries;
+    cachedColumnLayoutWidth = itemLabelWidth;
+    return cachedColumnLayout;
+  };
+
+  const resolveSelectionColumnHeader = (
+    layout: ReturnType<typeof createSelectionColumnLayout>,
+    itemLabelWidth: number,
+  ): string => {
+    if (cachedColumnHeaderLayout === layout) {
+      return cachedColumnHeader;
+    }
+    cachedColumnHeader = truncateForDisplay(formatSelectionColumnHeader(layout), itemLabelWidth);
+    cachedColumnHeaderLayout = layout;
+    return cachedColumnHeader;
+  };
+
+  const resolveSelectionEntryLabel = (
+    entry: ChartSelectionEntry,
+    layout: ReturnType<typeof createSelectionColumnLayout>,
+    itemLabelWidth: number,
+  ): string => {
+    if (cachedEntryLabelsLayout !== layout) {
+      cachedEntryLabelsLayout = layout;
+      cachedEntryLabels = new WeakMap<ChartSelectionEntry, string>();
+    }
+    const cached = cachedEntryLabels.get(entry);
+    if (cached) {
+      return cached;
+    }
+    const label = truncateForDisplay(formatSelectionEntryLabel(entry, layout), itemLabelWidth);
+    cachedEntryLabels.set(entry, label);
+    return label;
+  };
+
   const render = (): void => {
     const view = songSelectState.view();
     const columns = process.stdout.columns ?? 80;
@@ -1537,7 +1591,7 @@ async function selectChartInteractively(
     const numberWidth = String(Math.max(1, view.chartCount)).length;
     const lineWidth = Math.max(16, columns - 2);
     const itemLabelWidth = Math.max(8, lineWidth - numberWidth - 4);
-    const columnLayout = createSelectionColumnLayout(itemLabelWidth, view.entries);
+    const columnLayout = resolveSelectionColumnLayout(view.entries, itemLabelWidth);
 
     const { start, end } = resolveVisibleEntryRange(songSelectState.selectedIndex(), view.entries.length, listRows);
 
@@ -1554,8 +1608,7 @@ async function selectChartInteractively(
     );
     lines.push('');
     const headerPrefix = `  ${' '.repeat(numberWidth)} `;
-    const columnHeader = formatSelectionColumnHeader(columnLayout);
-    lines.push(`${headerPrefix}${truncateForDisplay(columnHeader, itemLabelWidth)}`);
+    lines.push(`${headerPrefix}${resolveSelectionColumnHeader(columnLayout, itemLabelWidth)}`);
 
     if (view.entries.length === 0) {
       lines.push('');
@@ -1579,7 +1632,10 @@ async function selectChartInteractively(
           fileLabel: `${SONG_SELECT_PREVIEW_SPINNER_FRAMES[previewSpinnerFrame]} ${entry.fileLabel}`,
         };
       }
-      const label = truncateForDisplay(formatSelectionEntryLabel(displayEntry, columnLayout), itemLabelWidth);
+      const label =
+        displayEntry === entry
+          ? resolveSelectionEntryLabel(entry, columnLayout, itemLabelWidth)
+          : truncateForDisplay(formatSelectionEntryLabel(displayEntry, columnLayout), itemLabelWidth);
       const line = `${marker} ${number} ${label}`;
       if (index === songSelectState.selectedIndex()) {
         lines.push(`\u001b[7m${line.padEnd(lineWidth, ' ')}\u001b[0m`);

--- a/packages/player/src/node/node-ui-worker.ts
+++ b/packages/player/src/node/node-ui-worker.ts
@@ -21,6 +21,7 @@ import { PlayerTui } from '../tui.ts';
 import { supportsKittyGraphicsProtocol } from '../tui/kitty-graphics.ts';
 import { estimateBgaAnsiDisplaySize as resolveBgaDisplaySize, resolveLaneWidths } from '../tui/layout.ts';
 import { createDeferredUiFlush } from './deferred-ui-flush.ts';
+import { createRenderThrottle } from './render-throttle.ts';
 import { createUiWorkerFrameState } from './ui-worker-frame-state.ts';
 import type {
   NodeUiWorkerInboundMessage,
@@ -30,6 +31,7 @@ import type {
 
 const port = parentPort;
 const initData = workerData as NodeUiWorkerInitData;
+const TUI_RENDER_MIN_INTERVAL_MS = Math.floor(1000 / 30);
 
 void bootstrap().catch((error) => {
   if (isAbortError(error)) {
@@ -150,6 +152,7 @@ async function bootstrap(): Promise<void> {
     bgaRenderer?.setDisplaySize(size.width, size.height);
   };
 
+  let renderThrottle: ReturnType<typeof createRenderThrottle> | undefined;
   const frameState = createUiWorkerFrameState({
     initialPaused: initData.initialPaused,
     initialHighSpeed: initData.highSpeed,
@@ -205,15 +208,27 @@ async function bootstrap(): Promise<void> {
       }
     }
 
-    const latestFrame = frameState.getFrame();
-    if (frame && latestFrame) {
+    if (frame || commands) {
+      renderThrottle?.request();
+    }
+  });
+
+  renderThrottle = createRenderThrottle(
+    () => {
+      const latestFrame = frameState.getFrame();
+      if (!latestFrame) {
+        return;
+      }
       tui.render({
         ...latestFrame,
         bgaAnsiLines: useKittyGraphicsForBga ? undefined : bgaRenderer?.getAnsiLines(latestFrame.currentSeconds),
         bgaKittyImage: useKittyGraphicsForBga ? bgaRenderer?.getKittyImage(latestFrame.currentSeconds) : undefined,
       });
-    }
-  });
+    },
+    {
+      minIntervalMs: TUI_RENDER_MIN_INTERVAL_MS,
+    },
+  );
 
   const handleRenderMessage = (message: NodeUiWorkerInboundMessage): boolean => {
     if (message.kind === 'start') {
@@ -272,6 +287,7 @@ async function bootstrap(): Promise<void> {
     if (message.kind === 'dispose') {
       frameState.dispose();
       deferredUiFlush.dispose();
+      renderThrottle?.dispose();
       bridgePort?.close();
       tui.stop();
       postWorkerMessage({ kind: 'disposed' });

--- a/packages/player/src/node/render-throttle.test.ts
+++ b/packages/player/src/node/render-throttle.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { createRenderThrottle } from './render-throttle.ts';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('render throttle', () => {
+  test('renders immediately on the first request', () => {
+    vi.useFakeTimers();
+    const renderSpy = vi.fn();
+    const throttle = createRenderThrottle(renderSpy, {
+      minIntervalMs: 33,
+    });
+
+    throttle.request();
+
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('coalesces repeated requests within the throttle window', async () => {
+    vi.useFakeTimers();
+    const renderSpy = vi.fn();
+    const throttle = createRenderThrottle(renderSpy, {
+      minIntervalMs: 33,
+    });
+
+    throttle.request();
+    throttle.request();
+    throttle.request();
+
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(32);
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(renderSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test('cancels pending renders on dispose', async () => {
+    vi.useFakeTimers();
+    const renderSpy = vi.fn();
+    const throttle = createRenderThrottle(renderSpy, {
+      minIntervalMs: 33,
+    });
+
+    throttle.request();
+    throttle.request();
+    throttle.dispose();
+
+    await vi.runAllTimersAsync();
+
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/player/src/node/render-throttle.ts
+++ b/packages/player/src/node/render-throttle.ts
@@ -1,0 +1,66 @@
+export interface RenderThrottle {
+  request: () => void;
+  dispose: () => void;
+}
+
+export interface CreateRenderThrottleOptions {
+  minIntervalMs?: number;
+  now?: () => number;
+}
+
+export function createRenderThrottle(
+  render: () => void,
+  options: CreateRenderThrottleOptions = {},
+): RenderThrottle {
+  const minIntervalMs = normalizeMinInterval(options.minIntervalMs);
+  const now = options.now ?? Date.now;
+  let disposed = false;
+  let lastRenderAtMs = Number.NEGATIVE_INFINITY;
+  let timer: NodeJS.Timeout | undefined;
+
+  const clearTimer = (): void => {
+    if (!timer) {
+      return;
+    }
+    clearTimeout(timer);
+    timer = undefined;
+  };
+
+  const run = (): void => {
+    timer = undefined;
+    if (disposed) {
+      return;
+    }
+    lastRenderAtMs = now();
+    render();
+  };
+
+  return {
+    request: () => {
+      if (disposed) {
+        return;
+      }
+      const remainingMs = minIntervalMs - (now() - lastRenderAtMs);
+      if (remainingMs <= 0) {
+        clearTimer();
+        run();
+        return;
+      }
+      if (timer) {
+        return;
+      }
+      timer = setTimeout(run, remainingMs);
+    },
+    dispose: () => {
+      disposed = true;
+      clearTimer();
+    },
+  };
+}
+
+function normalizeMinInterval(value: number | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.floor(value));
+}

--- a/packages/player/src/tui/kitty-graphics.ts
+++ b/packages/player/src/tui/kitty-graphics.ts
@@ -1,6 +1,7 @@
 const KITTY_GRAPHICS_ESCAPE_PREFIX = '\u001b_G';
 const KITTY_GRAPHICS_ESCAPE_SUFFIX = '\u001b\\';
 const DEFAULT_BASE64_CHUNK_SIZE = 4096;
+const encodedChunkCache = new WeakMap<KittyGraphicsImage, Map<number, string[]>>();
 
 export interface KittyGraphicsImage {
   pixelWidth: number;
@@ -49,9 +50,8 @@ export function buildKittyGraphicsRenderSequence(options: {
   const safeCellHeight = Math.max(1, Math.floor(options.image.cellHeight));
   const zIndex =
     typeof options.zIndex === 'number' && Number.isFinite(options.zIndex) ? Math.floor(options.zIndex) : undefined;
-  const base64 = Buffer.from(options.image.rgb).toString('base64');
   const chunkSize = Math.max(256, Math.floor(options.chunkSize ?? DEFAULT_BASE64_CHUNK_SIZE));
-  const chunks = splitBase64IntoChunks(base64, chunkSize);
+  const chunks = resolveEncodedChunks(options.image, chunkSize);
   const parameters = [
     'a=T',
     't=d',
@@ -76,6 +76,21 @@ export function buildKittyGraphicsRenderSequence(options: {
     })
     .join('');
   return `\u001b[${safeRow};${safeColumn}H${commands}`;
+}
+
+function resolveEncodedChunks(image: KittyGraphicsImage, chunkSize: number): string[] {
+  const cachedByChunkSize = encodedChunkCache.get(image);
+  const cachedChunks = cachedByChunkSize?.get(chunkSize);
+  if (cachedChunks) {
+    return cachedChunks;
+  }
+  const chunks = splitBase64IntoChunks(Buffer.from(image.rgb).toString('base64'), chunkSize);
+  const nextCachedByChunkSize = cachedByChunkSize ?? new Map<number, string[]>();
+  nextCachedByChunkSize.set(chunkSize, chunks);
+  if (!cachedByChunkSize) {
+    encodedChunkCache.set(image, nextCachedByChunkSize);
+  }
+  return chunks;
 }
 
 function splitBase64IntoChunks(base64: string, chunkSize: number): string[] {


### PR DESCRIPTION
## Summary
- throttle gameplay TUI rendering in the UI worker so heavy terminal redraws do not run on every dirty frame
- reduce Kitty/BGA work by reusing single-frame composites and caching encoded Kitty payload chunks per image
- cache song selection column layout and entry label formatting so repeated cursor moves avoid full relayout work

## Commits
- `perf(player): throttle gameplay UI rendering`
- `perf(player): reduce kitty BGA recomposition work`
- `perf(player): cache song selection layout formatting`

## Testing
- `mise exec -- pnpm --filter @be-music/player typecheck`
- `mise exec -- pnpm vitest run packages/player/src/node/render-throttle.test.ts packages/player/src/node/node-ui-runtime.test.ts packages/player/src/node/deferred-ui-flush.test.ts`
- `mise exec -- pnpm vitest run packages/player/src/bga.test.ts packages/player/src/tui.test.ts packages/player/src/node/node-ui-runtime.test.ts packages/player/src/cli.test.ts`
- `mise exec -- pnpm vitest run packages/player/src/cli.test.ts packages/player/src/cli/chart-preview.test.ts packages/player/src/cli/song-select-state.test.ts`
- `mise exec -- pnpm test`
