### PR TITLE
fix(player): stabilize video BGA streaming and rendering

### DIFF
--- a/packages/player/src/bga-video-worker.ts
+++ b/packages/player/src/bga-video-worker.ts
@@ -1,0 +1,240 @@
+import { parentPort, workerData } from 'node:worker_threads';
+import { createAbortError, isAbortError } from '@be-music/utils';
+import { decodeVideoFramesStreamDirect, type DecodedVideoFrame } from './bga-video.ts';
+
+const TRANSPARENT_ALPHA_THRESHOLD = 16;
+const VIDEO_BLACK_BORDER_THRESHOLD = 8;
+
+type FrameMode = 'base' | 'layer';
+
+interface VideoDecodeWorkerInitData {
+  videoPath: string;
+  mode: FrameMode;
+  stopAfterFirstFrame: boolean;
+}
+
+interface AnsiFrame {
+  width: number;
+  height: number;
+  rgb: Uint8Array;
+  opaqueMask: Uint8Array;
+}
+
+const port = parentPort;
+const initData = workerData as VideoDecodeWorkerInitData;
+
+void bootstrap().catch((error) => {
+  if (isAbortError(error)) {
+    port?.close();
+    process.exit(0);
+    return;
+  }
+  postMessage({
+    kind: 'error',
+    name: error instanceof Error ? error.name : undefined,
+    message: error instanceof Error ? error.message : String(error),
+  });
+  port?.close();
+  throw error;
+});
+
+async function bootstrap(): Promise<void> {
+  if (!port) {
+    throw new Error('Video decode worker parent port is unavailable');
+  }
+
+  const abortController = new AbortController();
+  port.on('message', (message: unknown) => {
+    if (
+      typeof message === 'object' &&
+      message !== null &&
+      'kind' in message &&
+      message.kind === 'abort' &&
+      !abortController.signal.aborted
+    ) {
+      abortController.abort(createAbortError());
+    }
+  });
+
+  try {
+    const result = await decodeVideoFramesStreamDirect(
+      initData.videoPath,
+      (frame) => {
+        const sourceFrame = convertDecodedVideoFrameToSourceFrame(frame, initData.mode);
+        postMessage(
+          {
+            kind: 'frame',
+            frame: {
+              seconds: frame.seconds,
+              width: sourceFrame.width,
+              height: sourceFrame.height,
+              rgb: sourceFrame.rgb,
+              opaqueMask: sourceFrame.opaqueMask,
+            },
+          },
+          [sourceFrame.rgb.buffer as ArrayBuffer, sourceFrame.opaqueMask.buffer as ArrayBuffer],
+        );
+      },
+      abortController.signal,
+      {
+        onReady: (info) => {
+          postMessage({
+            kind: 'ready',
+            info,
+          });
+        },
+        stopAfterFirstFrame: initData.stopAfterFirstFrame,
+      },
+    );
+
+    postMessage({
+      kind: 'done',
+      result,
+    });
+    port.close();
+  } catch (error) {
+    postMessage({
+      kind: 'error',
+      name: error instanceof Error ? error.name : undefined,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    port.close();
+  }
+}
+
+function postMessage(message: unknown, transferList?: ArrayBuffer[]): void {
+  port?.postMessage(message, transferList ?? []);
+}
+
+function convertDecodedVideoFrameToSourceFrame(frame: DecodedVideoFrame, mode: FrameMode): AnsiFrame {
+  const safeWidth = Math.max(1, Math.floor(frame.width));
+  const safeHeight = Math.max(1, Math.floor(frame.height));
+  const sourceFrame = createSolidAnsiFrame(safeWidth, safeHeight, 0, 0, 0, 0);
+
+  for (let y = 0; y < safeHeight; y += 1) {
+    for (let x = 0; x < safeWidth; x += 1) {
+      const sourceOffset = (y * safeWidth + x) * 4;
+      const r = frame.rgba[sourceOffset] ?? 0;
+      const g = frame.rgba[sourceOffset + 1] ?? 0;
+      const b = frame.rgba[sourceOffset + 2] ?? 0;
+      const a = frame.rgba[sourceOffset + 3] ?? 255;
+      if (!isOpaqueVideoPixel(r, g, b, a, mode)) {
+        continue;
+      }
+
+      const targetPixelOffset = y * safeWidth + x;
+      const targetRgbOffset = targetPixelOffset * 3;
+      sourceFrame.rgb[targetRgbOffset] = r;
+      sourceFrame.rgb[targetRgbOffset + 1] = g;
+      sourceFrame.rgb[targetRgbOffset + 2] = b;
+      sourceFrame.opaqueMask[targetPixelOffset] = 1;
+    }
+  }
+
+  return trimBlackVideoFrameBorders(sourceFrame);
+}
+
+function createSolidAnsiFrame(
+  width: number,
+  height: number,
+  r: number,
+  g: number,
+  b: number,
+  maskFill: 0 | 1,
+): AnsiFrame {
+  const safeWidth = Math.max(1, width);
+  const safeHeight = Math.max(1, height);
+  const rgb = new Uint8Array(safeWidth * safeHeight * 3);
+  const opaqueMask = new Uint8Array(safeWidth * safeHeight);
+  if (maskFill === 0) {
+    return {
+      width: safeWidth,
+      height: safeHeight,
+      rgb,
+      opaqueMask,
+    };
+  }
+
+  for (let pixelOffset = 0; pixelOffset < safeWidth * safeHeight; pixelOffset += 1) {
+    const rgbOffset = pixelOffset * 3;
+    rgb[rgbOffset] = r;
+    rgb[rgbOffset + 1] = g;
+    rgb[rgbOffset + 2] = b;
+    opaqueMask[pixelOffset] = 1;
+  }
+
+  return {
+    width: safeWidth,
+    height: safeHeight,
+    rgb,
+    opaqueMask,
+  };
+}
+
+function isOpaqueVideoPixel(r: number, g: number, b: number, a: number, mode: FrameMode): boolean {
+  if (mode !== 'layer') {
+    return true;
+  }
+  if (a <= TRANSPARENT_ALPHA_THRESHOLD) {
+    return false;
+  }
+  return !(r === 0 && g === 0 && b === 0);
+}
+
+function trimBlackVideoFrameBorders(source: AnsiFrame): AnsiFrame {
+  let minX = source.width;
+  let minY = source.height;
+  let maxX = -1;
+  let maxY = -1;
+
+  for (let y = 0; y < source.height; y += 1) {
+    for (let x = 0; x < source.width; x += 1) {
+      const pixelOffset = y * source.width + x;
+      if (source.opaqueMask[pixelOffset] === 0) {
+        continue;
+      }
+      const rgbOffset = pixelOffset * 3;
+      const r = source.rgb[rgbOffset] ?? 0;
+      const g = source.rgb[rgbOffset + 1] ?? 0;
+      const b = source.rgb[rgbOffset + 2] ?? 0;
+      if (r <= VIDEO_BLACK_BORDER_THRESHOLD && g <= VIDEO_BLACK_BORDER_THRESHOLD && b <= VIDEO_BLACK_BORDER_THRESHOLD) {
+        continue;
+      }
+      minX = Math.min(minX, x);
+      minY = Math.min(minY, y);
+      maxX = Math.max(maxX, x);
+      maxY = Math.max(maxY, y);
+    }
+  }
+
+  if (maxX < 0 || maxY < 0) {
+    return source;
+  }
+  if (minX === 0 && minY === 0 && maxX === source.width - 1 && maxY === source.height - 1) {
+    return source;
+  }
+
+  const width = maxX - minX + 1;
+  const height = maxY - minY + 1;
+  const trimmed = createSolidAnsiFrame(width, height, 0, 0, 0, 0);
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const sourceX = minX + x;
+      const sourceY = minY + y;
+      const sourcePixelOffset = sourceY * source.width + sourceX;
+      if (source.opaqueMask[sourcePixelOffset] === 0) {
+        continue;
+      }
+      const targetPixelOffset = y * width + x;
+      const sourceRgbOffset = sourcePixelOffset * 3;
+      const targetRgbOffset = targetPixelOffset * 3;
+      trimmed.rgb[targetRgbOffset] = source.rgb[sourceRgbOffset] ?? 0;
+      trimmed.rgb[targetRgbOffset + 1] = source.rgb[sourceRgbOffset + 1] ?? 0;
+      trimmed.rgb[targetRgbOffset + 2] = source.rgb[sourceRgbOffset + 2] ?? 0;
+      trimmed.opaqueMask[targetPixelOffset] = 1;
+    }
+  }
+
+  return trimmed;
+}

--- a/packages/player/src/bga-video.ts
+++ b/packages/player/src/bga-video.ts
@@ -1,12 +1,15 @@
 import { readFile } from 'node:fs/promises';
 import { basename } from 'node:path';
-import { isAbortError, throwIfAborted } from '@be-music/utils';
+import { fileURLToPath } from 'node:url';
+import { Worker } from 'node:worker_threads';
+import { createAbortError, isAbortError, throwIfAborted } from '@be-music/utils';
 
 const SUPPORTED_VIDEO_CODECS = new Set(['mpeg1video', 'h264', 'mjpeg']);
 // Keep chunks small so ff_decode_multi never allocates too many full-size frames at once.
 const PACKET_READ_CHUNK_BYTES = 65_536;
 const MAX_PACKET_READ_ITERATIONS = 16_384;
 const FALLBACK_FPS = 30;
+type FrameMode = 'base' | 'layer';
 
 interface LibAvPlaneLayout {
   offset: number;
@@ -83,10 +86,78 @@ export interface DecodedVideoFrame {
   rgba: Uint8Array;
 }
 
+export interface DecodedVideoStreamInfo {
+  codecName: 'mpeg1video' | 'h264' | 'mjpeg';
+  durationSeconds?: number;
+}
+
+export interface DecodedSourceVideoFrame {
+  seconds: number;
+  width: number;
+  height: number;
+  rgb: Uint8Array;
+  opaqueMask: Uint8Array;
+}
+
+interface VideoDecodeWorkerInitData {
+  videoPath: string;
+  mode: FrameMode;
+  stopAfterFirstFrame: boolean;
+}
+
+interface VideoDecodeWorkerAbortMessage {
+  kind: 'abort';
+}
+
+type VideoDecodeWorkerInboundMessage = VideoDecodeWorkerAbortMessage;
+
+interface VideoDecodeWorkerReadyMessage {
+  kind: 'ready';
+  info: DecodedVideoStreamInfo;
+}
+
+interface VideoDecodeWorkerFrameMessage {
+  kind: 'frame';
+  frame: DecodedSourceVideoFrame;
+}
+
+interface VideoDecodeWorkerDoneMessage {
+  kind: 'done';
+  result?: { codecName: 'mpeg1video' | 'h264' | 'mjpeg'; frameCount: number; durationSeconds?: number };
+}
+
+interface VideoDecodeWorkerErrorMessage {
+  kind: 'error';
+  name?: string;
+  message: string;
+}
+
+type VideoDecodeWorkerOutboundMessage =
+  | VideoDecodeWorkerReadyMessage
+  | VideoDecodeWorkerFrameMessage
+  | VideoDecodeWorkerDoneMessage
+  | VideoDecodeWorkerErrorMessage;
+
 export async function decodeVideoFramesStream(
   videoPath: string,
   onFrame: (frame: DecodedVideoFrame) => void,
   signal?: AbortSignal,
+  options: {
+    onReady?: (info: DecodedVideoStreamInfo) => void;
+    stopAfterFirstFrame?: boolean;
+  } = {},
+): Promise<{ codecName: 'mpeg1video' | 'h264' | 'mjpeg'; frameCount: number; durationSeconds?: number } | undefined> {
+  return await decodeVideoFramesStreamDirect(videoPath, onFrame, signal, options);
+}
+
+export async function decodeVideoFramesStreamDirect(
+  videoPath: string,
+  onFrame: (frame: DecodedVideoFrame) => void,
+  signal?: AbortSignal,
+  options: {
+    onReady?: (info: DecodedVideoStreamInfo) => void;
+    stopAfterFirstFrame?: boolean;
+  } = {},
 ): Promise<{ codecName: 'mpeg1video' | 'h264' | 'mjpeg'; frameCount: number; durationSeconds?: number } | undefined> {
   let libav: LibAvInstance | undefined;
   try {
@@ -109,13 +180,17 @@ export async function decodeVideoFramesStream(
     if (!isSupportedVideoCodec(codecName)) {
       return undefined;
     }
+    const durationSeconds = resolveStreamDurationSeconds(videoStream);
+    options.onReady?.({
+      codecName,
+      durationSeconds,
+    });
 
     const [, decoderContext, packetRef, frameRef] = await libavInstance.ff_init_decoder(
       videoStream.codec_id,
       videoStream.codecpar,
     );
     try {
-      const durationSeconds = resolveStreamDurationSeconds(videoStream);
       const frameCount = await decodeVideoFramesWithCallback(
         libavInstance,
         formatContext,
@@ -125,6 +200,7 @@ export async function decodeVideoFramesStream(
         frameRef,
         onFrame,
         signal,
+        options.stopAfterFirstFrame === true,
       );
       if (frameCount === undefined || frameCount <= 0) {
         return undefined;
@@ -148,6 +224,91 @@ export async function decodeVideoFramesStream(
   }
 }
 
+export async function decodeVideoFramesToSourceFramesInWorker(
+  videoPath: string,
+  mode: FrameMode,
+  onFrame: (frame: DecodedSourceVideoFrame) => void,
+  signal?: AbortSignal,
+  options: {
+    onReady?: (info: DecodedVideoStreamInfo) => void;
+    stopAfterFirstFrame?: boolean;
+  } = {},
+): Promise<{ codecName: 'mpeg1video' | 'h264' | 'mjpeg'; frameCount: number; durationSeconds?: number } | undefined> {
+  throwIfAborted(signal);
+  const worker = new Worker(resolveBgaVideoWorkerUrl(), {
+    workerData: {
+      videoPath,
+      mode,
+      stopAfterFirstFrame: options.stopAfterFirstFrame === true,
+    } satisfies VideoDecodeWorkerInitData,
+    execArgv: resolveBgaVideoWorkerExecArgv(),
+    env: resolveBgaVideoWorkerEnv(),
+  });
+
+  return await new Promise((resolve, reject) => {
+    let settled = false;
+
+    const cleanup = (): void => {
+      worker.off('message', onMessage);
+      worker.off('error', onError);
+      worker.off('exit', onExit);
+      signal?.removeEventListener('abort', onAbort);
+    };
+
+    const settle = (callback: () => void): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      callback();
+    };
+
+    const onMessage = (message: VideoDecodeWorkerOutboundMessage): void => {
+      if (message.kind === 'ready') {
+        options.onReady?.(message.info);
+        return;
+      }
+      if (message.kind === 'frame') {
+        onFrame(message.frame);
+        return;
+      }
+      if (message.kind === 'done') {
+        settle(() => resolve(message.result));
+        return;
+      }
+      settle(() =>
+        reject(
+          message.name === 'AbortError'
+            ? createAbortError()
+            : new Error(message.message),
+        ),
+      );
+    };
+
+    const onError = (error: Error): void => {
+      settle(() => reject(error));
+    };
+
+    const onExit = (code: number): void => {
+      if (settled) {
+        return;
+      }
+      settle(() => reject(new Error(`Video decode worker exited unexpectedly (code ${code})`)));
+    };
+
+    const onAbort = (): void => {
+      void worker.terminate();
+      settle(() => reject(createAbortError()));
+    };
+
+    worker.on('message', onMessage);
+    worker.on('error', onError);
+    worker.on('exit', onExit);
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
 function isSupportedVideoCodec(codecName: string): codecName is 'mpeg1video' | 'h264' | 'mjpeg' {
   return SUPPORTED_VIDEO_CODECS.has(codecName);
 }
@@ -161,6 +322,7 @@ async function decodeVideoFramesWithCallback(
   frameRef: number,
   onFrame: (frame: DecodedVideoFrame) => void,
   signal?: AbortSignal,
+  stopAfterFirstFrame = false,
 ): Promise<number | undefined> {
   const timeScale = resolveTimeScale(stream);
   const fallbackStep = resolveFallbackStep();
@@ -218,6 +380,9 @@ async function decodeVideoFramesWithCallback(
         ignoreErrors: true,
       });
       consume(decoded);
+      if (stopAfterFirstFrame && frameCount > 0) {
+        return frameCount;
+      }
     }
 
     if (readResult === libav.AVERROR_EOF) {
@@ -477,4 +642,30 @@ async function createLibAvInstance(): Promise<LibAvInstance> {
     noworker: true,
     variant: 'fat',
   });
+}
+
+function resolveBgaVideoWorkerUrl(): URL {
+  return new URL(import.meta.url.endsWith('.ts') ? './bga-video-worker.ts' : './bga-video-worker.js', import.meta.url);
+}
+
+function resolveBgaVideoWorkerExecArgv(): string[] {
+  if (!import.meta.url.endsWith('.ts')) {
+    return process.execArgv;
+  }
+  if (process.execArgv.includes('--conditions=source')) {
+    return process.execArgv;
+  }
+  return [...process.execArgv, '--conditions=source'];
+}
+
+function resolveBgaVideoWorkerEnv(): NodeJS.ProcessEnv {
+  if (!import.meta.url.endsWith('.ts')) {
+    return process.env;
+  }
+
+  return {
+    ...process.env,
+    TSX_TSCONFIG_PATH:
+      process.env.TSX_TSCONFIG_PATH ?? fileURLToPath(new URL('../../../tsconfig.typecheck.json', import.meta.url)),
+  };
 }

--- a/packages/player/src/bga.test.ts
+++ b/packages/player/src/bga.test.ts
@@ -12,9 +12,10 @@ import {
   loadStageFileAnsiLines,
   loadTerminalAnsiImage,
 } from './bga.ts';
+import { decodeVideoFramesStream, decodeVideoFramesToSourceFramesInWorker } from './bga-video.ts';
 
 vi.mock('./bga-video.ts', () => ({
-  decodeVideoFramesStream: vi.fn(async (videoPath: string, onFrame: (frame: unknown) => void) => {
+  decodeVideoFramesStream: vi.fn(async (videoPath: string, onFrame: (frame: unknown) => void, _signal: AbortSignal | undefined, options?: { onReady?: (info: { codecName: 'mpeg1video' | 'h264' | 'mjpeg'; durationSeconds?: number }) => void }) => {
     const hasBlackBorder = videoPath.includes('bordered');
     const isPortrait = videoPath.includes('portrait');
     const width = isPortrait ? 180 : 320;
@@ -30,6 +31,10 @@ vi.mock('./bga-video.ts', () => ({
         rgba[offset + 3] = 255;
       }
     }
+    options?.onReady?.({
+      codecName: 'h264',
+      durationSeconds: 2.5,
+    });
     onFrame({
       seconds: 0,
       width,
@@ -42,7 +47,39 @@ vi.mock('./bga-video.ts', () => ({
       durationSeconds: 2.5,
     };
   }),
+  decodeVideoFramesToSourceFramesInWorker: vi.fn(
+    async (
+      videoPath: string,
+      _mode: 'base' | 'layer',
+      onFrame: (frame: unknown) => void,
+      _signal: AbortSignal | undefined,
+      options?: { onReady?: (info: { codecName: 'mpeg1video' | 'h264' | 'mjpeg'; durationSeconds?: number }) => void },
+    ) => {
+      const hasBlackBorder = videoPath.includes('bordered');
+      const isPortrait = videoPath.includes('portrait');
+      const width = isPortrait ? 180 : 320;
+      const height = isPortrait ? 320 : 240;
+      options?.onReady?.({
+        codecName: 'h264',
+        durationSeconds: 2.5,
+      });
+      onFrame({
+        seconds: 0,
+        width,
+        height,
+        ...createSolidSourceVideoFrame(width, height, { r: hasBlackBorder ? 0 : 255, g: 0, b: 0 }),
+      });
+      return {
+        codecName: 'h264',
+        frameCount: 1,
+        durationSeconds: 2.5,
+      };
+    },
+  ),
 }));
+
+const decodeVideoFramesStreamMock = vi.mocked(decodeVideoFramesStream);
+const decodeVideoFramesToSourceFramesInWorkerMock = vi.mocked(decodeVideoFramesToSourceFramesInWorker);
 
 interface RgbColor {
   r: number;
@@ -51,6 +88,26 @@ interface RgbColor {
 }
 
 type Pixel = RgbColor | undefined;
+
+function createSolidSourceVideoFrame(width: number, height: number, color: RgbColor): {
+  rgb: Uint8Array;
+  opaqueMask: Uint8Array;
+} {
+  const rgb = new Uint8Array(width * height * 3);
+  const opaqueMask = new Uint8Array(width * height);
+  for (let pixelOffset = 0; pixelOffset < width * height; pixelOffset += 1) {
+    const rgbOffset = pixelOffset * 3;
+    rgb[rgbOffset] = color.r;
+    rgb[rgbOffset + 1] = color.g;
+    rgb[rgbOffset + 2] = color.b;
+    opaqueMask[pixelOffset] = 1;
+  }
+  return {
+    rgb,
+    opaqueMask,
+  };
+}
+
 describe('player bga', () => {
   test('player bga: reports loading progress details with target file names', async () => {
     const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-progress-'));
@@ -496,6 +553,170 @@ describe('player bga', () => {
     }
   });
 
+  test('player bga: returns after the first decoded video frame and only streams later frames after startStreaming', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-video-stream-'));
+    let releaseRemainingFrames: (() => void) | undefined;
+    try {
+      await writeFile(join(baseDir, 'streaming.mp4'), '');
+      const initialDecodeCallCount = decodeVideoFramesStreamMock.mock.calls.length;
+      const initialWorkerDecodeCallCount = decodeVideoFramesToSourceFramesInWorkerMock.mock.calls.length;
+      decodeVideoFramesStreamMock.mockImplementationOnce(
+        async (_videoPath, onFrame, _signal, options) => {
+          options?.onReady?.({
+            codecName: 'h264',
+            durationSeconds: 2.5,
+          });
+          onFrame({
+            seconds: 0,
+            width: 320,
+            height: 240,
+            rgba: createSolidVideoRgba(320, 240, { r: 255, g: 0, b: 0 }),
+          });
+          await new Promise<void>((resolve) => {
+            releaseRemainingFrames = resolve;
+          });
+          onFrame({
+            seconds: 1,
+            width: 320,
+            height: 240,
+            rgba: createSolidVideoRgba(320, 240, { r: 0, g: 255, b: 0 }),
+          });
+          return {
+            codecName: 'h264',
+            frameCount: 1,
+            durationSeconds: 2.5,
+          };
+        },
+      );
+      decodeVideoFramesToSourceFramesInWorkerMock.mockImplementationOnce(
+        async (_videoPath, _mode, onFrame, _signal, options) => {
+          options?.onReady?.({
+            codecName: 'h264',
+            durationSeconds: 2.5,
+          });
+          onFrame({
+            seconds: 0,
+            width: 320,
+            height: 240,
+            ...createSolidSourceVideoFrame(320, 240, { r: 255, g: 0, b: 0 }),
+          });
+          await new Promise<void>((resolve) => {
+            releaseRemainingFrames = resolve;
+          });
+          onFrame({
+            seconds: 1,
+            width: 320,
+            height: 240,
+            ...createSolidSourceVideoFrame(320, 240, { r: 0, g: 255, b: 0 }),
+          });
+          return {
+            codecName: 'h264',
+            frameCount: 2,
+            durationSeconds: 2.5,
+          };
+        },
+      );
+
+      const json = createEmptyJson('bms');
+      json.metadata.bpm = 120;
+      json.resources.bmp['01'] = 'streaming.mp4';
+      json.events = [{ measure: 0, channel: '04', position: [1, 2], value: '01' }];
+
+      const rendererPromise = createBgaAnsiRenderer(json, {
+        baseDir,
+        width: 40,
+        height: 20,
+      });
+      const readyState = await Promise.race([
+        rendererPromise.then(() => 'ready' as const),
+        new Promise<'pending'>((resolve) => setTimeout(() => resolve('pending'), 0)),
+      ]);
+      expect(readyState).toBe('ready');
+
+      const renderer = await rendererPromise;
+      expect(renderer?.playbackEndSeconds).toBeCloseTo(3.5, 6);
+      expect(parseAnsiPixels(renderer?.getAnsiLines(1.1) ?? [])[10]?.[20]).toEqual({ r: 255, g: 0, b: 0 });
+      expect(decodeVideoFramesStreamMock.mock.calls.length - initialDecodeCallCount).toBe(1);
+
+      renderer?.startStreaming();
+      expect(decodeVideoFramesToSourceFramesInWorkerMock.mock.calls.length - initialWorkerDecodeCallCount).toBe(1);
+      releaseRemainingFrames?.();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(parseAnsiPixels(renderer?.getAnsiLines(2.1) ?? [])[10]?.[20]).toEqual({ r: 0, g: 255, b: 0 });
+    } finally {
+      releaseRemainingFrames?.();
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  test('player bga: waits for full video decode when streaming is disabled', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-video-legacy-'));
+    let releaseRemainingFrames: (() => void) | undefined;
+    try {
+      await writeFile(join(baseDir, 'legacy.mp4'), '');
+      const initialDecodeCallCount = decodeVideoFramesStreamMock.mock.calls.length;
+      decodeVideoFramesStreamMock.mockImplementationOnce(
+        async (_videoPath, onFrame, _signal, options) => {
+          options?.onReady?.({
+            codecName: 'h264',
+            durationSeconds: 2.5,
+          });
+          onFrame({
+            seconds: 0,
+            width: 320,
+            height: 240,
+            rgba: createSolidVideoRgba(320, 240, { r: 255, g: 0, b: 0 }),
+          });
+          await new Promise<void>((resolve) => {
+            releaseRemainingFrames = resolve;
+          });
+          onFrame({
+            seconds: 1,
+            width: 320,
+            height: 240,
+            rgba: createSolidVideoRgba(320, 240, { r: 0, g: 255, b: 0 }),
+          });
+          return {
+            codecName: 'h264',
+            frameCount: 2,
+            durationSeconds: 2.5,
+          };
+        },
+      );
+
+      const json = createEmptyJson('bms');
+      json.metadata.bpm = 120;
+      json.resources.bmp['01'] = 'legacy.mp4';
+      json.events = [{ measure: 0, channel: '04', position: [1, 2], value: '01' }];
+
+      const rendererPromise = createBgaAnsiRenderer(json, {
+        baseDir,
+        width: 40,
+        height: 20,
+        videoBgaStreaming: false,
+      });
+      for (let attempt = 0; attempt < 10 && !releaseRemainingFrames; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+      const readyState = await Promise.race([
+        rendererPromise.then(() => 'ready' as const),
+        new Promise<'pending'>((resolve) => setTimeout(() => resolve('pending'), 0)),
+      ]);
+      expect(readyState).toBe('pending');
+
+      releaseRemainingFrames?.();
+      const renderer = await rendererPromise;
+
+      expect(decodeVideoFramesStreamMock.mock.calls.length - initialDecodeCallCount).toBe(1);
+      expect(renderer?.playbackEndSeconds).toBeCloseTo(3.5, 6);
+      expect(parseAnsiPixels(renderer?.getAnsiLines(2.1) ?? [])[10]?.[20]).toEqual({ r: 0, g: 255, b: 0 });
+    } finally {
+      releaseRemainingFrames?.();
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
   test('player bga: renders undefined base keys as black instead of STAGEFILE', async () => {
     const baseDir = await mkdtemp(join(tmpdir(), 'be-music-bga-undefined-base-'));
     try {
@@ -915,6 +1136,17 @@ describe('player bga', () => {
     }
 
     await writeFile(path, data);
+  }
+
+  function createSolidVideoRgba(width: number, height: number, color: RgbColor): Uint8Array {
+    const rgba = new Uint8Array(width * height * 4);
+    for (let index = 0; index < rgba.length; index += 4) {
+      rgba[index] = color.r;
+      rgba[index + 1] = color.g;
+      rgba[index + 2] = color.b;
+      rgba[index + 3] = 255;
+    }
+    return rgba;
   }
 
   function parseAnsiPixels(lines: string[]): Pixel[][] {

--- a/packages/player/src/bga.ts
+++ b/packages/player/src/bga.ts
@@ -13,7 +13,7 @@ import { createTimingResolver } from '@be-music/audio-renderer';
 import { decode as decodeBmpFast } from 'fast-bmp';
 import { decode as decodePngFast } from 'fast-png';
 import jpeg from 'jpeg-js';
-import { decodeVideoFramesStream } from './bga-video.ts';
+import { decodeVideoFramesStream, decodeVideoFramesToSourceFramesInWorker } from './bga-video.ts';
 
 const BASE_BGA_CHANNEL = '04';
 const POOR_BGA_CHANNEL = '06';
@@ -68,6 +68,7 @@ interface VideoFrameSource {
   kind: 'video';
   frames: TimedAnsiFrame[];
   durationSeconds?: number;
+  ensureStreaming?: () => void;
 }
 
 type FrameSource = StaticFrameSource | VideoFrameSource;
@@ -96,6 +97,7 @@ export interface BgaAnsiOptions {
   baseDir: string;
   width?: number;
   height?: number;
+  videoBgaStreaming?: boolean;
   onLoadProgress?: (progress: BgaAnsiLoadProgress) => void;
   signal?: AbortSignal;
 }
@@ -313,6 +315,14 @@ export class BgaAnsiRenderer {
     this.cachedComposite = undefined;
     this.cachedLines = undefined;
     this.cachedKittyImage = undefined;
+  }
+
+  startStreaming(): void {
+    const seen = new Set<FrameSource>();
+    startStreamingFrameSourceMap(this.baseSourceFramesByKey, seen);
+    startStreamingFrameSourceMap(this.poorSourceFramesByKey, seen);
+    startStreamingFrameSourceMap(this.layerSourceFramesByKey, seen);
+    startStreamingFrameSourceMap(this.layer2SourceFramesByKey, seen);
   }
 
   setDisplaySize(width: number, height: number): void {
@@ -574,6 +584,7 @@ export async function createBgaAnsiRenderer(
     mode: 'base',
     width: displaySize.width,
     height: displaySize.height,
+    videoBgaStreaming: options.videoBgaStreaming,
     onLoadProgress: reportLoadProgress,
     signal: options.signal,
   });
@@ -585,6 +596,7 @@ export async function createBgaAnsiRenderer(
     mode: 'base',
     width: displaySize.width,
     height: displaySize.height,
+    videoBgaStreaming: options.videoBgaStreaming,
     onLoadProgress: reportLoadProgress,
     signal: options.signal,
   });
@@ -596,6 +608,7 @@ export async function createBgaAnsiRenderer(
     mode: 'layer',
     width: displaySize.width,
     height: displaySize.height,
+    videoBgaStreaming: options.videoBgaStreaming,
     onLoadProgress: reportLoadProgress,
     signal: options.signal,
   });
@@ -607,6 +620,7 @@ export async function createBgaAnsiRenderer(
     mode: 'layer',
     width: displaySize.width,
     height: displaySize.height,
+    videoBgaStreaming: options.videoBgaStreaming,
     onLoadProgress: reportLoadProgress,
     signal: options.signal,
   });
@@ -660,10 +674,11 @@ async function loadFramesByKeys(params: {
   mode: FrameMode;
   width: number;
   height: number;
+  videoBgaStreaming?: boolean;
   onLoadProgress?: (detail: string) => void;
   signal?: AbortSignal;
 }): Promise<Map<string, FrameSource>> {
-  const { keys, resources, baseDir, mode, width, height, onLoadProgress, signal } = params;
+  const { keys, resources, baseDir, mode, width, height, videoBgaStreaming, onLoadProgress, signal } = params;
   const map = new Map<string, FrameSource>();
   const cache = new Map<string, FrameSource | null>();
 
@@ -679,9 +694,9 @@ async function loadFramesByKeys(params: {
       continue;
     }
 
-    const cacheKey = `${mode}:${width}x${height}:${resolved}`;
+    const cacheKey = `${mode}:${width}x${height}:${videoBgaStreaming === false ? 'full' : 'stream'}:${resolved}`;
     if (!cache.has(cacheKey)) {
-      const source = await loadFrameSource(resolved, mode, width, height, signal);
+      const source = await loadFrameSource(resolved, mode, width, height, videoBgaStreaming, signal);
       cache.set(cacheKey, source ?? null);
     }
 
@@ -785,13 +800,25 @@ function fillFrameSourceBackground(source: FrameSource, r: number, g: number, b:
   if (source.kind === 'static') {
     return createStaticFrameSource(fillAnsiFrameBackground(source.frame, r, g, b));
   }
+  const filledFrames: TimedAnsiFrame[] = [];
   return {
     kind: 'video',
-    durationSeconds: source.durationSeconds,
-    frames: source.frames.map((entry) => ({
-      seconds: entry.seconds,
-      frame: fillAnsiFrameBackground(entry.frame, r, g, b),
-    })),
+    get durationSeconds() {
+      return source.durationSeconds;
+    },
+    ensureStreaming: () => {
+      source.ensureStreaming?.();
+    },
+    get frames() {
+      for (let index = filledFrames.length; index < source.frames.length; index += 1) {
+        const entry = source.frames[index]!;
+        filledFrames.push({
+          seconds: entry.seconds,
+          frame: fillAnsiFrameBackground(entry.frame, r, g, b),
+        });
+      }
+      return filledFrames;
+    },
   };
 }
 
@@ -832,13 +859,25 @@ function resizeFrameSourceWithAspectMode(
     };
   }
 
+  const resizedFrames: TimedAnsiFrame[] = [];
   return {
     kind: 'video',
-    durationSeconds: source.durationSeconds,
-    frames: source.frames.map((entry) => ({
-      seconds: entry.seconds,
-      frame: resizeAnsiFrameWithAspectMode(entry.frame, width, height, aspectX, aspectY, mode),
-    })),
+    get durationSeconds() {
+      return source.durationSeconds;
+    },
+    ensureStreaming: () => {
+      source.ensureStreaming?.();
+    },
+    get frames() {
+      for (let index = resizedFrames.length; index < source.frames.length; index += 1) {
+        const entry = source.frames[index]!;
+        resizedFrames.push({
+          seconds: entry.seconds,
+          frame: resizeAnsiFrameWithAspectMode(entry.frame, width, height, aspectX, aspectY, mode),
+        });
+      }
+      return resizedFrames;
+    },
   };
 }
 
@@ -1209,6 +1248,7 @@ async function loadFrameSource(
   mode: FrameMode,
   _width: number,
   _height: number,
+  videoBgaStreaming = true,
   signal?: AbortSignal,
 ): Promise<FrameSource | undefined> {
   throwIfAborted(signal);
@@ -1217,7 +1257,7 @@ async function loadFrameSource(
     return createStaticFrameSource(imageFrame);
   }
 
-  return loadVideoAsFrameSource(resourcePath, mode, signal);
+  return loadVideoAsFrameSource(resourcePath, mode, videoBgaStreaming, signal);
 }
 
 async function loadTerminalAnsiImageInternal(
@@ -1263,41 +1303,154 @@ async function loadTerminalAnsiImageInternal(
 async function loadVideoAsFrameSource(
   videoPath: string,
   mode: FrameMode,
+  videoBgaStreaming = true,
   signal?: AbortSignal,
 ): Promise<FrameSource | undefined> {
   throwIfAborted(signal);
   const frames: TimedAnsiFrame[] = [];
-  const decoded = await decodeVideoFramesStream(
+  const source: VideoFrameSource = {
+    kind: 'video',
+    frames,
+    durationSeconds: undefined,
+  };
+
+  let settleFirstFrame: ((hasFrame: boolean) => void) | undefined;
+  let rejectFirstFrame: ((error: unknown) => void) | undefined;
+  let firstFrameSettled = false;
+  const firstFramePromise = new Promise<boolean>((resolve, reject) => {
+    settleFirstFrame = resolve;
+    rejectFirstFrame = reject;
+  });
+
+  const settleHasFirstFrame = (hasFrame: boolean): void => {
+    if (firstFrameSettled) {
+      return;
+    }
+    firstFrameSettled = true;
+    settleFirstFrame?.(hasFrame);
+  };
+
+  const appendFrame = (frame: { seconds: number; width: number; height: number; rgba: Uint8Array }): void => {
+    throwIfAborted(signal);
+    const sourceFrame = convertImageToSourceFrame(
+      {
+        width: frame.width,
+        height: frame.height,
+        data: frame.rgba,
+        format: 'video',
+      },
+      mode,
+    );
+    frames.push({
+      seconds: frame.seconds,
+      frame: sourceFrame,
+    });
+  };
+
+  if (!videoBgaStreaming) {
+    const decoded = await decodeVideoFramesStream(
+      videoPath,
+      (frame) => {
+        appendFrame(frame);
+      },
+      signal,
+      {
+        onReady: (info) => {
+          source.durationSeconds = info.durationSeconds;
+        },
+      },
+    );
+    if (decoded) {
+      source.durationSeconds = decoded.durationSeconds;
+    }
+    throwIfAborted(signal);
+    return frames.length > 0 ? source : undefined;
+  }
+
+  void decodeVideoFramesStream(
     videoPath,
     (frame) => {
-      throwIfAborted(signal);
-      const sourceFrame = convertImageToSourceFrame(
-        {
-          width: frame.width,
-          height: frame.height,
-          data: frame.rgba,
-          format: 'video',
-        },
-        mode,
-      );
-      frames.push({
-        seconds: frame.seconds,
-        frame: sourceFrame,
-      });
+      appendFrame(frame);
+      settleHasFirstFrame(true);
     },
     signal,
-  );
-  throwIfAborted(signal);
+    {
+      onReady: (info) => {
+        source.durationSeconds = info.durationSeconds;
+      },
+      stopAfterFirstFrame: true,
+    },
+  )
+    .then((decoded) => {
+      if (decoded) {
+        source.durationSeconds = decoded.durationSeconds;
+      }
+      settleHasFirstFrame(frames.length > 0);
+    })
+    .catch((error) => {
+      if (isAbortError(error)) {
+        if (!firstFrameSettled) {
+          firstFrameSettled = true;
+          rejectFirstFrame?.(error);
+        }
+        return;
+      }
+      settleHasFirstFrame(false);
+    });
 
-  if (!decoded || frames.length === 0) {
+  const hasFirstFrame = await firstFramePromise;
+  throwIfAborted(signal);
+  if (!hasFirstFrame) {
     return undefined;
   }
 
-  return {
-    kind: 'video',
-    durationSeconds: decoded.durationSeconds,
-    frames,
+  let streamingStarted = false;
+  source.ensureStreaming = () => {
+    if (streamingStarted) {
+      return;
+    }
+    streamingStarted = true;
+    void (async () => {
+      let skipFrameCount = frames.length;
+      try {
+        throwIfAborted(signal);
+        const decoded = await decodeVideoFramesToSourceFramesInWorker(
+          videoPath,
+          mode,
+          (frame) => {
+            if (skipFrameCount > 0) {
+              skipFrameCount -= 1;
+              return;
+            }
+            frames.push({
+              seconds: frame.seconds,
+              frame: {
+                width: frame.width,
+                height: frame.height,
+                rgb: frame.rgb,
+                opaqueMask: frame.opaqueMask,
+              },
+            });
+          },
+          signal,
+          {
+            onReady: (info) => {
+              source.durationSeconds = info.durationSeconds;
+            },
+          },
+        );
+        if (decoded) {
+          source.durationSeconds = decoded.durationSeconds;
+        }
+      } catch (error) {
+        if (isAbortError(error)) {
+          return;
+        }
+      }
+    })();
   };
+
+  return source;
 }
 
 async function loadTerminalImageSourceFrame(
@@ -1314,7 +1467,7 @@ async function loadTerminalImageSourceFrame(
   if (imageFrame) {
     return createStaticFrameSource(imageFrame);
   }
-  return loadVideoAsFrameSource(resolved, 'base', signal);
+  return loadVideoAsFrameSource(resolved, 'base', true, signal);
 }
 
 function normalizeTerminalImageDisplaySize(width?: number, height?: number): { width: number; height: number } {
@@ -1354,6 +1507,23 @@ function resolveFrameSourceDurationSeconds(source: FrameSource | undefined): num
   const previousFrameSeconds = source.frames.at(-2)?.seconds ?? 0;
   const estimatedTailSeconds = Math.max(0, lastFrameSeconds - previousFrameSeconds);
   return Math.max(streamDuration, lastFrameSeconds + estimatedTailSeconds);
+}
+
+function startStreamingFrameSourceMap(
+  sourceMap: ReadonlyMap<string, FrameSource>,
+  seen: Set<FrameSource>,
+): void {
+  for (const source of sourceMap.values()) {
+    startStreamingFrameSource(source, seen);
+  }
+}
+
+function startStreamingFrameSource(source: FrameSource | undefined, seen: Set<FrameSource>): void {
+  if (!source || source.kind === 'static' || seen.has(source)) {
+    return;
+  }
+  seen.add(source);
+  source.ensureStreaming?.();
 }
 
 function createMediaPathCandidates(mediaPath: string): string[] {

--- a/packages/player/src/cli.test.ts
+++ b/packages/player/src/cli.test.ts
@@ -107,6 +107,14 @@ describe('player cli', () => {
     expect(parseArgs(['chart.bms', '--kitty-graphics', '--no-kitty-graphics']).kittyGraphics).toBe(false);
   });
 
+  test('cli: enables video BGA streaming by default and lets the user switch back to legacy decode', () => {
+    expect(parseArgs(['chart.bms']).videoBgaStreaming).toBe(true);
+    expect(parseArgs(['chart.bms', '--no-video-bga-streaming']).videoBgaStreaming).toBe(false);
+    expect(parseArgs(['chart.bms', '--no-video-bga-streaming', '--video-bga-streaming']).videoBgaStreaming).toBe(
+      true,
+    );
+  });
+
   test('cli: defaults TUI rendering to 60fps and accepts custom fps', () => {
     expect(parseArgs(['chart.bms']).uiFps).toBe(60);
     expect(parseArgs(['chart.bms', '--tui-fps', '120']).uiFps).toBe(120);

--- a/packages/player/src/cli/runner.ts
+++ b/packages/player/src/cli/runner.ts
@@ -112,6 +112,7 @@ interface CliArgs {
   auto: boolean;
   autoScratch: boolean;
   kittyGraphics: boolean;
+  videoBgaStreaming: boolean;
   inferBmsLnTypeWhenMissing: boolean;
   showInvisibleNotes: boolean;
   compressor: boolean;
@@ -870,11 +871,13 @@ async function playChartOnce(chartPath: string, args: CliArgs): Promise<PlayedCh
     })(),
     tui: args.tui,
     kittyGraphics: args.kittyGraphics,
+    videoBgaStreaming: args.videoBgaStreaming,
   };
   logCli('info', 'play.start', {
     chartPath,
     mode: args.auto ? 'auto' : 'manual',
     kittyGraphics: args.kittyGraphics === true,
+    videoBgaStreaming: args.videoBgaStreaming === true,
   });
 
   let summary: PlayerSummary;
@@ -913,7 +916,7 @@ async function playChartOnce(chartPath: string, args: CliArgs): Promise<PlayedCh
           logCli('info', 'play.loading.complete', {
             chartPath,
           });
-          clearPlayLoadingStageFileImage(playLoadingScreenRenderState);
+          clearPlayLoadingScreen(playLoadingScreenRenderState);
           disposePlaybackLoadingAbortCapture();
         },
         onLog: (entry) => {
@@ -1314,6 +1317,7 @@ export function parseArgs(rawArgs: string[]): CliArgs {
     auto: false,
     autoScratch: false,
     kittyGraphics: false,
+    videoBgaStreaming: true,
     inferBmsLnTypeWhenMissing: false,
     showInvisibleNotes: false,
     compressor: false,
@@ -1551,6 +1555,14 @@ export function parseArgs(rawArgs: string[]): CliArgs {
       args.kittyGraphics = false;
       continue;
     }
+    if (token === '--video-bga-streaming') {
+      args.videoBgaStreaming = true;
+      continue;
+    }
+    if (token === '--no-video-bga-streaming') {
+      args.videoBgaStreaming = false;
+      continue;
+    }
     positional.push(token);
   }
 
@@ -1607,6 +1619,8 @@ function printUsage(): void {
       '                           Audio backend: node-web-audio-api (fixed)',
       '  --tui / --no-tui          Enable or disable TUI play screen (default: on in TTY)',
       '  --kitty-graphics          Enable Kitty graphics protocol BGA rendering when supported (default: off)',
+      '  --video-bga-streaming     Stream video BGA frames progressively (default: on)',
+      '  --no-video-bga-streaming  Decode full video BGA before playback (legacy behavior)',
       '  --log-file <path>         Write structured NDJSON logs to a file',
       '                           Default: ~/.be-music/logs/player.ndjson',
       '',
@@ -1928,6 +1942,14 @@ function resolvePlayLoadingStageFileBlock(
     );
   }
   return stageFileImage.lines.length > 0 ? `${stageFileImage.lines.join('\n')}\u001b[H` : '';
+}
+
+function clearPlayLoadingScreen(state: PlayLoadingScreenRenderState): void {
+  clearPlayLoadingStageFileImage(state);
+  if (state.initialized) {
+    process.stdout.write('\u001b[2J\u001b[H');
+    state.initialized = false;
+  }
 }
 
 function clearPlayLoadingStageFileImage(state: PlayLoadingScreenRenderState): void {

--- a/packages/player/src/core/bootstrap.ts
+++ b/packages/player/src/core/bootstrap.ts
@@ -182,6 +182,7 @@ export async function initializePlayerUiRuntime({
     uiFps: options.uiFps,
     judgeWindowMs,
     highSpeed,
+    videoBgaStreaming: options.videoBgaStreaming,
     showLaneChannels: options.debugActiveAudio === true,
     randomPatternSummary,
     stateSignals,

--- a/packages/player/src/core/engine.ts
+++ b/packages/player/src/core/engine.ts
@@ -73,6 +73,7 @@ export interface CreatePlayerUiRuntimeContext {
   uiFps?: number;
   judgeWindowMs: number;
   highSpeed: number;
+  videoBgaStreaming?: boolean;
   showLaneChannels: boolean;
   randomPatternSummary?: string;
   stateSignals: PlayerStateSignals;
@@ -121,6 +122,7 @@ export interface PlayerOptions {
   audioLeadStepUpMs?: number;
   audioLeadStepDownMs?: number;
   tui?: boolean;
+  videoBgaStreaming?: boolean;
   signal?: AbortSignal;
   onLoadProgress?: (progress: PlayerLoadProgress) => void;
   onLoadComplete?: () => void;
@@ -546,7 +548,11 @@ function emitPlayerLog(
     source: 'engine',
     level,
     event,
-    fields,
+    fields: {
+      emittedAtUnixMs: Date.now(),
+      emittedAtMonotonicMs: performance.now(),
+      ...fields,
+    },
   });
 }
 

--- a/packages/player/src/node/node-gameplay-runtime.test.ts
+++ b/packages/player/src/node/node-gameplay-runtime.test.ts
@@ -172,6 +172,7 @@ describe('node gameplay runtime', () => {
 
     expect(uiRuntimeState.context?.laneDisplayMode).toBe('7 KEY');
     expect(uiRuntimeState.context?.uiFps).toBe(60);
+    expect(uiRuntimeState.context?.videoBgaStreaming).toBe(true);
     const uiInitResults = messagesOfKind(worker, 'ui-init-result');
     expect(uiInitResults).toHaveLength(1);
     expect(uiInitResults[0]).toMatchObject({
@@ -311,6 +312,7 @@ function createOptions(
       tui: true,
       speed: 1,
       audioBaseDir: process.cwd(),
+      videoBgaStreaming: true,
     },
     ...overrides,
   };
@@ -328,6 +330,7 @@ function createUiInit() {
     highSpeed: 1,
     showLaneChannels: false,
     baseDir: process.cwd(),
+    videoBgaStreaming: true,
     initialFrame: {
       currentBeat: 0,
       currentSeconds: 0,

--- a/packages/player/src/node/node-gameplay-runtime.ts
+++ b/packages/player/src/node/node-gameplay-runtime.ts
@@ -2,7 +2,7 @@ import { effect } from 'alien-signals';
 import { createAbortError, type LogEntry } from '@be-music/utils';
 import type { BeMusicJson } from '@be-music/json';
 import { fileURLToPath } from 'node:url';
-import { Worker, type TransferListItem } from 'node:worker_threads';
+import { Worker, type MessagePort } from 'node:worker_threads';
 import { createPlayerInputSignalBus } from '../core/input-signal-bus.ts';
 import type { PlayerLoadProgress, PlayerSummary } from '../core/engine.ts';
 import { PlayerInterruptedError } from '../core/engine.ts';
@@ -208,6 +208,7 @@ async function handleUiInit(
       randomPatternSummary: message.runtime.randomPatternSummary,
       baseDir: message.runtime.baseDir,
       kittyGraphics: message.runtime.kittyGraphics,
+      videoBgaStreaming: message.runtime.videoBgaStreaming,
       initialPaused: message.runtime.initialPaused,
       initialJudgeCombo: message.runtime.initialJudgeCombo,
       loadSignal: runtimeStore.loadSignal,
@@ -221,7 +222,7 @@ async function handleUiInit(
       },
     });
     runtimeStore.setRuntime(runtime.tuiEnabled ? runtime : undefined);
-    const transferList: TransferListItem[] = [];
+    const transferList: MessagePort[] = [];
     const response: NodeGameplayWorkerInboundMessage = {
       kind: 'ui-init-result',
       requestId: message.requestId,
@@ -304,7 +305,7 @@ function resolveNodeGameplayWorkerEnv(): NodeJS.ProcessEnv {
 function postWorkerMessage(
   worker: Worker,
   message: NodeGameplayWorkerInboundMessage,
-  transferList?: TransferListItem[],
+  transferList?: MessagePort[],
 ): void {
   worker.postMessage(message, transferList ?? []);
 }

--- a/packages/player/src/node/node-gameplay-worker-protocol.ts
+++ b/packages/player/src/node/node-gameplay-worker-protocol.ts
@@ -40,6 +40,7 @@ export interface NodeGameplayWorkerPlayOptions {
   laneModeExtension?: string;
   tui?: boolean;
   kittyGraphics?: boolean;
+  videoBgaStreaming?: boolean;
 }
 
 export interface NodeGameplayWorkerInitData {
@@ -62,6 +63,7 @@ export interface NodeGameplayUiRuntimeInit {
   randomPatternSummary?: string;
   baseDir: string;
   kittyGraphics?: boolean;
+  videoBgaStreaming?: boolean;
   initialFrame: PlayerUiFramePayload;
   initialPaused: boolean;
   initialJudgeCombo: PlayerJudgeComboSignalState;

--- a/packages/player/src/node/node-gameplay-worker.ts
+++ b/packages/player/src/node/node-gameplay-worker.ts
@@ -233,6 +233,7 @@ async function bootstrap(): Promise<void> {
         if (disposed) {
           return;
         }
+        postLog('info', 'ui.start.posted');
         postUiMessage({ kind: 'start' });
       },
       stop: () => {
@@ -397,6 +398,7 @@ function serializeUiRuntimeInit(context: CreatePlayerUiRuntimeContext): NodeGame
     randomPatternSummary: context.randomPatternSummary,
     baseDir: context.baseDir,
     kittyGraphics: initData.playOptions.kittyGraphics === true,
+    videoBgaStreaming: context.videoBgaStreaming !== false,
     initialFrame: context.uiSignals.getFrame(),
     initialPaused: context.stateSignals.paused(),
     initialJudgeCombo: context.stateSignals.getJudgeCombo(),
@@ -433,7 +435,11 @@ function postLog(level: LogLevel, event: string, fields?: Record<string, unknown
       source: 'gameplay-worker',
       level,
       event,
-      fields,
+      fields: {
+        emittedAtUnixMs: Date.now(),
+        emittedAtMonotonicMs: performance.now(),
+        ...fields,
+      },
     },
   });
 }

--- a/packages/player/src/node/node-ui-runtime.test.ts
+++ b/packages/player/src/node/node-ui-runtime.test.ts
@@ -142,7 +142,7 @@ describe('node ui runtime', () => {
     const workerEnvObject = typeof workerEnv === 'object' ? (workerEnv as NodeJS.ProcessEnv) : undefined;
     const workerExecArgv = workerState.lastWorkerOptions?.execArgv;
     const workerData = workerState.lastWorkerOptions?.workerData as
-      | { stdinIsTTY?: boolean; stdoutIsTTY?: boolean; uiFps?: number }
+      | { stdinIsTTY?: boolean; stdoutIsTTY?: boolean; uiFps?: number; videoBgaStreaming?: boolean }
       | undefined;
 
     expect(typeof workerEnv).toBe('object');
@@ -152,6 +152,7 @@ describe('node ui runtime', () => {
       stdinIsTTY: Boolean(process.stdin.isTTY),
       stdoutIsTTY: Boolean(process.stdout.isTTY),
       uiFps: 60,
+      videoBgaStreaming: true,
     });
 
     await runtime.dispose();
@@ -270,6 +271,7 @@ function createContext(
     uiFps: 60,
     judgeWindowMs: 16.67,
     highSpeed: 1,
+    videoBgaStreaming: true,
     stateSignals,
     uiSignals,
     baseDir: process.cwd(),

--- a/packages/player/src/node/node-ui-runtime.ts
+++ b/packages/player/src/node/node-ui-runtime.ts
@@ -25,6 +25,7 @@ export interface NodeUiRuntimeOptions {
   showLaneChannels?: boolean;
   randomPatternSummary?: string;
   kittyGraphics?: boolean;
+  videoBgaStreaming?: boolean;
   stateSignals?: PlayerStateSignals;
   uiSignals?: PlayerUiSignalBus;
   baseDir: string;
@@ -267,6 +268,7 @@ function createWorkerInitData(options: NodeUiRuntimeOptions): NodeUiWorkerInitDa
     randomPatternSummary: options.randomPatternSummary,
     baseDir: options.baseDir,
     kittyGraphics: options.kittyGraphics,
+    videoBgaStreaming: options.videoBgaStreaming,
     stdinIsTTY: Boolean(process.stdin.isTTY),
     stdoutIsTTY: Boolean(process.stdout.isTTY),
     initialPaused: options.initialPaused ?? options.stateSignals?.paused() ?? false,

--- a/packages/player/src/node/node-ui-worker-protocol.ts
+++ b/packages/player/src/node/node-ui-worker-protocol.ts
@@ -18,6 +18,7 @@ export interface NodeUiWorkerInitData {
   randomPatternSummary?: string;
   baseDir: string;
   kittyGraphics?: boolean;
+  videoBgaStreaming?: boolean;
   stdinIsTTY: boolean;
   stdoutIsTTY: boolean;
   initialPaused: boolean;

--- a/packages/player/src/node/node-ui-worker.ts
+++ b/packages/player/src/node/node-ui-worker.ts
@@ -133,6 +133,7 @@ async function bootstrap(): Promise<void> {
     baseDir: initData.baseDir,
     width: initialBgaSize.width,
     height: initialBgaSize.height,
+    videoBgaStreaming: initData.videoBgaStreaming,
     signal: abortController.signal,
     onLoadProgress: (progress) => {
       postWorkerMessage({
@@ -147,6 +148,7 @@ async function bootstrap(): Promise<void> {
   postLog('info', 'ui-worker.ready', {
     hasBgaRenderer: bgaRenderer !== undefined,
     bgaPlaybackEndSeconds: bgaRenderer?.playbackEndSeconds,
+    videoBgaStreaming: initData.videoBgaStreaming !== false,
   });
 
   const queuedCommands: PlayerUiCommand[] = [];
@@ -163,6 +165,7 @@ async function bootstrap(): Promise<void> {
   };
 
   let renderThrottle: ReturnType<typeof createRenderThrottle> | undefined;
+  let bgaStreamingScheduled = false;
   const frameState = createUiWorkerFrameState({
     initialPaused: initData.initialPaused,
     initialHighSpeed: initData.highSpeed,
@@ -250,6 +253,13 @@ async function bootstrap(): Promise<void> {
     if (message.kind === 'start') {
       postLog('info', 'ui-worker.start.received');
       tui.start();
+      if (!bgaStreamingScheduled) {
+        bgaStreamingScheduled = true;
+        setImmediate(() => {
+          bgaRenderer?.startStreaming();
+        });
+      }
+      deferredUiFlush.markFrameDirty();
       return true;
     }
     if (message.kind === 'frame') {
@@ -291,6 +301,7 @@ async function bootstrap(): Promise<void> {
       bridgePort?.off('message', handleControlMessage);
       bridgePort = message.port;
       bridgePort.on('message', handleControlMessage);
+      postLog('info', 'ui-worker.bridge-port.attached');
       return;
     }
     if (handleRenderMessage(message)) {
@@ -371,7 +382,11 @@ function postLog(level: LogLevel, event: string, fields?: Record<string, unknown
       source: 'ui-worker',
       level,
       event,
-      fields,
+      fields: {
+        emittedAtUnixMs: Date.now(),
+        emittedAtMonotonicMs: performance.now(),
+        ...fields,
+      },
     },
   });
 }

--- a/packages/player/src/tui/tui.test.ts
+++ b/packages/player/src/tui/tui.test.ts
@@ -123,6 +123,23 @@ function isLeftProgressRailLineRaw(line: string): boolean {
   return line.startsWith(PLAY_PROGRESS_HEAD_MARKER) || line.startsWith(PLAY_PROGRESS_GROOVE_MARKER);
 }
 
+function createKittyTestImage(token: string, color: { r: number; g: number; b: number }) {
+  const rgb = new Uint8Array(4 * 4 * 3);
+  for (let index = 0; index < rgb.length; index += 3) {
+    rgb[index] = color.r;
+    rgb[index + 1] = color.g;
+    rgb[index + 2] = color.b;
+  }
+  return {
+    pixelWidth: 4,
+    pixelHeight: 4,
+    cellWidth: 1,
+    cellHeight: 1,
+    rgb,
+    token,
+  };
+}
+
 describe('player-tui', () => {
   test('long note head stays on the same row as a regular note at the same beat', () => {
     const regularHeadRows = renderRowsContaining([{ channel: '11', beat: 1, seconds: 0.5 }], '███');
@@ -208,5 +225,84 @@ describe('player-tui', () => {
 
     expect(playfieldLines.length).toBeGreaterThan(0);
     expect(playfieldLines.every((line) => isRightProgressRailLine(line))).toBe(true);
+  });
+
+  test('updates kitty BGA by double-buffering image ids instead of overwriting the visible image', () => {
+    const chunks: string[] = [];
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      chunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'));
+      return true;
+    }) as typeof process.stdout.write;
+
+    try {
+      const tui = new PlayerTui({
+        mode: 'AUTO',
+        laneDisplayMode: '5 KEY SP',
+        title: 'test',
+        lanes: [{ channel: '11', key: 'z' }],
+        speed: 1,
+        highSpeed: 1,
+        judgeWindowMs: 100,
+        stdoutIsTTY: true,
+        stdinIsTTY: true,
+        terminalImageProtocol: 'kitty',
+      });
+      tui.setTerminalSize(40, 24);
+      tui.start();
+      chunks.length = 0;
+
+      tui.render({
+        currentBeat: 0,
+        currentSeconds: 0,
+        totalSeconds: 10,
+        summary: {
+          total: 1,
+          perfect: 0,
+          fast: 0,
+          slow: 0,
+          great: 0,
+          good: 0,
+          bad: 0,
+          poor: 0,
+          exScore: 0,
+          score: 0,
+        },
+        notes: [],
+        bgaKittyImage: createKittyTestImage('frame-1', { r: 255, g: 0, b: 0 }),
+      });
+      const firstRender = chunks.join('');
+      chunks.length = 0;
+
+      tui.render({
+        currentBeat: 1,
+        currentSeconds: 1,
+        totalSeconds: 10,
+        summary: {
+          total: 1,
+          perfect: 0,
+          fast: 0,
+          slow: 0,
+          great: 0,
+          good: 0,
+          bad: 0,
+          poor: 0,
+          exScore: 0,
+          score: 0,
+        },
+        notes: [],
+        bgaKittyImage: createKittyTestImage('frame-2', { r: 0, g: 255, b: 0 }),
+      });
+      const secondRender = chunks.join('');
+      tui.stop();
+
+      expect(firstRender).toContain('i=1337');
+      expect(firstRender).toContain('a=T');
+      expect(secondRender).toContain('i=1338');
+      expect(secondRender).toContain('a=T');
+      expect(secondRender).toContain('a=d,d=I,i=1337');
+    } finally {
+      process.stdout.write = originalWrite;
+    }
   });
 });

--- a/packages/player/src/tui/tui.ts
+++ b/packages/player/src/tui/tui.ts
@@ -5,7 +5,10 @@ import type { BgaKittyImage } from '../bga.ts';
 import type { PlayerSummary } from '../index.ts';
 import { formatSeconds, resolveAltModifierLabel } from '../utils.ts';
 import type { PlayerStateSignals } from '../state-signals.ts';
-import { buildKittyGraphicsDeleteImageSequence, buildKittyGraphicsRenderSequence } from './kitty-graphics.ts';
+import {
+  buildKittyGraphicsDeleteImageSequence,
+  buildKittyGraphicsRenderSequence,
+} from './kitty-graphics.ts';
 import { findStackableRowIndex } from './lane-stacking.ts';
 import { normalizeHighSpeed, resolveAnimatedHighSpeedValue, resolveVisibleBeatsForTuiGrid } from './high-speed.ts';
 import {
@@ -140,7 +143,7 @@ const INVISIBLE_NOTE_HEAD_SYMBOL = '◯';
 const INVISIBLE_LONG_NOTE_BODY_SYMBOL = '□';
 const INVISIBLE_LONG_NOTE_TAIL_SYMBOL = '◇';
 const ANSI_RESET = '\u001b[0m';
-const KITTY_BGA_IMAGE_ID = 1_337;
+const KITTY_BGA_IMAGE_IDS = [1_337, 1_338] as const;
 const SCORE_COUNTUP_MIN_PER_SEC = 4000;
 const SCORE_COUNTUP_DISTANCE_FACTOR = 6;
 const HIGH_SPEED_TRANSITION_MS = 180;
@@ -285,6 +288,10 @@ export class PlayerTui {
 
   private lastKittyBgaToken = '';
 
+  private lastKittyBgaPlacementToken = '';
+
+  private activeKittyBgaImageIndex = 0;
+
   private kittyBgaVisible = false;
 
   constructor(options: TuiOptions) {
@@ -348,6 +355,8 @@ export class PlayerTui {
     this.active = true;
     this.needsFullRefresh = false;
     this.lastKittyBgaToken = '';
+    this.lastKittyBgaPlacementToken = '';
+    this.activeKittyBgaImageIndex = 0;
     this.kittyBgaVisible = false;
     process.stdout.write('\u001b[?1049h\u001b[2J\u001b[H\u001b[?25l');
   }
@@ -379,8 +388,12 @@ export class PlayerTui {
     this.smoothedFps = Number.NaN;
     this.lastFrameRenderedAtMs = 0;
     this.lastRenderedBeat = Number.NaN;
-    const clearKittyBga = this.kittyBgaVisible ? buildKittyGraphicsDeleteImageSequence(KITTY_BGA_IMAGE_ID) : '';
+    const clearKittyBga = this.kittyBgaVisible
+      ? KITTY_BGA_IMAGE_IDS.map((imageId) => buildKittyGraphicsDeleteImageSequence(imageId)).join('')
+      : '';
     this.lastKittyBgaToken = '';
+    this.lastKittyBgaPlacementToken = '';
+    this.activeKittyBgaImageIndex = 0;
     this.kittyBgaVisible = false;
     process.stdout.write(`${clearKittyBga}\u001b[0m\u001b[?25h\u001b[?1049l`);
   }
@@ -835,10 +848,14 @@ export class PlayerTui {
     const needsFullRefresh = this.needsFullRefresh;
     let overlaySequence = '';
     if (kittyBgaPlacement) {
-      const kittyToken = `${kittyBgaPlacement.image.token}:${kittyBgaPlacement.row}:${kittyBgaPlacement.column}`;
-      if (needsFullRefresh || this.lastKittyBgaToken !== kittyToken) {
+      const placementToken =
+        `${kittyBgaPlacement.row}:${kittyBgaPlacement.column}:` +
+        `${kittyBgaPlacement.image.cellWidth}:${kittyBgaPlacement.image.cellHeight}`;
+      if (needsFullRefresh || !this.kittyBgaVisible || this.lastKittyBgaPlacementToken !== placementToken) {
+        const activeImageId = KITTY_BGA_IMAGE_IDS[this.activeKittyBgaImageIndex]!;
+        const inactiveImageId = KITTY_BGA_IMAGE_IDS[(this.activeKittyBgaImageIndex + 1) % KITTY_BGA_IMAGE_IDS.length]!;
         overlaySequence = buildKittyGraphicsRenderSequence({
-          imageId: KITTY_BGA_IMAGE_ID,
+          imageId: activeImageId,
           placementId: 1,
           row: kittyBgaPlacement.row,
           column: kittyBgaPlacement.column,
@@ -846,12 +863,32 @@ export class PlayerTui {
           zIndex: -1,
           doNotMoveCursor: true,
         });
-        this.lastKittyBgaToken = kittyToken;
+        overlaySequence += buildKittyGraphicsDeleteImageSequence(inactiveImageId);
+        this.lastKittyBgaToken = kittyBgaPlacement.image.token;
+        this.lastKittyBgaPlacementToken = placementToken;
         this.kittyBgaVisible = true;
+      } else if (this.lastKittyBgaToken !== kittyBgaPlacement.image.token) {
+        const nextImageIndex = (this.activeKittyBgaImageIndex + 1) % KITTY_BGA_IMAGE_IDS.length;
+        const nextImageId = KITTY_BGA_IMAGE_IDS[nextImageIndex]!;
+        const previousImageId = KITTY_BGA_IMAGE_IDS[this.activeKittyBgaImageIndex]!;
+        overlaySequence = buildKittyGraphicsRenderSequence({
+          imageId: nextImageId,
+          placementId: 1,
+          row: kittyBgaPlacement.row,
+          column: kittyBgaPlacement.column,
+          image: kittyBgaPlacement.image,
+          zIndex: -1,
+          doNotMoveCursor: true,
+        });
+        overlaySequence += buildKittyGraphicsDeleteImageSequence(previousImageId);
+        this.lastKittyBgaToken = kittyBgaPlacement.image.token;
+        this.activeKittyBgaImageIndex = nextImageIndex;
       }
     } else if (this.kittyBgaVisible) {
-      overlaySequence = buildKittyGraphicsDeleteImageSequence(KITTY_BGA_IMAGE_ID);
+      overlaySequence = KITTY_BGA_IMAGE_IDS.map((imageId) => buildKittyGraphicsDeleteImageSequence(imageId)).join('');
       this.lastKittyBgaToken = '';
+      this.lastKittyBgaPlacementToken = '';
+      this.activeKittyBgaImageIndex = 0;
       this.kittyBgaVisible = false;
     }
     process.stdout.write(`${needsFullRefresh ? '\u001b[2J' : ''}\u001b[H${paddedLines.join('\n')}${overlaySequence}`);

--- a/packages/player/tsdown.config.ts
+++ b/packages/player/tsdown.config.ts
@@ -9,6 +9,7 @@ export default createPackageTsdownConfig({
   entries: {
     index: 'src/index.ts',
     cli: 'src/cli.ts',
+    'bga-video-worker': 'src/bga-video-worker.ts',
     'node-gameplay-worker': 'src/node/node-gameplay-worker.ts',
     'node-ui-worker': 'src/node/node-ui-worker.ts',
   },


### PR DESCRIPTION
## Summary
- stabilize Kitty video BGA updates with double-buffered image rendering
- add structured player logging and video BGA streaming toggles for runtime diagnosis
- move streaming video decode work off the UI worker so gameplay frames can keep rendering while video catches up

## Verification
- mise exec -- pnpm --filter @be-music/player typecheck
- mise exec -- pnpm --filter @be-music/player run build:bundle
- mise exec -- pnpm test