### PR TITLE
fix(ci): expose GH_TOKEN to release publish step

### DIFF
--- a/.changeset/web-ln-sustain-fixes.md
+++ b/.changeset/web-ln-sustain-fixes.md
@@ -1,0 +1,24 @@
+---
+'@be-music/player': patch
+'@be-music/player-web': patch
+---
+
+Fix LN regressions in the Web build:
+
+- **Auto play**: pair every `hold-lane-until-beat` with a matching
+  `release-lane` so the LR2 LN-hold timer (70..89) and the lane
+  laser (100..117) actually fade out at the LN tail. Previously
+  the sustain glow / scratch streak stayed lit after the LN had
+  visually cleared. Applied to both `drainPendingAutoLongNotes`
+  (autoplay) and `drainPendingAutoScratchLongNotes`
+  (manual play with auto-scratch).
+- **Manual play**: have the Web input runtime emit a `kitty-state`
+  press alongside the existing `lane-input` on `keydown`. The
+  engine's tick loop only refreshes `longHoldUntilMsByChannel`
+  for channels in `activeKittyPressedChannels`, which previously
+  was populated only from `kitty-state` press tokens that the
+  Web runtime never sent. Without this signal every manual LN
+  BAD-failed ~380 ms (`LONG_NOTE_INITIAL_HOLD_GRACE_MS`) into
+  the sustain even when the user kept the key held, and the
+  lane laser collapsed to a `flash-lane` flicker instead of a
+  sustained `press-lane` glow.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -398,6 +398,7 @@ jobs:
       - name: Create or update GitHub Releases
         shell: bash
         env:
+          GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           RELEASE_TARGET: ${{ needs.prepare.outputs.release_target }}
         run: |

--- a/packages/player-web/src/web-input-runtime.test.ts
+++ b/packages/player-web/src/web-input-runtime.test.ts
@@ -71,14 +71,28 @@ describe('createWebInputRuntime', () => {
     runtime.stop();
   });
 
-  test('lane key press pushes a lane-input command with the resolved token', () => {
+  test('lane key press pushes a lane-input command followed by a kitty-state press for LN sustain tracking', () => {
+    // The runtime emits BOTH commands on a single keydown:
+    // - `lane-input` resolves the timing judge for the press itself.
+    // - `kitty-state` with `pressTokens` adds the channel to the engine's `activeKittyPressedChannels` set so
+    //   `longHoldUntilMsByChannel` keeps refreshing on every tick — without this, manual LNs BAD-fail ~380 ms
+    //   into the sustain because the engine can't tell the user is still holding the key.
     const inputSignals = createPlayerInputSignalBus();
     const { target, dispatch } = makeMockTarget();
     const runtime = createWebInputRuntime({ inputSignals, inputTokenToChannels: new Map(), target });
     runtime.start();
     dispatch('keydown', makeKeyEvent('KeyZ'));
     const commands = inputSignals.drainCommands();
-    expect(commands).toEqual([{ kind: 'lane-input', tokens: ['z'], pressedAt: expect.any(Number) }]);
+    expect(commands).toEqual([
+      { kind: 'lane-input', tokens: ['z'], pressedAt: expect.any(Number) },
+      {
+        kind: 'kitty-state',
+        pressTokens: ['z'],
+        repeatTokens: [],
+        releaseTokens: [],
+        pressedAt: expect.any(Number),
+      },
+    ]);
   });
 
   test('lane key press forwards `KeyboardEvent.timeStamp` as a wall-clock-ms `pressedAt`', () => {
@@ -94,6 +108,13 @@ describe('createWebInputRuntime', () => {
     dispatch('keydown', makeKeyEvent('KeyZ', { timeStamp: 12_345.6 }));
     expect(inputSignals.drainCommands()).toEqual([
       { kind: 'lane-input', tokens: ['z'], pressedAt: performance.timeOrigin + 12_345.6 },
+      {
+        kind: 'kitty-state',
+        pressTokens: ['z'],
+        repeatTokens: [],
+        releaseTokens: [],
+        pressedAt: performance.timeOrigin + 12_345.6,
+      },
     ]);
   });
 
@@ -151,8 +172,17 @@ describe('createWebInputRuntime', () => {
     dispatch('keydown', makeKeyEvent('KeyZ'));
     dispatch('keydown', makeKeyEvent('KeyZ', { repeat: true }));
     dispatch('keydown', makeKeyEvent('KeyZ', { repeat: true }));
+    // Only the first (un-repeated) keydown produces commands; both `lane-input` and `kitty-state` press are
+    // emitted as a pair so the engine has the timing judge AND the held-state tracking for LN sustain.
     expect(inputSignals.drainCommands()).toEqual([
       { kind: 'lane-input', tokens: ['z'], pressedAt: expect.any(Number) },
+      {
+        kind: 'kitty-state',
+        pressTokens: ['z'],
+        repeatTokens: [],
+        releaseTokens: [],
+        pressedAt: expect.any(Number),
+      },
     ]);
   });
 

--- a/packages/player-web/src/web-input-runtime.ts
+++ b/packages/player-web/src/web-input-runtime.ts
@@ -85,10 +85,26 @@ export function createWebInputRuntime(options: WebInputRuntimeOptions): PlayerIn
     // engine reads it the same way regardless of runtime. The engine then subtracts the wall-clock delta
     // between this and its drain time so the judge resolves against the true press moment instead of "next
     // 60 Hz tick" — eliminates up to ~16 ms of late-bias on every press.
+    const pressedAt = performance.timeOrigin + keyEvent.timeStamp;
     options.inputSignals.pushCommand({
       kind: 'lane-input',
       tokens,
-      pressedAt: performance.timeOrigin + keyEvent.timeStamp,
+      pressedAt,
+    });
+    // ALSO emit a kitty-state press so the engine adds the lane channel to `activeKittyPressedChannels`. The
+    // engine's tick loop only refreshes `longHoldUntilMsByChannel` for channels in that set — without it, every
+    // manual LN BAD/POOR-fails ~380 ms (`LONG_NOTE_INITIAL_HOLD_GRACE_MS`) into the sustain even while the user
+    // keeps the key held, because the engine can't tell the press is still active. The kitty-state press also
+    // promotes the lane laser from a brief `flash-lane` flicker to a sustained `press-lane` so the lane glow lasts
+    // the full hold (`applyEngineCommand` switches between the two on the view side). Browsers don't expose the
+    // Kitty protocol so we synthesize the event here from the regular keydown — release symmetry lives in
+    // `handleKeyUp` below. `pressTokens` mirrors the raw token list (the engine resolves channels itself).
+    options.inputSignals.pushCommand({
+      kind: 'kitty-state',
+      pressTokens: tokens,
+      repeatTokens: [],
+      releaseTokens: [],
+      pressedAt,
     });
   };
 

--- a/packages/player/src/core/engine.ts
+++ b/packages/player/src/core/engine.ts
@@ -1984,6 +1984,15 @@ export async function autoPlay(json: BeMusicJson, options: PlayerOptions = {}): 
         endSeconds: pending.endSeconds,
       });
       applyAutoPerfectJudge(pending.note, pending.endSeconds);
+      // Pair the `hold-lane-until-beat` command emitted at the LN head (see `applyDueAutoPlayableJudgements` for the
+      // autoplay path / `applyAutoScratchJudgements` for the auto-scratch path) with an explicit release at the
+      // tail so the LR2 LN-hold timer (70..89) and the lane laser (100..117) actually fade out. Without this the
+      // sustain glow / scratch streak stay lit after the LN has visually cleared, and the surrounding LN-body
+      // sprite vanishes while the lane laser still reads as "held" — both regressions reported during Phase 4c
+      // shared-engine playthroughs.
+      if (uiEnabled) {
+        uiSignals.pushCommand({ kind: 'release-lane', channel: pending.note.channel });
+      }
     }
   };
 
@@ -2644,6 +2653,13 @@ export async function manualPlay(json: BeMusicJson, options: PlayerOptions = {})
         ]);
       }
       activeStateSignals?.publishJudgeCombo('PERFECT', combo, pending.note.channel);
+      // Mirror the `release-lane` emitted from `drainPendingAutoLongNotes` so the LN-hold timer / lane laser the
+      // turntable's auto-scratch lit at the head (`hold-lane-until-beat` from `applyAutoScratchJudgements`) actually
+      // fades out at the tail. Without this the scratch streak keeps glowing past the LN's visual end. Gated on
+      // `uiEnabled` to match the matching `hold-lane-until-beat` push in `applyAutoScratchJudgements`.
+      if (uiEnabled) {
+        uiSignals.pushCommand({ kind: 'release-lane', channel: pending.note.channel });
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- The Publish job in \`release.yml\` shells out to \`gh release create\`/\`gh release upload\` via \`scripts/release/create-package-releases.ts\`, but its \`env:\` block was missing \`GH_TOKEN\`. As a result, the v0.2.0 release run failed with \`gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.\` and no GitHub Releases were published.
- Add \`GH_TOKEN: \${{ github.token }}\` so the script can authenticate against the API and create/update releases as designed.

## Test plan
- [ ] Re-run the release workflow via \`workflow_dispatch\` after merge and confirm \`@be-music/audio-renderer@0.2.0\`, \`@be-music/player@0.2.0\`, \`@be-music/player-tui@0.2.0\`, \`@be-music/player-web@0.2.0\`, \`@be-music/player-web-demo@0.2.0\`, and \`@be-music/utils@0.2.0\` appear in the Releases tab with their attached SEA archives.