### PR TITLE
fix(player-web): wrap remaining elapsedSinceTimer callbacks for makeLr2StaticImageSprite

### DIFF
--- a/packages/player-web/src/pixi-decide.ts
+++ b/packages/player-web/src/pixi-decide.ts
@@ -498,7 +498,7 @@ export class PixiDecideView {
   private makeStaticImageSprite(image: Lr2ImageElement) {
     return makeLr2StaticImageSprite(image, this.evaluateElementDst(image), {
       textures: this.skinTextures.asReadonlyMap(),
-      elapsedSinceTimer: this.elapsedSinceTimer,
+      elapsedSinceTimer: (timer) => this.elapsedSinceTimer(timer),
       resolveSpecialGraphicTexture: (path) => this.resolveSpecialGraphicTexture(path),
     });
   }

--- a/packages/player-web/src/pixi-result.ts
+++ b/packages/player-web/src/pixi-result.ts
@@ -1218,7 +1218,7 @@ export class PixiResultView {
   private makeStaticImageSprite(image: Lr2ImageElement) {
     return makeLr2StaticImageSprite(image, this.evaluateElementDst(image), {
       textures: this.skinTextures.asReadonlyMap(),
-      elapsedSinceTimer: this.elapsedSinceTimer,
+      elapsedSinceTimer: (timer) => this.elapsedSinceTimer(timer),
       resolveSpecialGraphicTexture: (path) => this.resolveSpecialGraphicTexture(path),
     });
   }

--- a/packages/player-web/src/pixi-select.ts
+++ b/packages/player-web/src/pixi-select.ts
@@ -3561,7 +3561,7 @@ export class PixiSongSelectView {
   private makeStaticImageSprite(image: Lr2ImageElement) {
     return makeLr2StaticImageSprite(image, this.evaluateElementDst(image), {
       textures: this.skinTextures.asReadonlyMap(),
-      elapsedSinceTimer: this.elapsedSinceTimer,
+      elapsedSinceTimer: (timer) => this.elapsedSinceTimer(timer),
       resolveSpecialGraphicTexture: (path) => this.resolveSpecialGraphicTexture(path),
     });
   }


### PR DESCRIPTION
## Summary

Follow-up bug fix for the LR2 sprite-builder consolidation refactor. `makeLr2StaticImageSprite` takes an `elapsedSinceTimer` callback in its options bag; the three scenes that call it (\`pixi-select\`, \`pixi-result\`, \`pixi-decide\`) were still passing the raw \`this.elapsedSinceTimer\` method reference. Destructuring the options bag inside \`lr2-render.ts\` drops the \`this\` context, so the song-select scene crashed with \`Cannot read properties of undefined (reading 'get')\` on the first frame after a chart drop (the helper hit \`this.timerStartedAt.get\` with \`this === undefined\`).

Wraps each call in an arrow so the binding sticks:
\`elapsedSinceTimer: (timer) => this.elapsedSinceTimer(timer)\`.

Sibling fix to the earlier \`evaluateElementDestination\` arrow wrapping; this commit closes the same regression for the static-image / slider / bargraph sprite builders.

## Test plan

- [x] \`pnpm --filter player-web typecheck\` clean
- [x] \`pnpm test packages/player-web\` 213 / 213 pass
- [ ] Release workflow re-run via \`workflow_dispatch\` will now create the 12 GitHub Releases for 0.2.0 (release.yml SEA paths were already corrected on main by PR #82).