### PR TITLE
perf(player): speed up chart and BGA loading

### DIFF
--- a/packages/player/src/bga.test.ts
+++ b/packages/player/src/bga.test.ts
@@ -85,6 +85,45 @@ describe('player bga', () => {
     }
   });
 
+  test('player bga: reuses identical base-mode assets across layers during initialization', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-shared-load-'));
+    try {
+      const sharedPath = join(baseDir, 'shared.png');
+      await writePng(sharedPath, 256, 256, () => ({ r: 255, g: 0, b: 0, a: 255 }));
+
+      const json = createEmptyJson('bms');
+      json.metadata.bpm = 120;
+      json.resources.bmp['01'] = 'shared.png';
+      json.events = [
+        { measure: 0, channel: '04', position: [0, 1], value: '01' },
+        { measure: 0, channel: '06', position: [0, 1], value: '01' },
+      ];
+
+      const fsPromises = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+      const readFileMock = vi.fn(fsPromises.readFile);
+      vi.resetModules();
+      vi.doMock('node:fs/promises', () => ({
+        ...fsPromises,
+        readFile: readFileMock,
+      }));
+      const { createBgaAnsiRenderer: createBgaAnsiRendererWithMock } = await import('./bga.ts');
+
+      const renderer = await createBgaAnsiRendererWithMock(json, {
+        baseDir,
+        width: 40,
+        height: 20,
+      });
+
+      expect(renderer).toBeDefined();
+      const sharedReads = readFileMock.mock.calls.filter(([filePath]) => filePath === sharedPath);
+      expect(sharedReads).toHaveLength(1);
+    } finally {
+      vi.doUnmock('node:fs/promises');
+      vi.resetModules();
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
   test('player bga: loads STAGEFILE splash lines as a full-screen cover image', async () => {
     const baseDir = await mkdtemp(join(tmpdir(), 'be-music-stagefile-splash-'));
     try {

--- a/packages/player/src/bga.ts
+++ b/packages/player/src/bga.ts
@@ -1,4 +1,5 @@
 import { readFile } from 'node:fs/promises';
+import { availableParallelism } from 'node:os';
 import { extname } from 'node:path';
 import {
   invokeWorkerizedFunction,
@@ -31,6 +32,7 @@ const ANSI_RESET = '\u001b[0m';
 const SPEC_BGA_CANVAS_SIZE = 256;
 const TERMINAL_PIXEL_ASPECT_X = 2;
 const TERMINAL_PIXEL_ASPECT_Y = 1;
+const BGA_SOURCE_LOAD_CONCURRENCY = Math.max(1, Math.min(8, availableParallelism()));
 
 type ImageFormat = 'bmp' | 'png' | 'jpeg' | 'video';
 type FrameMode = 'base' | 'layer';
@@ -128,6 +130,8 @@ export interface TerminalKittyImage {
 
 export type StageFileAnsiImage = TerminalAnsiImage;
 export type StageFileKittyImage = TerminalKittyImage;
+
+type FrameSourceLoadCache = Map<string, Promise<FrameSource | null>>;
 
 export interface BgaKittyImage {
   pixelWidth: number;
@@ -567,49 +571,54 @@ export async function createBgaAnsiRenderer(
     });
   };
 
-  const baseSourceFramesByKey = await loadFramesByKeys({
-    keys: baseKeys,
-    resources: json.resources.bmp,
-    baseDir: options.baseDir,
-    mode: 'base',
-    width: displaySize.width,
-    height: displaySize.height,
-    onLoadProgress: reportLoadProgress,
-    signal: options.signal,
-  });
-  throwIfAborted(options.signal);
-  const poorSourceFramesByKey = await loadFramesByKeys({
-    keys: poorKeys,
-    resources: json.resources.bmp,
-    baseDir: options.baseDir,
-    mode: 'base',
-    width: displaySize.width,
-    height: displaySize.height,
-    onLoadProgress: reportLoadProgress,
-    signal: options.signal,
-  });
-  throwIfAborted(options.signal);
-  const layerSourceFramesByKey = await loadFramesByKeys({
-    keys: layerKeys,
-    resources: json.resources.bmp,
-    baseDir: options.baseDir,
-    mode: 'layer',
-    width: displaySize.width,
-    height: displaySize.height,
-    onLoadProgress: reportLoadProgress,
-    signal: options.signal,
-  });
-  throwIfAborted(options.signal);
-  const layer2SourceFramesByKey = await loadFramesByKeys({
-    keys: layer2Keys,
-    resources: json.resources.bmp,
-    baseDir: options.baseDir,
-    mode: 'layer',
-    width: displaySize.width,
-    height: displaySize.height,
-    onLoadProgress: reportLoadProgress,
-    signal: options.signal,
-  });
+  const sharedSourceCache: FrameSourceLoadCache = new Map();
+  const [baseSourceFramesByKey, poorSourceFramesByKey, layerSourceFramesByKey, layer2SourceFramesByKey] =
+    await Promise.all([
+      loadFramesByKeys({
+        keys: baseKeys,
+        resources: json.resources.bmp,
+        baseDir: options.baseDir,
+        mode: 'base',
+        width: displaySize.width,
+        height: displaySize.height,
+        onLoadProgress: reportLoadProgress,
+        signal: options.signal,
+        sharedSourceCache,
+      }),
+      loadFramesByKeys({
+        keys: poorKeys,
+        resources: json.resources.bmp,
+        baseDir: options.baseDir,
+        mode: 'base',
+        width: displaySize.width,
+        height: displaySize.height,
+        onLoadProgress: reportLoadProgress,
+        signal: options.signal,
+        sharedSourceCache,
+      }),
+      loadFramesByKeys({
+        keys: layerKeys,
+        resources: json.resources.bmp,
+        baseDir: options.baseDir,
+        mode: 'layer',
+        width: displaySize.width,
+        height: displaySize.height,
+        onLoadProgress: reportLoadProgress,
+        signal: options.signal,
+        sharedSourceCache,
+      }),
+      loadFramesByKeys({
+        keys: layer2Keys,
+        resources: json.resources.bmp,
+        baseDir: options.baseDir,
+        mode: 'layer',
+        width: displaySize.width,
+        height: displaySize.height,
+        onLoadProgress: reportLoadProgress,
+        signal: options.signal,
+        sharedSourceCache,
+      }),
+    ]);
   throwIfAborted(options.signal);
 
   if (
@@ -662,34 +671,41 @@ async function loadFramesByKeys(params: {
   height: number;
   onLoadProgress?: (detail: string) => void;
   signal?: AbortSignal;
+  sharedSourceCache: FrameSourceLoadCache;
 }): Promise<Map<string, FrameSource>> {
-  const { keys, resources, baseDir, mode, width, height, onLoadProgress, signal } = params;
+  const { keys, resources, baseDir, mode, width, height, onLoadProgress, signal, sharedSourceCache } = params;
   const map = new Map<string, FrameSource>();
-  const cache = new Map<string, FrameSource | null>();
+  const orderedKeys = [...keys];
+  await mapWithConcurrency(
+    orderedKeys,
+    Math.min(orderedKeys.length || 1, BGA_SOURCE_LOAD_CONCURRENCY),
+    async (key) => {
+      throwIfAborted(signal);
+      const resourcePath = resources[key];
+      if (!resourcePath) {
+        return;
+      }
+      const resolved = await resolveMediaPath(baseDir, resourcePath, signal);
+      if (!resolved) {
+        onLoadProgress?.(resourcePath);
+        return;
+      }
 
-  for (const key of keys) {
-    throwIfAborted(signal);
-    const resourcePath = resources[key];
-    if (!resourcePath) {
-      continue;
-    }
-    onLoadProgress?.(resourcePath);
-    const resolved = await resolveMediaPath(baseDir, resourcePath, signal);
-    if (!resolved) {
-      continue;
-    }
+      const cacheKey = `${mode}:${width}x${height}:${resolved}`;
+      let sourcePromise = sharedSourceCache.get(cacheKey);
+      if (!sourcePromise) {
+        sourcePromise = loadFrameSource(resolved, mode, width, height, signal).then((source) => source ?? null);
+        sharedSourceCache.set(cacheKey, sourcePromise);
+      }
 
-    const cacheKey = `${mode}:${width}x${height}:${resolved}`;
-    if (!cache.has(cacheKey)) {
-      const source = await loadFrameSource(resolved, mode, width, height, signal);
-      cache.set(cacheKey, source ?? null);
-    }
-
-    const source = cache.get(cacheKey);
-    if (source) {
-      map.set(key, source);
-    }
-  }
+      const source = await sourcePromise;
+      if (source) {
+        map.set(key, source);
+      }
+      onLoadProgress?.(resourcePath);
+    },
+    signal,
+  );
 
   return map;
 }
@@ -713,6 +729,32 @@ function normalizeDisplaySize(width?: number, height?: number): { width: number;
     width: Math.max(8, Math.floor(width ?? DEFAULT_BGA_ASCII_WIDTH)),
     height: Math.max(6, Math.floor(height ?? DEFAULT_BGA_ASCII_HEIGHT)),
   };
+}
+
+async function mapWithConcurrency<TInput>(
+  items: readonly TInput[],
+  concurrency: number,
+  worker: (item: TInput, index: number) => Promise<void>,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (items.length === 0) {
+    return;
+  }
+  let nextIndex = 0;
+  const workerCount = Math.max(1, Math.min(concurrency, items.length));
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (true) {
+        throwIfAborted(signal);
+        const currentIndex = nextIndex;
+        if (currentIndex >= items.length) {
+          return;
+        }
+        nextIndex += 1;
+        await worker(items[currentIndex]!, currentIndex);
+      }
+    }),
+  );
 }
 
 function resizeFrameSourceMap(

--- a/packages/player/src/cli/chart-selection.test.ts
+++ b/packages/player/src/cli/chart-selection.test.ts
@@ -92,6 +92,37 @@ describe('chart selection', () => {
     });
   });
 
+  test('buildChartSelectionEntries: reports progress for every chart while building in parallel', async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), 'be-music-chart-progress-'));
+    tempDirectories.push(tempRoot);
+
+    const chartPaths = [
+      join(tempRoot, 'alpha.bms'),
+      join(tempRoot, 'beta.bms'),
+      join(tempRoot, 'gamma.bms'),
+    ];
+    await Promise.all(
+      chartPaths.map((chartPath, index) =>
+        writeFile(chartPath, [`#TITLE Chart ${index + 1}`, '#ARTIST Codex', '#PLAYER 1', '#BPM 120'].join('\n')),
+      ),
+    );
+
+    const progressUpdates: Array<{ filePath: string; currentIndex: number; totalCount: number }> = [];
+    const entries = await buildChartSelectionEntries(tempRoot, chartPaths, {
+      onLoadingFile: (progress) => {
+        progressUpdates.push(progress);
+      },
+    });
+
+    expect(entries.filter((entry) => entry.kind === 'chart')).toHaveLength(chartPaths.length);
+    expect(progressUpdates).toHaveLength(chartPaths.length);
+    expect(progressUpdates.at(-1)).toMatchObject({
+      currentIndex: chartPaths.length,
+      totalCount: chartPaths.length,
+    });
+    expect(new Set(progressUpdates.map((progress) => progress.filePath))).toEqual(new Set(chartPaths));
+  });
+
   test('buildChartSelectionEntries: reuses cached summaries when chart content is unchanged', async () => {
     const tempRoot = await mkdtemp(join(tmpdir(), 'be-music-chart-cache-hit-'));
     const tempHome = await mkdtemp(join(tmpdir(), 'be-music-chart-cache-home-'));

--- a/packages/player/src/cli/chart-selection.ts
+++ b/packages/player/src/cli/chart-selection.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
-import { homedir } from 'node:os';
+import { availableParallelism, homedir } from 'node:os';
 import { dirname, extname, relative, resolve } from 'node:path';
 import { invokeWorkerizedFunction, isAbortError, throwIfAborted, workerize } from '@be-music/utils';
 import { type BeMusicJson, type BeMusicPlayLevel } from '@be-music/json';
@@ -115,6 +115,7 @@ export interface ListChartFilesOptions {
 
 const SELECTABLE_CHART_EXTENSIONS = new Set(['.bms', '.bme', '.bml', '.pms', '.bmson']);
 const CHART_SELECTION_CACHE_FORMAT = 'be-music-player-chart-selection-cache/3';
+const CHART_SELECTION_BUILD_CONCURRENCY = Math.max(1, Math.min(8, availableParallelism()));
 let buildChartSelectionEntriesWorker = createBuildChartSelectionEntriesWorker();
 
 export async function listChartFiles(rootDir: string, options: ListChartFilesOptions = {}): Promise<string[]> {
@@ -158,30 +159,30 @@ export async function buildChartSelectionEntries(
   const cachedEntries = cache.directories[rootDir]?.files ?? {};
   const nextCachedEntries: Record<string, PersistedChartSelectionCacheFileEntry> = {};
   let cacheDirty = cache.directories[rootDir] === undefined || Object.keys(cachedEntries).length !== files.length;
-  let resolvedEntries: ResolvedChartSummaryCacheEntry[];
-  if (!options.onLoadingFile) {
-    resolvedEntries = await Promise.all(
-      files.map((filePath) => {
-        const relativePath = resolveChartSummaryRelativePath(rootDir, filePath);
-        return buildChartSummaryWithCache(rootDir, filePath, relativePath, cachedEntries[relativePath], options.signal);
-      }),
-    );
-  } else {
-    resolvedEntries = [];
-    for (let index = 0; index < files.length; index += 1) {
+  let completedFileCount = 0;
+  const resolvedEntries = await mapWithConcurrency(
+    files,
+    Math.min(files.length || 1, CHART_SELECTION_BUILD_CONCURRENCY),
+    async (filePath) => {
       throwIfAborted(options.signal);
-      const filePath = files[index];
+      const relativePath = resolveChartSummaryRelativePath(rootDir, filePath);
+      const resolvedEntry = await buildChartSummaryWithCache(
+        rootDir,
+        filePath,
+        relativePath,
+        cachedEntries[relativePath],
+        options.signal,
+      );
+      completedFileCount += 1;
       options.onLoadingFile?.({
         filePath,
-        currentIndex: index + 1,
+        currentIndex: completedFileCount,
         totalCount: files.length,
       });
-      const relativePath = resolveChartSummaryRelativePath(rootDir, filePath);
-      resolvedEntries.push(
-        await buildChartSummaryWithCache(rootDir, filePath, relativePath, cachedEntries[relativePath], options.signal),
-      );
-    }
-  }
+      return resolvedEntry;
+    },
+    options.signal,
+  );
   const summaries = resolvedEntries.map((entry) => entry.summary);
   for (let index = 0; index < files.length; index += 1) {
     const filePath = files[index]!;
@@ -242,6 +243,34 @@ async function buildChartSummaryWithCache(
         : undefined,
     cacheHit: false,
   };
+}
+
+async function mapWithConcurrency<TInput, TOutput>(
+  items: readonly TInput[],
+  concurrency: number,
+  worker: (item: TInput, index: number) => Promise<TOutput>,
+  signal?: AbortSignal,
+): Promise<TOutput[]> {
+  if (items.length === 0) {
+    return [];
+  }
+  const results = new Array<TOutput>(items.length);
+  let nextIndex = 0;
+  const workerCount = Math.max(1, Math.min(concurrency, items.length));
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (true) {
+        throwIfAborted(signal);
+        const currentIndex = nextIndex;
+        if (currentIndex >= items.length) {
+          return;
+        }
+        nextIndex += 1;
+        results[currentIndex] = await worker(items[currentIndex]!, currentIndex);
+      }
+    }),
+  );
+  return results;
 }
 
 async function buildChartSelectionEntriesFromSummariesOffThread(

--- a/packages/player/src/cli/runner.ts
+++ b/packages/player/src/cli/runner.ts
@@ -145,6 +145,7 @@ interface PlayLoadingScreenRenderState {
   initialized: boolean;
   stageFileDrawn: boolean;
   stageFileKittyVisible: boolean;
+  lastOutput?: string;
 }
 
 interface SelectChartInteractivelyOptions {
@@ -1834,8 +1835,12 @@ function renderPlayLoadingProgress(
     resetScreen: shouldResetScreen,
     includeStageFileImage: shouldRedrawStageFile,
   });
+  if (options.state.lastOutput === output) {
+    return;
+  }
   process.stdout.write(output);
   options.state.initialized = true;
+  options.state.lastOutput = output;
   if (options.stageFileImage) {
     options.state.stageFileDrawn = true;
     options.state.stageFileKittyVisible =
@@ -1870,6 +1875,7 @@ function resolvePlayLoadingStageFileBlock(
 }
 
 function clearPlayLoadingStageFileImage(state: PlayLoadingScreenRenderState): void {
+  state.lastOutput = undefined;
   if (!state.stageFileKittyVisible) {
     return;
   }

--- a/packages/player/src/tui/tui.test.ts
+++ b/packages/player/src/tui/tui.test.ts
@@ -5,7 +5,10 @@ function stripAnsi(value: string): string {
   return value.replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, '');
 }
 
-function renderOutput(
+const PLAY_PROGRESS_HEAD_MARKER = '\u001b[38;2;255;186;54m┃\u001b[0m';
+const PLAY_PROGRESS_GROOVE_MARKER = '\u001b[38;2;18;18;18m┃\u001b[0m';
+
+function renderOutputRaw(
   notes: Array<{ channel: string; beat: number; seconds: number; endBeat?: number }>,
   options: {
     currentBeat?: number;
@@ -68,7 +71,23 @@ function renderOutput(
     process.stdout.write = originalWrite;
   }
 
-  return stripAnsi(chunks.join('')).split('\n');
+  return chunks.join('').split('\n');
+}
+
+function renderOutput(
+  notes: Array<{ channel: string; beat: number; seconds: number; endBeat?: number }>,
+  options: {
+    currentBeat?: number;
+    currentSeconds?: number;
+    totalSeconds?: number;
+    lanes?: Array<{ channel: string; key: string; isScratch?: boolean }>;
+    laneDisplayMode?: string;
+    splitAfterIndex?: number;
+    scrollTimeline?: Array<{ beat: number; speed: number }>;
+    speedTimeline?: Array<{ beat: number; speed: number }>;
+  } = {},
+): string[] {
+  return stripAnsi(renderOutputRaw(notes, options).join('\n')).split('\n');
 }
 
 function renderRowsContaining(
@@ -90,6 +109,18 @@ function renderRowsContaining(
     .map((line, index) => [index, line] as const)
     .filter(([, line]) => line.includes(fragment))
     .map(([index]) => index);
+}
+
+function isLeftProgressRailLine(line: string): boolean {
+  return line.startsWith('┃');
+}
+
+function isRightProgressRailLine(line: string): boolean {
+  return line.trimEnd().endsWith('┃');
+}
+
+function isLeftProgressRailLineRaw(line: string): boolean {
+  return line.startsWith(PLAY_PROGRESS_HEAD_MARKER) || line.startsWith(PLAY_PROGRESS_GROOVE_MARKER);
 }
 
 describe('player-tui', () => {
@@ -132,34 +163,34 @@ describe('player-tui', () => {
 
   test('renders play progress indicator on the left side of a single playfield', () => {
     const lines = renderOutput([]);
-    const playfieldLines = lines.filter((line) => line.startsWith('● ') || line.startsWith('╎ '));
+    const playfieldLines = lines.filter((line) => isLeftProgressRailLine(line));
 
     expect(playfieldLines.length).toBeGreaterThan(0);
-    expect(playfieldLines.every((line) => line.startsWith('● ') || line.startsWith('╎ '))).toBe(true);
+    expect(playfieldLines.every((line) => isLeftProgressRailLine(line))).toBe(true);
   });
 
   test('moves the play progress marker from top to bottom over time', () => {
-    const openingLines = renderOutput([], { currentSeconds: 0, totalSeconds: 10 }).filter(
-      (line) => line.startsWith('● ') || line.startsWith('╎ '),
+    const openingLines = renderOutputRaw([], { currentSeconds: 0, totalSeconds: 10 }).filter(
+      (line) => isLeftProgressRailLineRaw(line),
     );
-    const endingLines = renderOutput([], { currentSeconds: 10, totalSeconds: 10 }).filter(
-      (line) => line.startsWith('● ') || line.startsWith('╎ '),
+    const endingLines = renderOutputRaw([], { currentSeconds: 10, totalSeconds: 10 }).filter(
+      (line) => isLeftProgressRailLineRaw(line),
     );
 
-    expect(openingLines.findIndex((line) => line.startsWith('● '))).toBe(0);
-    expect(endingLines.findIndex((line) => line.startsWith('● '))).toBe(endingLines.length - 1);
+    expect(openingLines.findIndex((line) => line.includes(PLAY_PROGRESS_HEAD_MARKER))).toBe(0);
+    expect(endingLines.findIndex((line) => line.includes(PLAY_PROGRESS_HEAD_MARKER))).toBe(endingLines.length - 1);
   });
 
   test('stops the play progress rail at the judge line', () => {
     const lines = renderOutput([], { currentSeconds: 10, totalSeconds: 10 });
     const playfieldLineIndices = lines
       .map((line, index) => ({ line, index }))
-      .filter(({ line }) => line.startsWith('● ') || line.startsWith('╎ '))
+      .filter(({ line }) => isLeftProgressRailLine(line))
       .map(({ index }) => index);
     const postPlayfieldLines = lines.slice((playfieldLineIndices.at(-1) ?? -1) + 1);
 
     expect(playfieldLineIndices.length).toBeGreaterThan(0);
-    expect(postPlayfieldLines.some((line) => line.startsWith('● ') || line.startsWith('╎ '))).toBe(false);
+    expect(postPlayfieldLines.some((line) => isLeftProgressRailLine(line))).toBe(false);
   });
 
   test('renders the 2P play progress indicator on the right side of split lanes', () => {
@@ -173,9 +204,9 @@ describe('player-tui', () => {
     });
     const playfieldLines = lines
       .map((line) => line.trimEnd())
-      .filter((line) => line.startsWith('● ') || line.startsWith('╎ '));
+      .filter((line) => isLeftProgressRailLine(line));
 
     expect(playfieldLines.length).toBeGreaterThan(0);
-    expect(playfieldLines.every((line) => line.endsWith(' ●') || line.endsWith(' ╎'))).toBe(true);
+    expect(playfieldLines.every((line) => isRightProgressRailLine(line))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- parallelize chart summary building while keeping per-file progress updates
- parallelize BGA asset loading and reuse shared frame-source loads across base/layer initialization
- skip redundant loading-screen redraws and update TUI progress rail tests to match the current renderer

## Testing
- mise exec -- pnpm --filter @be-music/player typecheck
- mise exec -- pnpm test