### PR TITLE
fix(ci): retarget release SEA build at player-tui

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,10 @@ jobs:
 
       - name: Build player SEA executable
         if: needs.prepare.outputs.release_player == 'true'
-        run: pnpm --filter @be-music/player run build:sea
+        # The CLI / TUI bin moved to `@be-music/player-tui` during the player-tui-split refactor; the
+        # `build:sea` script lives there now (the SEA bundle still ships under `be-music-player` for
+        # backward compatibility with existing release assets).
+        run: pnpm --filter @be-music/player-tui run build:sea
 
       - name: Build audio-renderer SEA executable
         if: needs.prepare.outputs.release_audio_renderer == 'true'
@@ -222,7 +225,7 @@ jobs:
 
           files=()
           if [ "${{ needs.prepare.outputs.release_player }}" = 'true' ]; then
-            files+=(packages/player/dist-sea/be-music-player)
+            files+=(packages/player-tui/dist-sea/be-music-player)
           fi
           if [ "${{ needs.prepare.outputs.release_audio_renderer }}" = 'true' ]; then
             files+=(packages/audio-renderer/dist-sea/be-music-audio-render)
@@ -243,7 +246,7 @@ jobs:
           mkdir -p tmp/release-assets/player tmp/release-assets/audio-renderer
 
           if [ "${{ needs.prepare.outputs.release_player }}" = 'true' ]; then
-            cp packages/player/dist-sea/be-music-player tmp/release-assets/player/
+            cp packages/player-tui/dist-sea/be-music-player tmp/release-assets/player/
             chmod +x tmp/release-assets/player/be-music-player
             (
               cd tmp/release-assets/player
@@ -268,7 +271,7 @@ jobs:
 
           New-Item -ItemType Directory -Force -Path $assetDir | Out-Null
           if ('${{ needs.prepare.outputs.release_player }}' -eq 'true') {
-            Copy-Item 'packages/player/dist-sea/be-music-player.exe' "$assetDir/be-music-player.exe"
+            Copy-Item 'packages/player-tui/dist-sea/be-music-player.exe' "$assetDir/be-music-player.exe"
           }
           if ('${{ needs.prepare.outputs.release_audio_renderer }}' -eq 'true') {
             Copy-Item 'packages/audio-renderer/dist-sea/be-music-audio-render.exe' "$assetDir/be-music-audio-render.exe"


### PR DESCRIPTION
## Summary

Re-target the release workflow's SEA build steps at the
`@be-music/player-tui` workspace. The release run for 0.2.0
(triggered by PR #81) failed every SEA matrix job with
\`ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT  None of the selected packages
has a "build:sea" script\` because the workflow was still pointing
at the pre-player-tui-split layout (the script moved over to
\`packages/player-tui\` during the split, and the SEA output dir
follows \`config.packageDir\` in \`scripts/build-sea.ts\`).

This PR carries no version bumps. After it merges, kick the release
manually via Actions → Release → Run workflow with:

- \`release_target\`: the merge commit produced by this PR
- \`release_base\`: \`e119685\` (the last 0.1.0 release commit on main)

so the resolve script still detects the package version diffs that
PR #81 brought in.

## Test plan

- [x] Local clean SEA bundle build for both targets passes:
  \`pnpm --filter @be-music/player-tui run build:sea --bundle-only\`
  and the audio-renderer equivalent.
- [ ] Release run dispatched after merge actually creates the 12
  GitHub Releases.