### PR TITLE
docs: ship beatoraja-skin help/README updates missed by v0.2.3

### DIFF
--- a/.changeset/beatoraja-skin-help.md
+++ b/.changeset/beatoraja-skin-help.md
@@ -1,0 +1,11 @@
+---
+'@be-music/player-web-demo': patch
+---
+
+Help modal now documents beatoraja skin support alongside Lunatic Rave 2.
+The verified-skin note lists the four checked combinations: LR2 default,
+beatoraja default (`skin/default`), `ModernChic`, and `GdbG Original Skin`.
+"LR2 skin's PLAY / PLAY OPTION" wording is generalized to "the active skin's"
+since both rendering paths surface those buttons. Mirrored across the
+English and Japanese help panes. The change shipped as part of the
+beatoraja-skin work but was missed by the v0.2.3 release window.

--- a/README.ja.md
+++ b/README.ja.md
@@ -15,8 +15,9 @@ TypeScript + pnpm workspaces で構成した BMS/BMSON ツールチェーンで�
 - `@be-music/player`: 再生 engine、timing、判定、score、gauge、BGA timeline、UI/audio adapter 契約を共有する core package
 - `@be-music/player-tui`: autoplay、keyboard play、Music Select、BGA、SEA build を扱う terminal UI と `bms-player` CLI frontend
 - `@be-music/lr2-skin`: Lunatic Rave 2 skin parser、asset resolver、theme loader を renderer 非依存で提供する package
-- `@be-music/player-web`: 選曲、LR2 skin 描画、gameplay、result scene、録画を扱う browser PixiJS player core
-- `@be-music/player-web-demo`: folder / ZIP drop、LR2 theme、debug control、browser 再生を接続する private Vite demo
+- `@be-music/beatoraja-skin`: beatoraja JSON/Lua skin parser、normalizer、theme loader を renderer 非依存で提供する package
+- `@be-music/player-web`: 選曲、LR2 / beatoraja skin 描画、gameplay、result scene、録画を扱う browser PixiJS player core
+- `@be-music/player-web-demo`: folder / ZIP drop、LR2 / beatoraja theme、debug control、browser 再生を接続する private Vite demo
 - `@be-music/editor`: CLI エディタ (インポート・編集・エクスポート)
 
 ## 必要環境
@@ -69,6 +70,7 @@ tag は `@be-music/package-name@x.y.z` 形式で作成されます。
 - [Player 実装仕様](docs/player-spec.ja.md)
 - [Browser player 実装メモ](docs/player-web.ja.md)
 - [LR2 skin 実装メモ](docs/lr2-skin.ja.md)
+- [beatoraja skin 実装メモ](docs/beatoraja-skin.ja.md)
 - [BMS/BMSON 中間表現 (`@be-music/json`) 実装仕様](docs/json-spec.ja.md)
 - [用語集](docs/glossary.ja.md)
 
@@ -140,17 +142,27 @@ tag は `@be-music/package-name@x.y.z` 形式で作成されます。
 - image、number、text、slider、bargraph、button、BGA、judge line、measure line、gauge、score chart、result graph element を parse
 - case-insensitive / wildcard asset lookup、TGA decode、DXA archive extraction で theme asset を読み込み
 
+### beatoraja skin (`@be-music/beatoraja-skin`)
+
+- beatoraja JSON skin と Lua `.luaskin` entry を PixiJS 非依存で parse
+- beatoraja の 2-phase Lua contract を制限付き Fengari sandbox 上で評価
+- play / select / decide / result / course-result entry を discovery し、play skin を `5` / `7` / `9` / `10` / `14` / `24` / `24d` ごとに group 化
+- `property[]`、`filepath[]`、category group、custom offset、wildcard source path、case-insensitive asset を解決
+- image、imageset、value、float-value、text、slider、note、judge、gauge、graph、BPM graph、timing graph、song-list、custom event、destination、PM character element を normalize
+
 ### browser player (`@be-music/player-web` / `@be-music/player-web-demo`)
 
-- dropped folder、ZIP、BMS/LR2 theme 混在 drop を扱う browser song library
+- dropped folder、ZIP、song / LR2 / beatoraja theme 混在 drop を扱う browser song library
 - 大きな audio / video file を lazy に扱い、case-insensitive に path lookup
 - LR2 の select / decide / gameplay / result skin を parse して PixiJS で描画
+- beatoraja の select / decide / gameplay / result skin を parse して PixiJS で描画
 - destination 補間、sprite transform、number、text、slider、bargraph を扱う共通 LR2 Pixi helper
+- destination sampling、source cell selection、text、value、slider、gauge、graph、timing visualizer、note、marker、BGA、runtime op/timer wiring を扱う共通 beatoraja Pixi helper
 - note、timing、scroll distance、BGA cue、score、result は terminal player と共通の再生意味論を使用
 - key / BGM / master を分けた compressor control 付き WebAudio preview / gameplay bus
 - BGA still / video 描画、browser-side video transcode fallback、WebM gameplay recording
 - 1 つの renderer context を所有する PixiJS scene host と scene transition 時の resource dispose
-- hi-speed、BGA mode/size、filter、sort、HS-FIX、lane cover、auto-scratch、DP flip、random/mirror、gauge variant を扱う LR2 PLAY OPTION control
+- hi-speed、BGA mode/size、filter、sort、HS-FIX、lane cover、lift、auto-scratch、DP flip、random/mirror、gauge variant、skin option を扱う LR2 / beatoraja PLAY OPTION control
 
 ### editor (`@be-music/editor`)
 
@@ -236,7 +248,7 @@ pnpm run player chart.bms --no-ln-type-auto
 pnpm run player:web
 ```
 
-demo は Vite dev server を起動します。BMS/BMSON の楽曲 folder、LR2 theme folder、ZIP、または楽曲 folder と theme folder の組み合わせを browser に drop できます。
+demo は Vite dev server を起動します。BMS/BMSON の楽曲 folder、LR2 theme folder、beatoraja theme folder、ZIP、または楽曲 folder と LR2 / beatoraja theme folder の組み合わせを browser に drop できます。
 
 ### 6. エディタ
 
@@ -292,16 +304,18 @@ pnpm run editor export chart.json chart.bms
 - `.bms` -> `5 KEY SP/DP`
 - `.bme` -> `7 KEY SP/14 KEY DP`
 - `.pms` -> `9 KEY`
+- `11..19` をすべて使う 1P keyboard、または従来 IIDX 2P channel を含まない PMS-STD `22..25` も `9 KEY` として判定します。
 
 ### 代表モードのチャンネルと入力
 
-| Mode | Channel -> Input |
-| --- | --- |
-| `5 KEY SP` | `16 -> LShift`, `11 -> z`, `12 -> s`, `13 -> x`, `14 -> d`, `15 -> c` |
-| `5 KEY DP` | `16 -> LShift`, `11 -> z`, `12 -> s`, `13 -> x`, `14 -> d`, `15 -> c`, `21 -> b`, `22 -> h`, `23 -> n`, `24 -> j`, `25 -> m`, `26 -> RShift` |
-| `7 KEY SP` | `5 KEY SP` + `18 -> f`, `19 -> v` |
-| `14 KEY DP` | `7 KEY SP` + `21 -> b`, `22 -> h`, `23 -> n`, `24 -> j`, `25 -> m`, `28 -> k`, `29 -> ,`, `26 -> RShift` |
-| `9 KEY` | `11 -> z`, `12 -> s`, `13 -> x`, `14 -> d`, `15 -> c`, `16 -> f`, `17 -> v`, `18 -> g`, `19 -> b` |
+| Mode                     | Channel -> Input                                                                                                                             |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `5 KEY SP`               | `16 -> LShift`, `11 -> z`, `12 -> s`, `13 -> x`, `14 -> d`, `15 -> c`                                                                        |
+| `5 KEY DP`               | `16 -> LShift`, `11 -> z`, `12 -> s`, `13 -> x`, `14 -> d`, `15 -> c`, `21 -> b`, `22 -> h`, `23 -> n`, `24 -> j`, `25 -> m`, `26 -> RShift` |
+| `7 KEY SP`               | `5 KEY SP` + `18 -> f`, `19 -> v`                                                                                                            |
+| `14 KEY DP`              | `7 KEY SP` + `21 -> b`, `22 -> h`, `23 -> n`, `24 -> j`, `25 -> m`, `28 -> k`, `29 -> ,`, `26 -> RShift`                                     |
+| `9 KEY (BME-compatible)` | `11 -> z`, `12 -> s`, `13 -> x`, `14 -> d`, `15 -> c`, `16 -> f`, `17 -> v`, `18 -> g`, `19 -> b`                                            |
+| `9 KEY (PMS-STD)`        | `11 -> z`, `12 -> s`, `13 -> x`, `14 -> d`, `15 -> c`, `22 -> f`, `23 -> v`, `24 -> g`, `25 -> b`                                            |
 
 ## FREE ZONE (`17` / `27`)
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ BMS/BMSON toolchain composed of TypeScript + pnpm workspaces.
 - `@be-music/player`: Shared playback engine, timing, judgment, scoring, gauge, BGA timeline, and UI/audio adapter contracts
 - `@be-music/player-tui`: Terminal UI and `bms-player` CLI frontend for autoplay, keyboard play, Music Select, BGA, and SEA builds
 - `@be-music/lr2-skin`: Renderer-independent Lunatic Rave 2 skin parser, asset resolver, and theme loader
-- `@be-music/player-web`: Browser PixiJS player core for song selection, LR2 skin rendering, gameplay, result scenes, and recording
-- `@be-music/player-web-demo`: Private Vite demo that wires folder/ZIP drops, LR2 themes, debug controls, and browser playback together
+- `@be-music/beatoraja-skin`: Renderer-independent beatoraja JSON/Lua skin parser, normalizer, and theme loader
+- `@be-music/player-web`: Browser PixiJS player core for song selection, LR2 and beatoraja skin rendering, gameplay, result scenes, and recording
+- `@be-music/player-web-demo`: Private Vite demo that wires folder/ZIP drops, LR2/beatoraja themes, debug controls, and browser playback together
 - `@be-music/editor`: CLI editor (import/edit/export)
 
 ## Required environment
@@ -69,6 +70,7 @@ The tag is created in the format `@be-music/package-name@x.y.z`.
 - [Player implementation specification](./docs/player-spec.md)
 - [Browser player implementation notes](./docs/player-web.md)
 - [LR2 skin implementation notes](./docs/lr2-skin.md)
+- [beatoraja skin implementation notes](./docs/beatoraja-skin.md)
 - [BMS/BMSON intermediate representation (`@be-music/json`) implementation specification](./docs/json-spec.md)
 - [Glossary](./docs/glossary.md)
 
@@ -140,17 +142,27 @@ The semantics helper of the score is separated into `@be-music/chart`, and `@be-
 - Parses image, number, text, slider, bargraph, button, BGA, judge-line, measure-line, gauge, score-chart, and result graph elements
 - Loads theme assets with case-insensitive and wildcard lookup, TGA decoding, and DXA archive extraction
 
+### beatoraja skin (`@be-music/beatoraja-skin`)
+
+- Parses beatoraja JSON skins and Lua `.luaskin` entries independently from PixiJS
+- Evaluates the beatoraja two-phase Lua contract on a restricted Fengari sandbox
+- Discovers play / select / decide / result / course-result entries, with play skins grouped by `5` / `7` / `9` / `10` / `14` / `24` / `24d`
+- Resolves `property[]`, `filepath[]`, category groups, custom offsets, wildcard source paths, and case-insensitive assets
+- Normalizes image, imageset, value, float-value, text, slider, note, judge, gauge, graph, BPM graph, timing graph, song-list, custom event, destination, and PM character elements
+
 ### browser player (`@be-music/player-web` / `@be-music/player-web-demo`)
 
-- Browser song library for dropped folders, ZIPs, and mixed BMS/LR2 theme drops
+- Browser song library for dropped folders, ZIPs, and mixed song/LR2/beatoraja theme drops
 - Lazy browser asset loading for large audio/video files, with case-insensitive path lookup
 - LR2 select / decide / gameplay / result skin parsing and rendering on PixiJS
+- beatoraja select / decide / gameplay / result skin parsing and rendering on PixiJS
 - Shared LR2 Pixi helpers for destination interpolation, sprite transforms, numbers, text, sliders, and bargraphs
+- Shared beatoraja Pixi helpers for destination sampling, source-cell selection, text, values, sliders, gauges, graphs, timing visualizers, notes, markers, BGA, and runtime op/timer wiring
 - Shared playback semantics with the terminal player for notes, timing, scroll distance, BGA cues, score, and results
 - WebAudio preview and gameplay buses with split key/BGM/master compressor controls
 - BGA still/video rendering, browser-side video transcode fallback, and WebM gameplay recording
 - Single PixiJS scene host that owns one renderer context and disposes scene resources on transitions
-- In-scene LR2 PLAY OPTION controls for hi-speed, BGA mode/size, filters, sort, HS-FIX, lane cover, auto-scratch, DP flip, random/mirror modes, and gauge variants
+- In-scene LR2 and beatoraja PLAY OPTION controls for hi-speed, BGA mode/size, filters, sort, HS-FIX, lane cover, lift, auto-scratch, DP flip, random/mirror modes, gauge variants, and skin options
 
 ### editor (`@be-music/editor`)
 
@@ -236,7 +248,7 @@ pnpm run player chart.bms --no-ln-type-auto
 pnpm run player:web
 ```
 
-The demo starts a Vite dev server. Drop a BMS/BMSON song folder, an LR2 theme folder, a ZIP, or a song folder and theme folder together into the browser.
+The demo starts a Vite dev server. Drop a BMS/BMSON song folder, an LR2 theme folder, a beatoraja theme folder, a ZIP, or a song folder and LR2/beatoraja theme folder together into the browser.
 
 ### 6. Editor
 
@@ -292,16 +304,18 @@ If the automatic judgment is ambiguous, it will be supplemented with an extensio
 - `.bms` -> `5 KEY SP/DP`
 - `.bme` -> `7 KEY SP/14 KEY DP`
 - `.pms` -> `9 KEY`
+- A full `11..19` one-player keyboard or PMS-STD `22..25` without traditional IIDX 2P channels also resolves to `9 KEY`.
 
 ### Representative mode channels and inputs
 
-| Mode | Channel -> Input |
-| --- | --- |
-| `5 KEY SP` | `16 -> LShift`, `11 -> z`, `12 -> s`, `13 -> x`, `14 -> d`, `15 -> c` |
-| `5 KEY DP` | `16 -> LShift`, `11 -> z`, `12 -> s`, `13 -> x`, `14 -> d`, `15 -> c`, `21 -> b`, `22 -> h`, `23 -> n`, `24 -> j`, `25 -> m`, `26 -> RShift` |
-| `7 KEY SP` | `5 KEY SP` + `18 -> f`, `19 -> v` |
-| `14 KEY DP` | `7 KEY SP` + `21 -> b`, `22 -> h`, `23 -> n`, `24 -> j`, `25 -> m`, `28 -> k`, `29 -> ,`, `26 -> RShift` |
-| `9 KEY` | `11 -> z`, `12 -> s`, `13 -> x`, `14 -> d`, `15 -> c`, `16 -> f`, `17 -> v`, `18 -> g`, `19 -> b` |
+| Mode                     | Channel -> Input                                                                                                                             |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `5 KEY SP`               | `16 -> LShift`, `11 -> z`, `12 -> s`, `13 -> x`, `14 -> d`, `15 -> c`                                                                        |
+| `5 KEY DP`               | `16 -> LShift`, `11 -> z`, `12 -> s`, `13 -> x`, `14 -> d`, `15 -> c`, `21 -> b`, `22 -> h`, `23 -> n`, `24 -> j`, `25 -> m`, `26 -> RShift` |
+| `7 KEY SP`               | `5 KEY SP` + `18 -> f`, `19 -> v`                                                                                                            |
+| `14 KEY DP`              | `7 KEY SP` + `21 -> b`, `22 -> h`, `23 -> n`, `24 -> j`, `25 -> m`, `28 -> k`, `29 -> ,`, `26 -> RShift`                                     |
+| `9 KEY (BME-compatible)` | `11 -> z`, `12 -> s`, `13 -> x`, `14 -> d`, `15 -> c`, `16 -> f`, `17 -> v`, `18 -> g`, `19 -> b`                                            |
+| `9 KEY (PMS-STD)`        | `11 -> z`, `12 -> s`, `13 -> x`, `14 -> d`, `15 -> c`, `22 -> f`, `23 -> v`, `24 -> g`, `25 -> b`                                            |
 
 ## FREE ZONE (`17` / `27`)
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -10,6 +10,7 @@
 - [Player 実装仕様](player-spec.ja.md)
 - [Browser player 実装メモ](player-web.ja.md)
 - [LR2 skin 実装メモ](lr2-skin.ja.md)
+- [beatoraja skin 実装メモ](beatoraja-skin.ja.md)
 - [BMS/BMSON 中間表現 (`@be-music/json`) 実装仕様](json-spec.ja.md)
 - [用語集](glossary.ja.md)
 
@@ -20,3 +21,4 @@
 - これらの文書は現在の実装に集中させます。過去の判断は pull request、commit message、changelog に残してください。
 - `@be-music/json` は pure IR、`@be-music/chart` は beat 解決やイベント順序などの譜面意味論を担当します。
 - `@be-music/player` は共有 engine package です。terminal 固有の挙動は `@be-music/player-tui`、browser 固有の挙動は `@be-music/player-web` に置きます。
+- `@be-music/lr2-skin` と `@be-music/beatoraja-skin` は skin parsing を renderer 非依存に保ちます。browser PixiJS rendering は `@be-music/player-web` 側に記述します。

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ This directory is a Markdown collection of specifications used in the `be-music`
 - [Player implementation specification](./player-spec.md)
 - [Browser player implementation notes](./player-web.md)
 - [LR2 skin implementation notes](./lr2-skin.md)
+- [beatoraja skin implementation notes](./beatoraja-skin.md)
 - [BMS/BMSON intermediate representation (`@be-music/json`) implementation specification](./json-spec.md)
 - [Glossary](./glossary.md)
 
@@ -20,3 +21,4 @@ Supplement:
 - Keep these documents focused on the current implementation. Put past decisions in pull requests, commit messages, and changelogs.
 - `@be-music/json` is responsible for pure IR, and `@be-music/chart` is responsible for score semantics such as beat resolution and event order.
 - `@be-music/player` is the shared engine package. Terminal-specific behavior lives in `@be-music/player-tui`, and browser-specific behavior lives in `@be-music/player-web`.
+- `@be-music/lr2-skin` and `@be-music/beatoraja-skin` keep skin parsing renderer-independent. Browser PixiJS rendering is documented under `@be-music/player-web`.

--- a/docs/beatoraja-skin.ja.md
+++ b/docs/beatoraja-skin.ja.md
@@ -17,10 +17,10 @@ PixiJS rendering は `@be-music/player-web` の責務です。CLI/TUI render pat
 
 beatoraja theme は 2 種類の interchangeable な entry format を持ちます。
 
-| 拡張子 | format | discovery |
-| --- | --- | --- |
-| `*.json` | static JSON skin tree (trailing comma 含む) | `JSON.parse` で eager に parse |
-| `*.luaskin` + 兄弟 `*.lua` | `require()` で兄弟 module を読む Lua 5.3 script | Fengari で評価 (下記参照) |
+| 拡張子                     | format                                          | discovery                      |
+| -------------------------- | ----------------------------------------------- | ------------------------------ |
+| `*.json`                   | static JSON skin tree (trailing comma 含む)     | `JSON.parse` で eager に parse |
+| `*.luaskin` + 兄弟 `*.lua` | `require()` で兄弟 module を読む Lua 5.3 script | Fengari で評価 (下記参照)      |
 
 どちらも `BeatorajaSkin` (full) / `BeatorajaSkinHeader` (selector UI summary) と一致する value を返します。
 
@@ -29,27 +29,27 @@ beatoraja theme は 2 種類の interchangeable な entry format を持ちます
 各 skin の `type` 数値 field は beatoraja 本家の `SkinType` enum に対応します。
 package は `BEATORAJA_SKIN_TYPE` 定数と `playVariantForSkinType` / `sceneForSkinType` helper を export します。
 
-| code | label | scene |
-| --- | --- | --- |
-| 0 | `PLAY_7KEYS` | play (`'7'`) |
-| 1 | `PLAY_5KEYS` | play (`'5'`) |
-| 2 | `PLAY_14KEYS` | play (`'14'`) |
-| 3 | `PLAY_10KEYS` | play (`'10'`) |
-| 4 | `PLAY_9KEYS` | play (`'9'`) |
-| 5 | `MUSIC_SELECT` | select |
-| 6 | `DECIDE` | decide |
-| 7 | `RESULT` | result |
-| 8 | `KEY_CONFIG` | other |
-| 9 | `SKIN_SELECT` | other |
-| 10 | `SOUND_SET` | other |
-| 11 | `THEME` | other |
-| 12 | `PLAY_7KEYS_BATTLE` | play (unsupported battle layout) |
-| 13 | `PLAY_5KEYS_BATTLE` | play (unsupported battle layout) |
-| 14 | `PLAY_9KEYS_BATTLE` | play (unsupported battle layout) |
-| 15 | `COURSE_RESULT` | course-result |
-| 16 | `PLAY_24KEYS` | play (`'24'`) |
-| 17 | `PLAY_24KEYS_DOUBLE` | play (`'24d'`) |
-| 18 | `PLAY_24KEYS_BATTLE` | play (unsupported battle layout) |
+| code | label                | scene                            |
+| ---- | -------------------- | -------------------------------- |
+| 0    | `PLAY_7KEYS`         | play (`'7'`)                     |
+| 1    | `PLAY_5KEYS`         | play (`'5'`)                     |
+| 2    | `PLAY_14KEYS`        | play (`'14'`)                    |
+| 3    | `PLAY_10KEYS`        | play (`'10'`)                    |
+| 4    | `PLAY_9KEYS`         | play (`'9'`)                     |
+| 5    | `MUSIC_SELECT`       | select                           |
+| 6    | `DECIDE`             | decide                           |
+| 7    | `RESULT`             | result                           |
+| 8    | `KEY_CONFIG`         | other                            |
+| 9    | `SKIN_SELECT`        | other                            |
+| 10   | `SOUND_SET`          | other                            |
+| 11   | `THEME`              | other                            |
+| 12   | `PLAY_7KEYS_BATTLE`  | play (unsupported battle layout) |
+| 13   | `PLAY_5KEYS_BATTLE`  | play (unsupported battle layout) |
+| 14   | `PLAY_9KEYS_BATTLE`  | play (unsupported battle layout) |
+| 15   | `COURSE_RESULT`      | course-result                    |
+| 16   | `PLAY_24KEYS`        | play (`'24'`)                    |
+| 17   | `PLAY_24KEYS_DOUBLE` | play (`'24d'`)                   |
+| 18   | `PLAY_24KEYS_BATTLE` | play (unsupported battle layout) |
 
 ## Lua sandbox
 
@@ -80,6 +80,14 @@ end
 正規化 entry は active な `if` op-code を保持し、renderer は `isElementVisible()` で runtime に visibility を制御します。
 負数 op は negation 扱い (op が active で**ない**ことを要求) です。
 
+## Element normalization
+
+package は読み込んだ skin tree を upstream に近い形で保持しつつ、renderer 向けには型付き normalizer を expose します。
+normalizer は `src/elements/` 配下にあり、image、imageset、value、float-value、text、slider、note、judge、judge graph、gauge、gauge graph、BPM graph、timing visualizer、timing distribution graph、song list、custom event、direction、destination、PM character、generic graph element を扱います。
+
+destination normalization は keyframe、offset、op gate、interpolation data を renderer 非依存の object に変換します。
+value / image helper は `divx` / `divy` cell math、frame の carry-forward、loop wrapping を解決するため、renderer は source JSON / Lua table を再解釈せずに現在 frame を sample できます。
+
 ## Asset 解決
 
 `resolveBeatorajaPath()` は entry skin file からの相対 path を解決します。
@@ -93,21 +101,24 @@ user の `filepath[]` 選択がある場合はそれが wildcard より優先さ
 ## Theme discovery
 
 `discoverBeatorajaTheme()` は file map を walk し、scene 別 entry を持つ `BeatorajaTheme` を生成します。
-play skin は variant ごと (`'7' / '5' / '9' / '10' / '14' / '24' / '24d'`) に group 化し、
-同じ variant を `.json` / `.luaskin` の両方が cover する場合は JSON 側を優先します (parse が速く決定論的なため)。
+play skin は variant ごと (`'7' / '5' / '9' / '10' / '14' / '24' / '24d'`) に group 化します。
+複数 entry が同じ slot を cover する場合は、JSON entry、`skin/default/`、辞書順の順で優先します。
 個別 skin の error は `BeatorajaThemeDiscoveryWarning[]` に集約され、theme 全体の discovery を中断しません。
 
 `pickBeatorajaPlaySkin(playSkins, desired)` は chart の variant に対する fallback chain を解決します。
 
 ## Browser player への配線
 
-`@be-music/player-web` は `loadBeatorajaThemeFromFiles()` と helper 群
-(`loadBeatorajaPlaySkinFromBundle` / `loadBeatorajaSelectSkinFromBundle` / `loadBeatorajaResultSkinFromBundle` / `loadBeatorajaDecideSkinFromBundle`)
-を提供し、parser pipeline を browser 親和的な `File[]` API で wrap します。
-state は LR2 theme state と並列に保持され、demo は drop が両方を含む場合に両方の summary を log します。
+`@be-music/player-web` は `loadBeatorajaThemeFromFiles()` を提供し、dropped browser `File[]` を `BeatorajaThemeBundle` に wrap します。
+host はその bundle から、この package の `loadBeatorajaSkin()` / `loadBeatorajaPlaySkin()`、`source[]` 向けの `bundleBeatorajaSources()`、Pixi texture 向けの `loadBeatorajaTexturesFromBundle()`、CSS / bitmap font 向けの `loadBeatorajaFonts()` を呼びます。
+state は LR2 theme state と並列に保持されるため、demo は両方の theme format を同時に保持できます。
 
-beatoraja skin の PixiJS rendering は後続 patch で実装されます。
-現状は parser の配線、drop 時の theme discovery、bundle の inspection 用 expose までが含まれます。
+browser renderer は select、decide、gameplay、result skin の共有 view として `BeatorajaPlaySkinView` を使います。
+scene module は `TEXT`、`NUM`、`OPTION`、timer、chart image、graph、gauge、note layer、BGA layer、system sound、result history など runtime 固有の resolver を提供します。
+gameplay は `BeatorajaRuntimeAdapter` で engine UI signal を beatoraja timer、op code、judge popup、combo digit、key beam、LN hold timer、timing sample へ変換します。
+
+browser gameplay path は chart variant `5`、`7`、`9`、`10`、`14` を mount します。
+parser は `24` / `24d` skin も discovery しますが、現在の共有 player engine は 24-key chart gameplay を駆動しません。
 
 ## 互換性の境界
 

--- a/docs/beatoraja-skin.md
+++ b/docs/beatoraja-skin.md
@@ -21,9 +21,9 @@ and Lua skin themes into renderer-independent data structures. PixiJS rendering 
 
 beatoraja themes ship two interchangeable entry formats:
 
-| extension | format | discovery |
-| --- | --- | --- |
-| `*.json` | static JSON skin tree (with optional trailing commas, which we strip) | parsed eagerly via `JSON.parse` |
+| extension                     | format                                                                         | discovery                       |
+| ----------------------------- | ------------------------------------------------------------------------------ | ------------------------------- |
+| `*.json`                      | static JSON skin tree (with optional trailing commas, which we strip)          | parsed eagerly via `JSON.parse` |
 | `*.luaskin` + sibling `*.lua` | Lua 5.3 script that returns a skin table; uses `require()` for sibling modules | evaluated by Fengari, see below |
 
 Both formats produce values matching `BeatorajaSkin` (full) and `BeatorajaSkinHeader` (selector-UI summary).
@@ -34,27 +34,27 @@ The numeric `type` field on every skin matches beatoraja's upstream `SkinType` e
 `BEATORAJA_SKIN_TYPE` and the helpers `playVariantForSkinType` / `sceneForSkinType` so consumers can route entries
 without hard-coding integer literals.
 
-| code | label | scene |
-| --- | --- | --- |
-| 0 | `PLAY_7KEYS` | play (`'7'`) |
-| 1 | `PLAY_5KEYS` | play (`'5'`) |
-| 2 | `PLAY_14KEYS` | play (`'14'`) |
-| 3 | `PLAY_10KEYS` | play (`'10'`) |
-| 4 | `PLAY_9KEYS` | play (`'9'`) |
-| 5 | `MUSIC_SELECT` | select |
-| 6 | `DECIDE` | decide |
-| 7 | `RESULT` | result |
-| 8 | `KEY_CONFIG` | other |
-| 9 | `SKIN_SELECT` | other |
-| 10 | `SOUND_SET` | other |
-| 11 | `THEME` | other |
-| 12 | `PLAY_7KEYS_BATTLE` | play (unsupported battle layout) |
-| 13 | `PLAY_5KEYS_BATTLE` | play (unsupported battle layout) |
-| 14 | `PLAY_9KEYS_BATTLE` | play (unsupported battle layout) |
-| 15 | `COURSE_RESULT` | course-result |
-| 16 | `PLAY_24KEYS` | play (`'24'`) |
-| 17 | `PLAY_24KEYS_DOUBLE` | play (`'24d'`) |
-| 18 | `PLAY_24KEYS_BATTLE` | play (unsupported battle layout) |
+| code | label                | scene                            |
+| ---- | -------------------- | -------------------------------- |
+| 0    | `PLAY_7KEYS`         | play (`'7'`)                     |
+| 1    | `PLAY_5KEYS`         | play (`'5'`)                     |
+| 2    | `PLAY_14KEYS`        | play (`'14'`)                    |
+| 3    | `PLAY_10KEYS`        | play (`'10'`)                    |
+| 4    | `PLAY_9KEYS`         | play (`'9'`)                     |
+| 5    | `MUSIC_SELECT`       | select                           |
+| 6    | `DECIDE`             | decide                           |
+| 7    | `RESULT`             | result                           |
+| 8    | `KEY_CONFIG`         | other                            |
+| 9    | `SKIN_SELECT`        | other                            |
+| 10   | `SOUND_SET`          | other                            |
+| 11   | `THEME`              | other                            |
+| 12   | `PLAY_7KEYS_BATTLE`  | play (unsupported battle layout) |
+| 13   | `PLAY_5KEYS_BATTLE`  | play (unsupported battle layout) |
+| 14   | `PLAY_9KEYS_BATTLE`  | play (unsupported battle layout) |
+| 15   | `COURSE_RESULT`      | course-result                    |
+| 16   | `PLAY_24KEYS`        | play (`'24'`)                    |
+| 17   | `PLAY_24KEYS_DOUBLE` | play (`'24d'`)                   |
+| 18   | `PLAY_24KEYS_BATTLE` | play (unsupported battle layout) |
 
 ## Lua sandbox
 
@@ -86,6 +86,17 @@ Pass `skinConfig: undefined` for the first phase and a populated `BeatorajaSkinC
 `flattenBeatorajaElements()`. Each normalized entry carries the active `if` op-codes so the renderer can gate
 visibility at runtime via `isElementVisible()`. Negative codes are treated as negation (the op must NOT be active).
 
+## Element normalization
+
+The package keeps the loaded skin tree close to upstream, then exposes typed normalizers for renderer work.
+Normalizers live under `src/elements/` and cover image, imageset, value, float-value, text, slider, note, judge,
+judge graph, gauge, gauge graph, BPM graph, timing visualizer, timing distribution graph, song list, custom event,
+direction, destination, PM character, and generic graph elements.
+
+Destination normalization carries keyframes, offsets, op gates, and interpolation data in renderer-independent
+objects. Value and image helpers resolve `divx` / `divy` cell math, carry-forward frames, and loop wrapping so a
+renderer can sample the current frame without reinterpreting the source JSON or Lua tables.
+
 ## Asset resolution
 
 `resolveBeatorajaPath()` resolves a `path` field relative to its entry skin file. `..` segments are honored, slashes
@@ -98,22 +109,29 @@ selection (when present) overrides the wildcard; otherwise the first sorted matc
 ## Theme discovery
 
 `discoverBeatorajaTheme()` walks a file map and produces a `BeatorajaTheme` whose fields point at the per-scene
-entries. Play skins are grouped by variant (`'7' / '5' / '9' / '10' / '14' / '24' / '24d'`); when both a `.json`
-and a `.luaskin` cover the same variant, the JSON entry wins (parsing is faster and deterministic). Errors are
-collected as `BeatorajaThemeDiscoveryWarning[]` instead of aborting discovery so a single bad skin can't break the
-whole theme.
+entries. Play skins are grouped by variant (`'7' / '5' / '9' / '10' / '14' / '24' / '24d'`). When multiple entries
+cover the same slot, JSON entries win over Lua entries, `skin/default/` wins over community skins, and lexicographic
+order resolves the final tie. Errors are collected as `BeatorajaThemeDiscoveryWarning[]` instead of aborting
+discovery so a single bad skin can't break the whole theme.
 
 `pickBeatorajaPlaySkin(playSkins, desired)` resolves a chart's variant against a fallback chain.
 
 ## Browser player wiring
 
-`@be-music/player-web` ships `loadBeatorajaThemeFromFiles()` and helper functions
-(`loadBeatorajaPlaySkinFromBundle`, `loadBeatorajaSelectSkinFromBundle`, `loadBeatorajaResultSkinFromBundle`,
-`loadBeatorajaDecideSkinFromBundle`) that wrap the parser pipeline behind a browser-friendly `File[]` API. The
-state lives in parallel with the LR2 theme state; the demo logs both summaries when a drop carries either format.
+`@be-music/player-web` ships `loadBeatorajaThemeFromFiles()` to wrap dropped browser `File[]` objects into a
+`BeatorajaThemeBundle`. Hosts then call `loadBeatorajaSkin()` or `loadBeatorajaPlaySkin()` from this package,
+`bundleBeatorajaSources()` for `source[]`, `loadBeatorajaTexturesFromBundle()` for Pixi textures, and
+`loadBeatorajaFonts()` for CSS or bitmap fonts. The state lives in parallel with LR2 theme state, so the demo can
+hold both theme formats at once.
 
-PixiJS rendering for beatoraja skins is implemented in a follow-up patch — for now the parser is wired, theme
-discovery runs on drop, and the resulting bundle is exposed for inspection.
+The browser renderer uses `BeatorajaPlaySkinView` as the shared view for select, decide, gameplay, and result
+skins. Scene modules provide the runtime-specific resolvers for `TEXT`, `NUM`, `OPTION`, timers, chart images,
+graphs, gauges, note layers, BGA layers, system sounds, and result histories. Gameplay uses
+`BeatorajaRuntimeAdapter` to translate engine UI signals into beatoraja timers, op codes, judge popups, combo
+digits, key beams, LN hold timers, and timing samples.
+
+The browser gameplay path mounts chart variants `5`, `7`, `9`, `10`, and `14`. The parser still discovers `24` and
+`24d` skins, but the current shared player engine does not drive 24-key chart gameplay.
 
 ## Compatibility boundary
 

--- a/docs/glossary.ja.md
+++ b/docs/glossary.ja.md
@@ -24,7 +24,7 @@
 - **BGA**: gameplay 中に表示する背景画像/動画です。base、layer、layer2、POOR などの cue を持ちます。
 - **POOR BGA**: `POOR` 判定時に表示する専用 BGA です。譜面側で定義されている場合だけ使います。
 - **STAGEFILE**: chart 選択後の loading screen に表示する画像です。gameplay 中の BGA とは別用途です。
-- **BACKBMP**: BMS `#BACKBMP` または bmson の back-image metadata から解決する LR2 skin special graphic slot です。
+- **BACKBMP**: BMS `#BACKBMP` または bmson の back-image metadata から解決する skin special graphic slot です。browser LR2 / beatoraja scene は chart imagery として解決できます。
 - **BANNER**: Music Select に表示する横長画像です。BMS では `#BANNER`、bmson では `info.banner_image` を使います。
 
 ## 再生と判定
@@ -56,8 +56,9 @@
 
 - **player core**: `@be-music/player` の共有 engine と helper surface です。timing、note extraction、judgment、scoring、gauge helper、BGA timeline、UI/audio adapter 契約を担当します。
 - **terminal player**: `@be-music/player-tui` の CLI / TUI frontend です。core engine の上に Music Select、terminal gameplay、terminal BGA、loading screen、SEA build を提供します。
-- **browser player**: `@be-music/player-web` の PixiJS/WebAudio runtime と `@be-music/player-web-demo` の Vite host です。browser drop、LR2 skin rendering、browser gameplay、result scene、recording を扱います。
+- **browser player**: `@be-music/player-web` の PixiJS/WebAudio runtime と `@be-music/player-web-demo` の Vite host です。browser drop、LR2 / beatoraja skin rendering、browser gameplay、result scene、recording を扱います。
 - **LR2 skin**: `@be-music/lr2-skin` が扱う Lunatic Rave 2 CSV skin format です。この package は PixiJS に依存せず、skin file の parse と theme asset 解決を行います。
+- **beatoraja skin**: `@be-music/beatoraja-skin` が扱う beatoraja JSON / Lua skin format です。この package は PixiJS に依存せず、header / full skin の parse、option / asset 解決、element normalization を行います。
 
 ## 内部モデル
 
@@ -101,4 +102,5 @@
 - [Player 実装仕様](./player-spec.ja.md)
 - [Browser player 実装メモ](./player-web.ja.md)
 - [LR2 skin 実装メモ](./lr2-skin.ja.md)
+- [beatoraja skin 実装メモ](./beatoraja-skin.ja.md)
 - [BMS/BMSON 中間表現 (`@be-music/json`) 実装仕様](./json-spec.ja.md)

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -24,7 +24,7 @@ The definitions follow general BMS/BMSON terminology where possible, but priorit
 - **BGA**: Background image or video displayed during gameplay. BGA timelines can have base, layer, layer2, and POOR cues.
 - **POOR BGA**: Dedicated visual shown during `POOR` judgment when the chart defines one.
 - **STAGEFILE**: Loading-screen image shown after chart selection. It is separate from gameplay BGA.
-- **BACKBMP**: LR2 skin special graphic slot backed by BMS `#BACKBMP` or bmson back-image metadata.
+- **BACKBMP**: Skin special graphic slot backed by BMS `#BACKBMP` or bmson back-image metadata. Browser LR2 and beatoraja scenes can resolve it as chart imagery.
 - **BANNER**: Horizontal image shown in Music Select. BMS uses `#BANNER`; bmson uses `info.banner_image`.
 
 ## Playback And Judgment
@@ -56,8 +56,9 @@ The definitions follow general BMS/BMSON terminology where possible, but priorit
 
 - **player core**: The shared `@be-music/player` engine and helper surface. It owns timing, note extraction, judgment, scoring, gauge helpers, BGA timelines, and UI/audio adapter contracts.
 - **terminal player**: The `@be-music/player-tui` CLI and TUI frontend. It provides Music Select, terminal gameplay, terminal BGA, loading screens, and SEA builds on top of the core engine.
-- **browser player**: The `@be-music/player-web` PixiJS/WebAudio runtime and the `@be-music/player-web-demo` Vite host. It handles browser drops, LR2 skin rendering, browser gameplay, result scenes, and recording.
+- **browser player**: The `@be-music/player-web` PixiJS/WebAudio runtime and the `@be-music/player-web-demo` Vite host. It handles browser drops, LR2/beatoraja skin rendering, browser gameplay, result scenes, and recording.
 - **LR2 skin**: Lunatic Rave 2 CSV skin format handled by `@be-music/lr2-skin`. The package parses skin files and resolves theme assets independently from PixiJS.
+- **beatoraja skin**: beatoraja JSON or Lua skin format handled by `@be-music/beatoraja-skin`. The package parses headers and full skins, resolves options and assets, and normalizes elements independently from PixiJS.
 
 ## Internal Model
 
@@ -101,4 +102,5 @@ The definitions follow general BMS/BMSON terminology where possible, but priorit
 - [Player implementation specification](./player-spec.md)
 - [Browser player implementation notes](./player-web.md)
 - [LR2 skin implementation notes](./lr2-skin.md)
+- [beatoraja skin implementation notes](./beatoraja-skin.md)
 - [BMS/BMSON intermediate representation (`@be-music/json`) implementation specification](./json-spec.md)

--- a/docs/player-spec.ja.md
+++ b/docs/player-spec.ja.md
@@ -15,7 +15,7 @@
 
 この文書が対象にするのは、`autoPlay()` と `manualPlay()` が返す結果、およびそれらが内部で使う判定・表示・音声処理です。
 `@be-music/player-tui` の CLI 引数、設定ファイル永続化、Node ワーカー間通信などの呼び出し方法は対象外です。
-terminal player と browser player は timing、note、BGA cue、score、result に同じ譜面意味論を再利用します。Terminal UI の挙動は `@be-music/player-tui` 側にあり、PixiJS scene、LR2 skin 描画、browser file loading、WebAudio lifecycle は [Browser player 実装メモ](./player-web.ja.md) に分けて記述します。
+terminal player と browser player は timing、note、BGA cue、score、result に同じ譜面意味論を再利用します。Terminal UI の挙動は `@be-music/player-tui` 側にあり、PixiJS scene、LR2 / beatoraja skin 描画、browser file loading、WebAudio lifecycle は [Browser player 実装メモ](./player-web.ja.md) に分けて記述します。
 
 core engine の既定ゲージは LR2 の `NORMAL` gauge に相当する `GROOVE` gauge です。
 export している gauge helper は browser PLAY OPTION control 向けに `HARD`、`DEATH`、`EASY` も扱います。bundled terminal player には現時点で gauge type switch はありません。
@@ -28,66 +28,66 @@ parser が IR へ保持するだけで、player が実行時に参照しない�
 
 ### 対応チャンネル
 
-| channel | player における扱い |
-| --- | --- |
-| `#xxx01` | BGM / sample trigger として再生します。 |
-| `#xxx02` | 小節長として時間解決と beat 解決に反映します。 |
-| `#xxx03`, `#xxx08` | BPM change として時間解決に反映します。 |
-| `#xxx04`, `#xxx07`, `#xxx0A` | BGA base / layer / layer2 として描画します。 |
-| `#xxx06` | POOR BGA cue として扱います。`#POORBGA` 未指定時は `#BMP00` を fallback に使います。 |
-| `#xxx09` | STOP として時間解決に反映します。 |
-| `#xxx11-19`, `#xxx21-29` | 可視演奏ノートとして扱います。`16` / `26` は scratch、`17` / `27` は 9KEY 以外では FREE ZONE、9KEY では通常ノートです。 |
-| `#xxx31-39`, `#xxx41-49` | 不可視ノートとして扱います。手動入力の候補と表示補助には使いますが、`summary.total` には含めません。`AUTO` では発音しません。 |
-| `#xxx51-59`, `#xxx61-69` | BMS legacy long note として扱います。 |
-| `#xxx97`, `#xxx98` | 以後に鳴る BGM / playable sound の初期 gain を変更する動的音量変更として扱います。 |
-| `#xxxA0` | `#EXRANKxx` を参照する動的判定幅変更として扱います。 |
-| `#xxxSC` | `#SCROLLxx` 参照の scroll segment として描画距離へ反映します。 |
-| `#xxxSP` | `#SPEEDxx` 参照の speed keyframe として描画距離へ反映します。 |
-| `#xxxD1-D9`, `#xxxE1-E9` | 地雷として扱います。 |
+| channel                      | player における扱い                                                                                                           |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `#xxx01`                     | BGM / sample trigger として再生します。                                                                                       |
+| `#xxx02`                     | 小節長として時間解決と beat 解決に反映します。                                                                                |
+| `#xxx03`, `#xxx08`           | BPM change として時間解決に反映します。                                                                                       |
+| `#xxx04`, `#xxx07`, `#xxx0A` | BGA base / layer / layer2 として描画します。                                                                                  |
+| `#xxx06`                     | POOR BGA cue として扱います。`#POORBGA` 未指定時は `#BMP00` を fallback に使います。                                          |
+| `#xxx09`                     | STOP として時間解決に反映します。                                                                                             |
+| `#xxx11-19`, `#xxx21-29`     | 可視演奏ノートとして扱います。`16` / `26` は scratch、`17` / `27` は 9KEY 以外では FREE ZONE、9KEY では通常ノートです。       |
+| `#xxx31-39`, `#xxx41-49`     | 不可視ノートとして扱います。手動入力の候補と表示補助には使いますが、`summary.total` には含めません。`AUTO` では発音しません。 |
+| `#xxx51-59`, `#xxx61-69`     | BMS legacy long note として扱います。                                                                                         |
+| `#xxx97`, `#xxx98`           | 以後に鳴る BGM / playable sound の初期 gain を変更する動的音量変更として扱います。                                            |
+| `#xxxA0`                     | `#EXRANKxx` を参照する動的判定幅変更として扱います。                                                                          |
+| `#xxxSC`                     | `#SCROLLxx` 参照の scroll segment として描画距離へ反映します。                                                                |
+| `#xxxSP`                     | `#SPEEDxx` 参照の speed keyframe として描画距離へ反映します。                                                                 |
+| `#xxxD1-D9`, `#xxxE1-E9`     | 地雷として扱います。                                                                                                          |
 
 ### 対応コマンド
 
-| command | player における扱い |
-| --- | --- |
-| `#TITLE`, `#SUBTITLE`, `#ARTIST`, `#SUBARTIST`, `#GENRE`, `#COMMENT` | 選曲画面の metadata 表示に使います。`#TITLE` / `#ARTIST` / `#GENRE` は TUI と結果画面にも使います。 |
-| `#BANNER` | 選曲画面の banner 表示に使います。bmson では `info.banner_image` を同用途で使います。 |
-| `#STAGEFILE` | 選曲後の loading screen 専用画像として使います。gameplay 中の BGA renderer では参照しません。 |
-| `#PLAYLEVEL`, `#DIFFICULTY` | 選曲画面の表示、ソート、フィルタ、結果表示に使います。 |
-| `#BPM`, `#BPMxx`, `#STOPxx`, `#STP` | 時間解決に使います。 |
-| `#RANK`, `#DEFEXRANK`, `#EXRANKxx`, `#TOTAL` | 判定幅、表示ランク、groove gauge 計算に使います。 |
-| `#WAVxx`, `#BMPxx` | 音声・BGA リソース解決に使います。 |
-| `#BASE` | BMS object ID の base を選びます。`#BASE 62` では sample、BGA、BPM/STOP 参照、long-note 終端、地雷値の解決時に小文字 ID を case-sensitive に扱います。 |
-| `#PREVIEW` | 選曲画面のプレビュー再生で優先的に使います。 |
-| `#PATH_WAV` | 選曲画面プレビューのファイル探索にだけ使います。通常プレイ中の sample 解決には使いません。 |
-| `#LNTYPE`, `#LNMODE`, `#LNOBJ` | BMS long note の解釈に使います。 |
-| `#PLAYER` | レーンモード推定と表示上の player metadata に使います。 |
-| `#VOLWAV` | 譜面全体の音量倍率として使います。 |
-| `#POORBGA` | POOR 画像の既定値上書きに使います。 |
-| `#SCROLLxx`, `#SPEEDxx` | ノート描画距離の計算に使います。 |
-| `#RANDOM`, `#SETRANDOM`, `#IF`, `#ELSEIF`, `#ELSE`, `#ENDIF`, `#ENDRANDOM`, `#SWITCH`, `#SETSWITCH`, `#CASE`, `#SKIP`, `#DEF`, `#ENDSW` | 再生開始前に制御構文として解決します。 |
+| command                                                                                                                                 | player における扱い                                                                                                                                    |
+| --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `#TITLE`, `#SUBTITLE`, `#ARTIST`, `#SUBARTIST`, `#GENRE`, `#COMMENT`                                                                    | 選曲画面の metadata 表示に使います。`#TITLE` / `#ARTIST` / `#GENRE` は TUI と結果画面にも使います。                                                    |
+| `#BANNER`                                                                                                                               | 選曲画面の banner 表示に使います。bmson では `info.banner_image` を同用途で使います。                                                                  |
+| `#STAGEFILE`                                                                                                                            | 選曲後の loading screen 専用画像として使います。gameplay 中の BGA renderer では参照しません。                                                          |
+| `#PLAYLEVEL`, `#DIFFICULTY`                                                                                                             | 選曲画面の表示、ソート、フィルタ、結果表示に使います。                                                                                                 |
+| `#BPM`, `#BPMxx`, `#STOPxx`, `#STP`                                                                                                     | 時間解決に使います。                                                                                                                                   |
+| `#RANK`, `#DEFEXRANK`, `#EXRANKxx`, `#TOTAL`                                                                                            | 判定幅、表示ランク、groove gauge 計算に使います。                                                                                                      |
+| `#WAVxx`, `#BMPxx`                                                                                                                      | 音声・BGA リソース解決に使います。                                                                                                                     |
+| `#BASE`                                                                                                                                 | BMS object ID の base を選びます。`#BASE 62` では sample、BGA、BPM/STOP 参照、long-note 終端、地雷値の解決時に小文字 ID を case-sensitive に扱います。 |
+| `#PREVIEW`                                                                                                                              | 選曲画面のプレビュー再生で優先的に使います。                                                                                                           |
+| `#PATH_WAV`                                                                                                                             | 選曲画面プレビューのファイル探索にだけ使います。通常プレイ中の sample 解決には使いません。                                                             |
+| `#LNTYPE`, `#LNMODE`, `#LNOBJ`                                                                                                          | BMS long note の解釈に使います。                                                                                                                       |
+| `#PLAYER`                                                                                                                               | レーンモード推定と表示上の player metadata に使います。                                                                                                |
+| `#VOLWAV`                                                                                                                               | 譜面全体の音量倍率として使います。                                                                                                                     |
+| `#POORBGA`                                                                                                                              | POOR 画像の既定値上書きに使います。                                                                                                                    |
+| `#SCROLLxx`, `#SPEEDxx`                                                                                                                 | ノート描画距離の計算に使います。                                                                                                                       |
+| `#RANDOM`, `#SETRANDOM`, `#IF`, `#ELSEIF`, `#ELSE`, `#ENDIF`, `#ENDRANDOM`, `#SWITCH`, `#SETSWITCH`, `#CASE`, `#SKIP`, `#DEF`, `#ENDSW` | 再生開始前に制御構文として解決します。                                                                                                                 |
 
 ### 未対応チャンネル
 
-| channel | 現在の player 実装 |
-| --- | --- |
-| `#xxxA6` | `#CHANGEOPTIONxx` の実行時反映チャンネルとしては未対応です。event として保持されても player runtime は参照しません。 |
+| channel                                                                     | 現在の player 実装                                                                                                                                                                              |
+| --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `#xxxA6`                                                                    | `#CHANGEOPTIONxx` の実行時反映チャンネルとしては未対応です。event として保持されても player runtime は参照しません。                                                                            |
 | `#xxx1A-1Z`, `#xxx2A-2Z` など、上の対応一覧に含まれない演奏系拡張チャンネル | 現在の runtime では playable note channel として扱いません。`24 KEY SP` / `48 KEY DP` の表示モード推定と入力割り当てはありますが、これらのチャンネル自体は score/judge 対象ノートになりません。 |
-| 上の対応一覧に含まれないその他の object channel | parser が保持しても、player runtime は意味解釈しません。 |
+| 上の対応一覧に含まれないその他の object channel                             | parser が保持しても、player runtime は意味解釈しません。                                                                                                                                        |
 
 ### 未対応コマンド
 
-| command | 現在の player 実装 |
-| --- | --- |
-| `#TEXTxx`, `#TEXT00` | parser は保持しますが、player の表示や runtime 演出には使いません。 |
-| `#OPTION`, `#CHANGEOPTIONxx` | parser は保持しますが、core runtime での play option 強制変更は未対応です。 |
-| `#WAVCMD`, `#EXWAVxx` | parser は保持します。bundled Node realtime audio session は適用しませんが、audio-renderer と browser WebAudio は実装済みの volume subset (`#WAVCMD 01` と `#EXWAVxx v`) を反映します。pitch、loop、pan、frequency parameter は未対応です。 |
-| `#BACKBMP` | core/terminal runtime には専用挙動がありません。browser LR2 special graphic はこの値を利用できます。 |
-| `#MAKER` | metadata-only / unsupported です。 |
-| `#EXBMPxx`, `#BGAxx`, `#SWBGAxx`, `#ARGBxx` | parser は保持します。terminal/core runtime は適用しませんが、browser player は BGA sub-region、switching、tint、alpha の実装済み subset を描画します。 |
-| `#BASEBPM` | parser は保持しますが、player は時間解決に使いません。 |
-| `#VIDEOFILE` | parser は保持しますが、player の BGA 動画解決には使いません。現実装の動画再生は `#BMPxx` で参照した動画ファイルだけを扱います。 |
-| `#MIDIFILE`, `#MATERIALS`, `#DIVIDEPROP`, `#CHARSET` | parser は保持しますが、player runtime は参照しません。 |
-| `#SONGxx`, `#EXBPMxx`, `#CHARFILE`, `#ExtChr`, `#CDDA`, `#VIDEOFPS`, `#VIDEODLY`, `#VIDEOCOLORS`, `#SEEK`, `#MATERIALSBMP`, `#MATERIALSWAV` | 現在の player 実装では未対応です。 |
+| command                                                                                                                                     | 現在の player 実装                                                                                                                                                                                                                         |
+| ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `#TEXTxx`, `#TEXT00`                                                                                                                        | parser は保持しますが、player の表示や runtime 演出には使いません。                                                                                                                                                                        |
+| `#OPTION`, `#CHANGEOPTIONxx`                                                                                                                | parser は保持しますが、core runtime での play option 強制変更は未対応です。                                                                                                                                                                |
+| `#WAVCMD`, `#EXWAVxx`                                                                                                                       | parser は保持します。bundled Node realtime audio session は適用しませんが、audio-renderer と browser WebAudio は実装済みの volume subset (`#WAVCMD 01` と `#EXWAVxx v`) を反映します。pitch、loop、pan、frequency parameter は未対応です。 |
+| `#BACKBMP`                                                                                                                                  | core/terminal runtime には専用挙動がありません。browser LR2 special graphic はこの値を利用できます。                                                                                                                                       |
+| `#MAKER`                                                                                                                                    | metadata-only / unsupported です。                                                                                                                                                                                                         |
+| `#EXBMPxx`, `#BGAxx`, `#SWBGAxx`, `#ARGBxx`                                                                                                 | parser は保持します。terminal/core runtime は適用しませんが、browser player は BGA sub-region、switching、tint、alpha の実装済み subset を描画します。                                                                                     |
+| `#BASEBPM`                                                                                                                                  | parser は保持しますが、player は時間解決に使いません。                                                                                                                                                                                     |
+| `#VIDEOFILE`                                                                                                                                | parser は保持しますが、player の BGA 動画解決には使いません。現実装の動画再生は `#BMPxx` で参照した動画ファイルだけを扱います。                                                                                                            |
+| `#MIDIFILE`, `#MATERIALS`, `#DIVIDEPROP`, `#CHARSET`                                                                                        | parser は保持しますが、player runtime は参照しません。                                                                                                                                                                                     |
+| `#SONGxx`, `#EXBPMxx`, `#CHARFILE`, `#ExtChr`, `#CDDA`, `#VIDEOFPS`, `#VIDEODLY`, `#VIDEOCOLORS`, `#SEEK`, `#MATERIALSBMP`, `#MATERIALSWAV` | 現在の player 実装では未対応です。                                                                                                                                                                                                         |
 
 ## 実行フロー
 

--- a/docs/player-spec.md
+++ b/docs/player-spec.md
@@ -15,7 +15,7 @@ Regarding the acceptance rules of musical score formats and the meaning of IR, p
 
 This document covers the results returned by `autoPlay()` and `manualPlay()`, as well as the judgment, display, and audio processing they use internally.
 Invocation methods such as `@be-music/player-tui` CLI arguments, configuration file persistence, and Node worker communication are not covered.
-The terminal player and browser player reuse the same chart semantics for timing, notes, BGA cues, score, and results. Terminal UI behavior lives in `@be-music/player-tui`, while PixiJS scenes, LR2 skin rendering, browser file loading, and WebAudio lifecycle are documented separately in [Browser player implementation notes](./player-web.md).
+The terminal player and browser player reuse the same chart semantics for timing, notes, BGA cues, score, and results. Terminal UI behavior lives in `@be-music/player-tui`, while PixiJS scenes, LR2/beatoraja skin rendering, browser file loading, and WebAudio lifecycle are documented separately in [Browser player implementation notes](./player-web.md).
 
 The core engine defaults to the LR2-compatible `GROOVE` gauge, which corresponds to LR2's `NORMAL` gauge.
 The exported gauge helper also supports `HARD`, `DEATH`, and `EASY` for browser PLAY OPTION controls. The bundled terminal player currently has no gauge-type switch.
@@ -28,66 +28,66 @@ Items that are only stored in the IR by the parser and not referenced by the pla
 
 ### Supported channels
 
-| channel | Handling in player |
-| --- | --- |
-| `#xxx01` | Play as BGM / sample trigger. |
-| `#xxx02` | Reflected in time resolution and beat resolution as bar length. |
-| `#xxx03`, `#xxx08` | Reflected in time resolution as BPM change. |
-| `#xxx04`, `#xxx07`, `#xxx0A` | Render as BGA base / layer / layer2. |
-| `#xxx06` | Treated as POOR BGA cue. If `#POORBGA` is not specified, `#BMP00` is used as fallback. |
-| `#xxx09` | Reflects in time resolution as STOP. |
-| `#xxx11-19`, `#xxx21-29` | Treated as visible performance notes. `16` / `26` is scratch, `17` / `27` is FREE ZONE except for 9KEY, and normal note for 9KEY. |
-| `#xxx31-39`, `#xxx41-49` | Treated as invisible notes. It is used for manual input suggestions and display aids, but is not included in `summary.total`. `AUTO` does not produce a sound. |
-| `#xxx51-59`, `#xxx61-69` | Treated as BMS legacy long note. |
-| `#xxx97`, `#xxx98` | Treated as a dynamic volume change that changes the initial gain of the BGM/playable sound that plays after that. |
-| `#xxxA0` | Treated as a dynamic judgment width change that refers to `#EXRANKxx`. |
-| `#xxxSC` | Reflects in the drawing distance as a scroll segment of the `#SCROLLxx` reference. |
-| `#xxxSP` | Reflects in the drawing distance as a speed keyframe of `#SPEEDxx` reference. |
-| `#xxxD1-D9`, `#xxxE1-E9` | Treated as a landmine. |
+| channel                      | Handling in player                                                                                                                                             |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `#xxx01`                     | Play as BGM / sample trigger.                                                                                                                                  |
+| `#xxx02`                     | Reflected in time resolution and beat resolution as bar length.                                                                                                |
+| `#xxx03`, `#xxx08`           | Reflected in time resolution as BPM change.                                                                                                                    |
+| `#xxx04`, `#xxx07`, `#xxx0A` | Render as BGA base / layer / layer2.                                                                                                                           |
+| `#xxx06`                     | Treated as POOR BGA cue. If `#POORBGA` is not specified, `#BMP00` is used as fallback.                                                                         |
+| `#xxx09`                     | Reflects in time resolution as STOP.                                                                                                                           |
+| `#xxx11-19`, `#xxx21-29`     | Treated as visible performance notes. `16` / `26` is scratch, `17` / `27` is FREE ZONE except for 9KEY, and normal note for 9KEY.                              |
+| `#xxx31-39`, `#xxx41-49`     | Treated as invisible notes. It is used for manual input suggestions and display aids, but is not included in `summary.total`. `AUTO` does not produce a sound. |
+| `#xxx51-59`, `#xxx61-69`     | Treated as BMS legacy long note.                                                                                                                               |
+| `#xxx97`, `#xxx98`           | Treated as a dynamic volume change that changes the initial gain of the BGM/playable sound that plays after that.                                              |
+| `#xxxA0`                     | Treated as a dynamic judgment width change that refers to `#EXRANKxx`.                                                                                         |
+| `#xxxSC`                     | Reflects in the drawing distance as a scroll segment of the `#SCROLLxx` reference.                                                                             |
+| `#xxxSP`                     | Reflects in the drawing distance as a speed keyframe of `#SPEEDxx` reference.                                                                                  |
+| `#xxxD1-D9`, `#xxxE1-E9`     | Treated as a landmine.                                                                                                                                         |
 
 ### Supported commands
 
-| command | Handling in player |
-| --- | --- |
-| `#TITLE`, `#SUBTITLE`, `#ARTIST`, `#SUBARTIST`, `#GENRE`, `#COMMENT` | Used to display metadata on the song selection screen. `#TITLE` / `#ARTIST` / `#GENRE` are also used for TUI and results screens. |
-| `#BANNER` | Used to display the banner on the song selection screen. bmson uses `info.banner_image` for the same purpose. |
-| `#STAGEFILE` | Used as a dedicated image for the loading screen after song selection. It is not referenced by the BGA renderer during gameplay. |
-| `#PLAYLEVEL`, `#DIFFICULTY` | Used to display, sort, filter, and display the results of the song selection screen. |
-| `#BPM`, `#BPMxx`, `#STOPxx`, `#STP` | Used for time resolution. |
-| `#RANK`, `#DEFEXRANK`, `#EXRANKxx`, `#TOTAL` | Used for judgment range, display rank, groove gauge calculation. |
-| `#WAVxx`, `#BMPxx` | Used for audio/BGA resource resolution. |
-| `#BASE` | Selects the BMS object ID base. `#BASE 62` keeps lowercase IDs case-sensitive when resolving samples, BGA, BPM/STOP references, long-note ends, and landmine values. |
-| `#PREVIEW` | Used preferentially for preview playback on the song selection screen. |
-| `#PATH_WAV` | Used only to search for files on the song selection screen preview. It is not used to solve samples during normal play. |
-| `#LNTYPE`, `#LNMODE`, `#LNOBJ` | Used to interpret BMS long notes. |
-| `#PLAYER` | Used for mode estimation and display player lane metadata. |
-| `#VOLWAV` | Used as a volume multiplier for the entire score. |
-| `#POORBGA` | Used to override the default value of POOR images. |
-| `#SCROLLxx`, `#SPEEDxx` | Used to calculate note drawing distance. |
-| `#RANDOM`, `#SETRANDOM`, `#IF`, `#ELSEIF`, `#ELSE`, `#ENDIF`, `#ENDRANDOM`, `#SWITCH`, `#SETSWITCH`, `#CASE`, `#SKIP`, `#DEF`, `#ENDSW` | Resolved as control syntax before playback starts. |
+| command                                                                                                                                 | Handling in player                                                                                                                                                   |
+| --------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `#TITLE`, `#SUBTITLE`, `#ARTIST`, `#SUBARTIST`, `#GENRE`, `#COMMENT`                                                                    | Used to display metadata on the song selection screen. `#TITLE` / `#ARTIST` / `#GENRE` are also used for TUI and results screens.                                    |
+| `#BANNER`                                                                                                                               | Used to display the banner on the song selection screen. bmson uses `info.banner_image` for the same purpose.                                                        |
+| `#STAGEFILE`                                                                                                                            | Used as a dedicated image for the loading screen after song selection. It is not referenced by the BGA renderer during gameplay.                                     |
+| `#PLAYLEVEL`, `#DIFFICULTY`                                                                                                             | Used to display, sort, filter, and display the results of the song selection screen.                                                                                 |
+| `#BPM`, `#BPMxx`, `#STOPxx`, `#STP`                                                                                                     | Used for time resolution.                                                                                                                                            |
+| `#RANK`, `#DEFEXRANK`, `#EXRANKxx`, `#TOTAL`                                                                                            | Used for judgment range, display rank, groove gauge calculation.                                                                                                     |
+| `#WAVxx`, `#BMPxx`                                                                                                                      | Used for audio/BGA resource resolution.                                                                                                                              |
+| `#BASE`                                                                                                                                 | Selects the BMS object ID base. `#BASE 62` keeps lowercase IDs case-sensitive when resolving samples, BGA, BPM/STOP references, long-note ends, and landmine values. |
+| `#PREVIEW`                                                                                                                              | Used preferentially for preview playback on the song selection screen.                                                                                               |
+| `#PATH_WAV`                                                                                                                             | Used only to search for files on the song selection screen preview. It is not used to solve samples during normal play.                                              |
+| `#LNTYPE`, `#LNMODE`, `#LNOBJ`                                                                                                          | Used to interpret BMS long notes.                                                                                                                                    |
+| `#PLAYER`                                                                                                                               | Used for mode estimation and display player lane metadata.                                                                                                           |
+| `#VOLWAV`                                                                                                                               | Used as a volume multiplier for the entire score.                                                                                                                    |
+| `#POORBGA`                                                                                                                              | Used to override the default value of POOR images.                                                                                                                   |
+| `#SCROLLxx`, `#SPEEDxx`                                                                                                                 | Used to calculate note drawing distance.                                                                                                                             |
+| `#RANDOM`, `#SETRANDOM`, `#IF`, `#ELSEIF`, `#ELSE`, `#ENDIF`, `#ENDRANDOM`, `#SWITCH`, `#SETSWITCH`, `#CASE`, `#SKIP`, `#DEF`, `#ENDSW` | Resolved as control syntax before playback starts.                                                                                                                   |
 
 ### Unsupported channels
 
-| channel | Current player implementation |
-| --- | --- |
-| `#xxxA6` | It is not supported as a runtime reflection channel for `#CHANGEOPTIONxx`. Even if it is kept as an event, the player runtime does not refer to it. |
+| channel                                                                                                                      | Current player implementation                                                                                                                                                                                                             |
+| ---------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `#xxxA6`                                                                                                                     | It is not supported as a runtime reflection channel for `#CHANGEOPTIONxx`. Even if it is kept as an event, the player runtime does not refer to it.                                                                                       |
 | Performance-related expansion channels such as `#xxx1A-1Z` and `#xxx2A-2Z` that are not included in the above supported list | are not treated as playable note channels in the current runtime. Although there is display mode estimation and input assignment for `24 KEY SP` / `48 KEY DP`, these channels themselves do not become the target notes for score/judge. |
-| Other object channels that are not included in the above list of correspondence | Even if the parser holds them, the player runtime does not interpret them. |
+| Other object channels that are not included in the above list of correspondence                                              | Even if the parser holds them, the player runtime does not interpret them.                                                                                                                                                                |
 
 ### Unsupported commands
 
-| command | Current player implementation |
-| --- | --- |
-| `#TEXTxx`, `#TEXT00` | The parser is retained, but it is not used for player display or runtime performance. |
-| `#OPTION`, `#CHANGEOPTIONxx` | Parser is retained, but forced play-option changes are not supported by the core runtime. |
-| `#WAVCMD`, `#EXWAVxx` | Parser is retained. The bundled Node realtime audio session does not apply them, while audio-renderer and browser WebAudio apply the implemented volume subset (`#WAVCMD 01` and `#EXWAVxx v`). Pitch, loop, pan, and frequency parameters are still unsupported. |
-| `#BACKBMP` | The core/terminal runtime has no dedicated behavior for this command. Browser LR2 special graphics can use it. |
-| `#MAKER` | Metadata-only/unsupported. |
-| `#EXBMPxx`, `#BGAxx`, `#SWBGAxx`, `#ARGBxx` | The parser retains them. The terminal/core runtime does not apply them, while the browser player renders the implemented BGA sub-region, switching, tint, and alpha subset. |
-| `#BASEBPM` | The parser is retained, but the player is not used for time resolution. |
-| `#VIDEOFILE` | The parser is retained, but it is not used for BGA video resolution in the player. Real-world video playback only handles video files referenced with `#BMPxx`. |
-| `#MIDIFILE`, `#MATERIALS`, `#DIVIDEPROP`, `#CHARSET` | Retains the parser but does not refer to the player runtime. |
-| `#SONGxx`, `#EXBPMxx`, `#CHARFILE`, `#ExtChr`, `#CDDA`, `#VIDEOFPS`, `#VIDEODLY`, `#VIDEOCOLORS`, `#SEEK`, `#MATERIALSBMP`, `#MATERIALSWAV` | Not supported by the current player implementation. |
+| command                                                                                                                                     | Current player implementation                                                                                                                                                                                                                                     |
+| ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `#TEXTxx`, `#TEXT00`                                                                                                                        | The parser is retained, but it is not used for player display or runtime performance.                                                                                                                                                                             |
+| `#OPTION`, `#CHANGEOPTIONxx`                                                                                                                | Parser is retained, but forced play-option changes are not supported by the core runtime.                                                                                                                                                                         |
+| `#WAVCMD`, `#EXWAVxx`                                                                                                                       | Parser is retained. The bundled Node realtime audio session does not apply them, while audio-renderer and browser WebAudio apply the implemented volume subset (`#WAVCMD 01` and `#EXWAVxx v`). Pitch, loop, pan, and frequency parameters are still unsupported. |
+| `#BACKBMP`                                                                                                                                  | The core/terminal runtime has no dedicated behavior for this command. Browser LR2 special graphics can use it.                                                                                                                                                    |
+| `#MAKER`                                                                                                                                    | Metadata-only/unsupported.                                                                                                                                                                                                                                        |
+| `#EXBMPxx`, `#BGAxx`, `#SWBGAxx`, `#ARGBxx`                                                                                                 | The parser retains them. The terminal/core runtime does not apply them, while the browser player renders the implemented BGA sub-region, switching, tint, and alpha subset.                                                                                       |
+| `#BASEBPM`                                                                                                                                  | The parser is retained, but the player is not used for time resolution.                                                                                                                                                                                           |
+| `#VIDEOFILE`                                                                                                                                | The parser is retained, but it is not used for BGA video resolution in the player. Real-world video playback only handles video files referenced with `#BMPxx`.                                                                                                   |
+| `#MIDIFILE`, `#MATERIALS`, `#DIVIDEPROP`, `#CHARSET`                                                                                        | Retains the parser but does not refer to the player runtime.                                                                                                                                                                                                      |
+| `#SONGxx`, `#EXBPMxx`, `#CHARFILE`, `#ExtChr`, `#CDDA`, `#VIDEOFPS`, `#VIDEODLY`, `#VIDEOCOLORS`, `#SEEK`, `#MATERIALSBMP`, `#MATERIALSWAV` | Not supported by the current player implementation.                                                                                                                                                                                                               |
 
 ## Execution flow
 

--- a/docs/player-web.ja.md
+++ b/docs/player-web.ja.md
@@ -9,16 +9,17 @@ timing、note、判定、score、gauge、BGA event の意味など、CLI と共�
 
 browser player は gameplay を `@be-music/player/core/engine` 経由で駆動します。
 判定、fallback keysound routing、long note、地雷優先度、score、gauge、chart finish の意味論は engine が担当します。
-`PixiGameplayView` は LR2 の `PLAYSTART` gate で 1 回 engine を起動し、engine の frame snapshot を scene state へ反映し、UI command を Pixi の視覚効果へ変換します。
+LR2 gameplay scene は LR2 の `PLAYSTART` gate で 1 回 engine を起動し、beatoraja gameplay scene は `BeatorajaRuntimeAdapter` の背後に engine を mount します。
+どちらの経路も engine の frame snapshot を scene state へ反映し、UI command を Pixi の視覚効果へ変換します。
 
 browser runtime は次の adapter module を使います。
 
-| module | 役割 |
-| --- | --- |
+| module                                                                            | 役割                                                                                                                                                                                                        |
+| --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`web-audio-session.ts`](../packages/player-web/src/runtime/web-audio-session.ts) | engine の `AudioSession` 契約を Web Audio で実装します。即時発音、BGM scheduling、channel stop、pause/resume、key/BGM routing、動的 volume change、bmson `c=true` continuation、`#WAVCMD` gain を扱います。 |
-| [`web-input-runtime.ts`](../packages/player-web/src/runtime/web-input-runtime.ts) | DOM `keydown` / `keyup` を engine の input bus へ写像します。OS auto-repeat を除外し、`Escape` / `F5` / `Space` を command event へ送り、lane press には物理 event timestamp を付けます。 |
-| [`web-ui-runtime.ts`](../packages/player-web/src/runtime/web-ui-runtime.ts) | engine UI signal を Pixi host へ流します。frame snapshot は note、score、gauge、result state を更新し、command は lane flash、key hold、POOR BGA、judge/combo effect を駆動します。 |
-| [`engine-driver.ts`](../packages/player-web/src/runtime/engine-driver.ts) | audio、input、UI adapter を組み立て、1 譜面分の `manualPlay` / `autoPlay` を呼び出します。 |
+| [`web-input-runtime.ts`](../packages/player-web/src/runtime/web-input-runtime.ts) | DOM `keydown` / `keyup` を engine の input bus へ写像します。OS auto-repeat を除外し、`Escape` / `F5` / `Space` を command event へ送り、lane press には物理 event timestamp を付けます。                   |
+| [`web-ui-runtime.ts`](../packages/player-web/src/runtime/web-ui-runtime.ts)       | engine UI signal を Pixi host へ流します。frame snapshot は note、score、gauge、result state を更新し、command は lane flash、key hold、POOR BGA、judge/combo effect を駆動します。                         |
+| [`engine-driver.ts`](../packages/player-web/src/runtime/engine-driver.ts)         | audio、input、UI adapter を組み立て、1 譜面分の `manualPlay` / `autoPlay` を呼び出します。                                                                                                                  |
 
 `@be-music/player/core/engine` は `node:path` / `node:timers/promises` 依存を排除済みで、 browser bundle にそのまま
 含められます。 `createNodeAudioSink` (Node 専用 audio backend) も lazy import なので、 host が
@@ -26,8 +27,8 @@ browser runtime は次の adapter module を使います。
 
 ## 対象範囲
 
-- `@be-music/player-web` は browser 向けの song loading、preview playback、LR2 skin parsing、PixiJS scene、WebAudio bus、gameplay recording を提供します。
-- `@be-music/player-web-demo` は core package を drag-and-drop loading、theme loading、debug control、recording control へ接続する private Vite application です。
+- `@be-music/player-web` は browser 向けの song loading、preview playback、LR2 / beatoraja skin rendering、PixiJS scene、WebAudio bus、gameplay recording を提供します。
+- `@be-music/player-web-demo` は core package を drag-and-drop loading、LR2 / beatoraja theme loading、debug control、recording control へ接続する private Vite application です。
 - browser player は shared core と terminal player と同じ parser、chart、player helper を通して BMS/BME/BML/PMS と bmson の譜面を扱います。
 
 ## demo の起動
@@ -41,16 +42,17 @@ pnpm run player:web
 - BMS/BMSON の楽曲 folder
 - 楽曲 folder を含む ZIP
 - LR2 theme folder
-- 楽曲 folder と LR2 theme folder の同時 drop
+- beatoraja theme folder
+- 楽曲 folder と LR2 または beatoraja theme folder の同時 drop
 
 chart file を含む混在 drop では、loader は chart directory を song file、それ以外を theme file として扱います。
-chart file が存在しない場合、drop 全体を theme として扱います。
+chart file が存在しない場合、drop 全体を theme candidate として扱います。LR2 detection は `.lr2skin` file、beatoraja detection は `.luaskin` file または `skin/` path segment 配下の JSON file を使います。
 
 ## Browser loading model
 
 - dropped path は共有の `@be-music/utils/core` path helper で normalize します。
 - chart discovery は `.bms`, `.bme`, `.bml`, `.pms`, `.bmson` を受け付けます。
-- file lookup は case-insensitive です。大文字小文字だけが異なる LR2 風の asset reference でも browser drop で解決できます。
+- file lookup は case-insensitive です。大文字小文字だけが異なる LR2 / beatoraja 風の asset reference でも browser drop で解決できます。
 - 大きな audio / video file は既定で lazy な `File` reference のまま保持します。image、skin、chart、小さな metadata file は collection loading 中に bytes として読み込みます。
 - folder walking と file read は bounded concurrency と progress callback を使い、大きな folder でも browser の FileSystem API や UI update loop を過剰に詰まらせないようにします。
 - parse error は drop 全体を abort せず、collection に蓄積します。
@@ -81,17 +83,35 @@ select 時の option は chart preparation 時に gameplay へ引き継ぎます
 scene に依存しない LR2 Pixi helper は [`skin/lr2/render.ts`](../packages/player-web/src/skin/lr2/render.ts) と
 [`skin/lr2/scene-render.ts`](../packages/player-web/src/skin/lr2/scene-render.ts) にあります。destination keyframe 評価、sprite transform、source cell 選択、text rendering、number、slider、bargraph を共通化します。scene module は state 固有の値解決、timer、input behavior だけを保持します。
 
+## beatoraja skin と theme support
+
+`@be-music/player-web` は `loadBeatorajaThemeFromFiles()` 経由で `@be-music/beatoraja-skin` を利用します。
+browser layer は JSON / Lua skin entry の discovery 後、同じ dropped bundle から source、texture、font、theme BGM、system sound を読み込みます。
+
+実装済みの beatoraja browser feature:
+
+- `BeatorajaPlaySkinView` を使う select、decide、gameplay、result scene
+- play variant `5`, `7`, `9`, `10`, `14`。`24` / `24d` skin は discovery しますが、chart gameplay では mount しません
+- skin `property[]`、`filepath[]`、custom offset、category group、mid-session `replaceSkin()` refresh
+- score、combo、judge、gauge、chart metadata、clear lamp、rank、play option 向けの runtime `TIMER_*`、`OPTION_*`、`TEXT`、`NUM` wiring
+- beatoraja-style note、LN/CN/HCN cap/body、lane marker、BGA still/video layer、judge popup、timing visualizer、gauge graph、BPM graph、note-distribution graph、result score/gauge history graph
+- select scene の folder browsing、search、keymode filter、sort cycle、favorite、chart preview playback、select BGM、navigation system sound
+- decide / result BGM、`STAGEFILE` / `BACKBMP` / `BANNER` の chart-image synthetic slot、loading-progress visual
+
+[beatoraja skin 実装メモ](./beatoraja-skin.ja.md) では、renderer に依存しない parser と theme loader の境界をまとめています。
+beatoraja default skin を primary compatibility target とし、community theme は同文書の normalized element family と runtime ID の範囲に収まるほど安定して動きます。
+
 ## Scene lifecycle
 
 browser player は session 全体で 1 つの `PixiSceneHost` を使います。
 host は 1 つの PixiJS `Application` を所有し、同時に 1 つの scene root だけを attach し、scene transition を直列化し、host dispose 時だけ renderer を破棄します。
 
-現在の scene set:
+LR2 と beatoraja は同じ high-level scene set をそれぞれ持ちます。
 
 - chart browsing、preview playback、skin-side interaction を扱う select scene
 - gameplay 前の短い transition を扱う decide scene
 - note、lane、BGA、HUD、judgment、audio、recording tap を扱う gameplay scene
-- score summary と LR2 result skin rendering を扱う result scene
+- score summary と skin-rendered result presentation を扱う result scene
 
 scene は `enter()`, `exit()`, `dispose()` を実装します。
 `exit()` は transition 向けに一時的な listener と ticker work を外し、`dispose()` は scene 所有 resource を恒久的に解放します。
@@ -100,7 +120,8 @@ scene は `enter()`, `exit()`, `dispose()` を実装します。
 
 - PixiJS は既定で WebGPU preference を使い、browser が初期化できない場合は PixiJS 側で fallback します。
 - `?renderer=webgl` で renderer 比較用に WebGL を強制できます。
-- skin / BGA texture は LR2 の pixel-art asset を保つため nearest sampling を使います。
+- skin / BGA texture は LR2 / beatoraja の pixel-art asset を保つため nearest sampling を使います。
+- beatoraja source texture は bitmap が保守的な GPU texture-size cap を超える場合、upload 前に downscale します。
 - gameplay path は decide scene から gameplay へ渡す前に、chart parse、audio decode、BGA resource preload を進めます。
 - 共有の scroll-distance helper により、terminal player と browser の note placement behavior を揃えます。
 - WebGL context に依存しない pure な browser-core helper は benchmark 対象です。
@@ -115,6 +136,7 @@ pnpm bench -- --packages player-web
 - gameplay audio は既定の split topology で key、BGM、master compressor stage を分けます。
 - `?compressor=legacy` は比較用に旧 single-compressor 構成を維持します。
 - `?compressor=off` は demo で compressor construction を無効化します。
+- beatoraja theme audio は Lua `main_state.audio_play` / `audio_loop` call、select BGM、navigation system sound、decide BGM、result jingle に同じ browser bundle lookup を使います。
 - BGA は chart BGA event が参照する still image と video asset を扱います。
 - BMS rendering は、実装済み subset として `#BGAxx` sub-region、`#SWBGAxx` switching、`#ARGBxx` / `#EXBMPxx` tint / alpha を反映します。
 - bmson rendering は `bga.bga_events`、`bga.layer_events`、`bga.poor_events` を使います。BMS layer channel と異なり、bmson layer image は黒を透明化せず黒ピクセルとして保持します。
@@ -123,6 +145,6 @@ pnpm bench -- --packages player-web
 
 ## Compatibility boundary
 
-browser player は、この repository の parser、chart、audio-renderer、player、utils package を共有する runtime consumer です。
+browser player は、この repository の parser、chart、audio-renderer、player、utils、LR2 skin、beatoraja skin package を共有する runtime consumer です。
 browser behavior が terminal player と分岐する場合は、pure な path、timing、scroll、lookup、event mapping helper を shared package へ移し、package-local test で覆う方針を優先します。
 PixiJS scene wiring は browser rendering や WebAudio resource に依存する場合、`player-web` に残してかまいません。

--- a/docs/player-web.md
+++ b/docs/player-web.md
@@ -9,17 +9,18 @@ Use [`player-spec.md`](./player-spec.md) for shared runtime semantics such as ti
 
 The browser player drives gameplay through `@be-music/player/core/engine`.
 The engine owns judgment, fallback keysound routing, long-note handling, mine priority, score, gauge, and chart-finish
-semantics. `PixiGameplayView` starts one engine run at the LR2 `PLAYSTART` gate, mirrors engine frame snapshots into
-the scene state, and translates engine UI commands into Pixi visual effects.
+semantics. The LR2 gameplay scene starts one engine run at the LR2 `PLAYSTART` gate, while the beatoraja gameplay
+scene mounts the engine behind `BeatorajaRuntimeAdapter`. Both paths mirror engine frame snapshots into scene state
+and translate engine UI commands into Pixi visual effects.
 
 The browser runtime uses these adapter modules:
 
-| module | role |
-| --- | --- |
+| module                                                                            | role                                                                                                                                                                                                                                  |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`web-audio-session.ts`](../packages/player-web/src/runtime/web-audio-session.ts) | Implements the engine's `AudioSession` contract with Web Audio. It handles immediate triggers, BGM scheduling, channel stops, pause/resume, key/BGM routing, dynamic volume changes, bmson `c=true` continuation, and `#WAVCMD` gain. |
-| [`web-input-runtime.ts`](../packages/player-web/src/runtime/web-input-runtime.ts) | Maps DOM `keydown` / `keyup` events to the engine input bus. It filters OS auto-repeat, routes `Escape` / `F5` / `Space` to command events, and sends lane presses with physical event timestamps. |
-| [`web-ui-runtime.ts`](../packages/player-web/src/runtime/web-ui-runtime.ts) | Drains engine UI signals into the Pixi host. Frame snapshots update notes, score, gauge, and result state; commands drive lane flashes, key holds, POOR BGA, and judge/combo effects. |
-| [`engine-driver.ts`](../packages/player-web/src/runtime/engine-driver.ts) | Wires audio, input, and UI adapters together and invokes `manualPlay` / `autoPlay` for one chart play. |
+| [`web-input-runtime.ts`](../packages/player-web/src/runtime/web-input-runtime.ts) | Maps DOM `keydown` / `keyup` events to the engine input bus. It filters OS auto-repeat, routes `Escape` / `F5` / `Space` to command events, and sends lane presses with physical event timestamps.                                    |
+| [`web-ui-runtime.ts`](../packages/player-web/src/runtime/web-ui-runtime.ts)       | Drains engine UI signals into the Pixi host. Frame snapshots update notes, score, gauge, and result state; commands drive lane flashes, key holds, POOR BGA, and judge/combo effects.                                                 |
+| [`engine-driver.ts`](../packages/player-web/src/runtime/engine-driver.ts)         | Wires audio, input, and UI adapters together and invokes `manualPlay` / `autoPlay` for one chart play.                                                                                                                                |
 
 `@be-music/player/core/engine` no longer imports `node:path` / `node:timers/promises`, so the module can be
 bundled into the browser as-is. The Node-only `createNodeAudioSink` backend is loaded lazily and is never reached
@@ -27,8 +28,8 @@ when the host supplies a `PlayerOptions.createAudioSession` factory (e.g. `creat
 
 ## Scope
 
-- `@be-music/player-web` provides browser-friendly song loading, preview playback, LR2 skin parsing, PixiJS scenes, WebAudio bus construction, and gameplay recording.
-- `@be-music/player-web-demo` is a private Vite application that wires the core package to drag-and-drop loading, theme loading, debug controls, and recording controls.
+- `@be-music/player-web` provides browser-friendly song loading, preview playback, LR2/beatoraja skin rendering, PixiJS scenes, WebAudio bus construction, and gameplay recording.
+- `@be-music/player-web-demo` is a private Vite application that wires the core package to drag-and-drop loading, LR2/beatoraja theme loading, debug controls, and recording controls.
 - The browser player supports both BMS/BME/BML/PMS and bmson charts through the same parser, chart, and player helpers used by the shared core and terminal player.
 
 ## Running the demo
@@ -42,16 +43,17 @@ The command starts the Vite demo. Drop any of the following into the page:
 - A BMS/BMSON song folder
 - A ZIP that contains a song folder
 - An LR2 theme folder
-- A song folder and an LR2 theme folder together
+- A beatoraja theme folder
+- A song folder and an LR2 or beatoraja theme folder together
 
 When a mixed drop contains chart files, the loader treats the chart directories as song files and the remaining files as theme files.
-When no chart file is present, the whole drop is treated as a theme.
+When no chart file is present, the whole drop is treated as a theme candidate. LR2 detection uses `.lr2skin` files, while beatoraja detection uses `.luaskin` files or JSON files under a `skin/` path segment.
 
 ## Browser loading model
 
 - Dropped paths are normalized with the shared `@be-music/utils/core` path helpers.
 - Chart discovery accepts `.bms`, `.bme`, `.bml`, `.pms`, and `.bmson`.
-- File lookup is case-insensitive so browser drops work with LR2-style asset references that differ only by letter case.
+- File lookup is case-insensitive so browser drops work with LR2 and beatoraja asset references that differ only by letter case.
 - Large audio and video files stay as lazy `File` references by default. Image, skin, chart, and smaller metadata files are read into bytes during collection loading.
 - Folder walking and file reads use bounded concurrency and progress callbacks so large folders can load without flooding the browser's FileSystem APIs or UI update loop.
 - Parse errors are accumulated in the collection instead of aborting the whole drop.
@@ -84,17 +86,36 @@ Scene-independent LR2 Pixi helpers live in [`skin/lr2/render.ts`](../packages/pl
 sprite transforms, source-cell selection, text rendering, numbers, sliders, and bargraphs. Scene modules keep the
 state-specific value resolution, timers, and input behavior.
 
+## beatoraja skin and theme support
+
+`@be-music/player-web` consumes `@be-music/beatoraja-skin` through `loadBeatorajaThemeFromFiles()`.
+The package discovers JSON and Lua skin entries, then the browser layer loads sources, textures, fonts, theme BGM,
+and system sounds from the same dropped bundle.
+
+Implemented beatoraja browser features include:
+
+- Select, decide, gameplay, and result scenes backed by `BeatorajaPlaySkinView`
+- Play variants `5`, `7`, `9`, `10`, and `14`; `24` and `24d` skins are discovered but not mounted for chart gameplay
+- Skin `property[]`, `filepath[]`, custom offsets, category groups, and mid-session `replaceSkin()` refreshes
+- Runtime `TIMER_*`, `OPTION_*`, `TEXT`, and `NUM` wiring for score, combo, judge, gauge, chart metadata, clear lamp, rank, and play options
+- Beatoraja-style notes, LN/CN/HCN caps and bodies, lane markers, BGA still/video layers, judge popups, timing visualizers, gauge graphs, BPM graphs, note-distribution graphs, and result score/gauge history graphs
+- Select-scene folder browsing, search, keymode filtering, sort cycling, favorites, chart preview playback, select BGM, and navigation system sounds
+- Decide and result BGM, chart-image synthetic slots for `STAGEFILE` / `BACKBMP` / `BANNER`, and loading-progress visuals
+
+See [beatoraja skin implementation notes](./beatoraja-skin.md) for the renderer-independent parser and theme-loader boundary.
+The default beatoraja skin is the primary compatibility target. Community themes work best when they use the normalized element families and runtime IDs listed there.
+
 ## Scene lifecycle
 
 The browser player uses one `PixiSceneHost` for the whole session.
 The host owns a single PixiJS `Application`, attaches one scene root at a time, serializes scene transitions, and destroys the renderer only when the host is disposed.
 
-The current scene set is:
+The LR2 and beatoraja paths each provide the same high-level scene set:
 
 - Select scene for chart browsing, preview playback, and skin-side interactions
 - Decide scene for the short transition before gameplay
 - Gameplay scene for notes, lanes, BGA, HUD, judgment, audio, and recording taps
-- Result scene for score summary and LR2 result skin rendering
+- Result scene for score summary and skin-rendered result presentation
 
 Scenes implement `enter()`, `exit()`, and `dispose()`.
 `exit()` detaches transient listeners and ticker work for transitions, while `dispose()` permanently releases scene-owned resources.
@@ -103,8 +124,9 @@ Scenes implement `enter()`, `exit()`, and `dispose()`.
 
 - PixiJS defaults to a WebGPU preference and falls back through PixiJS when the browser cannot initialize it.
 - `?renderer=webgl` forces WebGL for renderer comparison.
-- Loaded skin and BGA textures use nearest sampling to preserve LR2 pixel-art assets.
-- The gameplay path preloads chart parse, audio decode, and BGA resources before the decide scene hands off to gameplay.
+- Loaded skin and BGA textures use nearest sampling to preserve LR2 and beatoraja pixel-art assets.
+- beatoraja source textures are downscaled before upload when a bitmap exceeds the conservative GPU texture-size cap.
+- The gameplay paths preload chart parse, audio decode, and BGA resources before the decide scene hands off to gameplay.
 - Shared scroll-distance helpers keep CLI and browser note-placement behavior aligned.
 - Benchmarks include browser-core helpers that are pure enough to run outside a WebGL context:
 
@@ -118,6 +140,7 @@ pnpm bench -- --packages player-web
 - Gameplay audio separates key, BGM, and master compressor stages in the default split topology.
 - `?compressor=legacy` keeps the old single-compressor shape for comparison.
 - `?compressor=off` disables compressor construction in the demo.
+- beatoraja theme audio uses the same browser bundle lookup for Lua `main_state.audio_play` / `audio_loop` calls, select BGM, navigation system sounds, decide BGM, and result jingles.
 - BGA supports still images and video assets referenced by chart BGA events.
 - BMS rendering applies the implemented `#BGAxx` sub-region, `#SWBGAxx` switching, and `#ARGBxx` / `#EXBMPxx` tint and alpha subset.
 - bmson rendering uses `bga.bga_events`, `bga.layer_events`, and `bga.poor_events`; unlike BMS layer channels, bmson layer images preserve black pixels instead of treating black as transparent.
@@ -126,6 +149,6 @@ pnpm bench -- --packages player-web
 
 ## Compatibility boundary
 
-The browser player is a runtime consumer of the repository's shared parser, chart, audio-renderer, player, and utils packages.
+The browser player is a runtime consumer of the repository's shared parser, chart, audio-renderer, player, utils, LR2 skin, and beatoraja skin packages.
 When browser behavior diverges from the terminal player, prefer moving pure path, timing, scroll, lookup, or event-mapping helpers into shared packages and covering them with package-local tests.
 PixiJS scene wiring can remain in `player-web` when the behavior depends on browser rendering or WebAudio resources.

--- a/packages/player-web-demo/src/main.ts
+++ b/packages/player-web-demo/src/main.ts
@@ -347,9 +347,12 @@ app.innerHTML = `
             <section class="help-about">
               <p class="help-about-summary">
                 A browser-based BMS player. Drop in a folder containing BMS / BMSON charts and
-                play them straight from the page. Reads <strong>Lunatic Rave 2</strong> skin
-                files (<code>.lr2skin</code>) — drop your <code>LR2files</code> folder onto the
-                page (alongside or before the chart drop) and the theme is applied automatically.
+                play them straight from the page. Reads <strong>Lunatic Rave 2</strong> skins
+                (<code>.lr2skin</code>) and <strong>beatoraja</strong> skins
+                (<code>.json</code> / <code>.luaskin</code>) — drop your
+                <code>LR2files</code> folder, or your beatoraja <code>skin/</code> folder, onto
+                the page (alongside or before the chart drop) and the theme is applied
+                automatically.
               </p>
               <ul class="help-about-meta">
                 <li>
@@ -378,10 +381,12 @@ app.innerHTML = `
                   yet — refreshing the page or revisiting later loses every result.
                 </li>
                 <li>
-                  <strong>Only the Lunatic Rave 2 default skin has been verified.</strong> Other LR2
-                  skins parse and load, but their layout is unverified — expect element overlap,
-                  off-by-a-few-pixels positioning, or missing animation frames on third-party
-                  themes.
+                  <strong>Verified skins:</strong> the Lunatic Rave 2 default skin, plus the
+                  beatoraja default skin (<code>skin/default</code>),
+                  <code>ModernChic</code>, and <code>GdbG Original Skin</code>. Other LR2 /
+                  beatoraja skins parse and load, but their layout is unverified — expect element
+                  overlap, off-by-a-few-pixels positioning, or missing animation frames on
+                  third-party themes.
                 </li>
                 <li>Use at your own risk. No warranty is provided.</li>
               </ul>
@@ -389,11 +394,14 @@ app.innerHTML = `
             <h3 class="help-section-title">Loading songs</h3>
             <ul class="help-list">
               <li>Drop a BMS folder anywhere on the page to register its charts.</li>
-              <li>Drop an <code>LR2files</code> folder (or its contents) to apply an LR2 skin theme.</li>
+              <li>
+                Drop an <code>LR2files</code> folder, or a beatoraja <code>skin/</code> folder
+                (or their contents), to apply a skin theme.
+              </li>
               <li>
                 Or click <strong>Open Folder</strong> in the lil-gui panel (top-right) to use the native
-                file picker — same handling as a drag-drop, so a folder containing both an LR2 theme and
-                BMS charts loads both in one shot. Press the button again to add another folder.
+                file picker — same handling as a drag-drop, so a folder containing both an LR2 / beatoraja
+                theme and BMS charts loads both in one shot. Press the button again to add another folder.
               </li>
               <li>Subsequent drops add to the library and keep the current theme.</li>
             </ul>
@@ -402,7 +410,7 @@ app.innerHTML = `
             <ul class="help-list">
               <li><kbd>/</kbd> focuses the search input. Filter by title, artist, or genre.</li>
               <li><kbd>Esc</kbd> clears the search filter.</li>
-              <li>Click a song row, or click the LR2 skin's <em>PLAY</em> button, to start.</li>
+              <li>Click a song row, or click the active skin's <em>PLAY</em> button, to start.</li>
             </ul>
 
             <h3 class="help-section-title">Gameplay (default keys)</h3>
@@ -439,7 +447,7 @@ app.innerHTML = `
                 MediaRecorder support — see Open source / browser checks).
               </li>
               <li>
-                Open the LR2 skin's <strong>PLAY OPTION</strong> panel during song select to set per-side
+                Open the active skin's <strong>PLAY OPTION</strong> panel during song select to set per-side
                 modifiers (Random / Mirror / Auto-scratch / hi-speed).
               </li>
             </ul>
@@ -448,7 +456,7 @@ app.innerHTML = `
             <section class="help-about">
               <p class="help-about-summary">
                 ブラウザ上で動作する BMS プレイヤーです。BMS / BMSON が入ったフォルダをドロップするだけでそのまま再生できます。
-                <strong>Lunatic Rave 2</strong> のスキンファイル (<code>.lr2skin</code>) を解釈するので、<code>LR2files</code> フォルダをページにドロップすれば既存の LR2 用スキンをそのまま適用できます。
+                <strong>Lunatic Rave 2</strong> のスキン (<code>.lr2skin</code>) と <strong>beatoraja</strong> のスキン (<code>.json</code> / <code>.luaskin</code>) を解釈するので、<code>LR2files</code> フォルダや beatoraja の <code>skin/</code> フォルダをページにドロップすれば既存のスキンをそのまま適用できます。
               </p>
               <ul class="help-about-meta">
                 <li>
@@ -477,8 +485,8 @@ app.innerHTML = `
                   永続化やランキング機能は未実装で、ページをリロード / 再訪するとリザルトはすべて失われます。
                 </li>
                 <li>
-                  <strong>Lunatic Rave 2 のデフォルトスキンのみ動作確認しています。</strong>
-                  他の LR2 スキンも読み込み自体は可能ですが、レイアウトは未検証です。要素の重なり / 数ピクセル単位のズレ / 一部アニメーションの欠落などが残っている可能性があります。
+                  <strong>動作確認済みのスキン:</strong> Lunatic Rave 2 デフォルトスキンに加え、beatoraja デフォルトスキン (<code>skin/default</code>)、<code>ModernChic</code>、<code>GdbG Original Skin</code> の四種類です。
+                  これら以外の LR2 / beatoraja スキンも読み込み自体は可能ですが、レイアウトは未検証です。要素の重なり / 数ピクセル単位のズレ / 一部アニメーションの欠落などが残っている可能性があります。
                 </li>
                 <li>利用は自己責任でお願いします。本ソフトウェアは無保証で提供されます。</li>
               </ul>
@@ -486,10 +494,10 @@ app.innerHTML = `
             <h3 class="help-section-title">楽曲の読み込み</h3>
             <ul class="help-list">
               <li>BMS フォルダをページ上にドロップすると、その中のチャートが登録されます。</li>
-              <li><code>LR2files</code> フォルダ (またはその中身) をドロップすると LR2 スキンが適用されます。</li>
+              <li><code>LR2files</code> フォルダか beatoraja の <code>skin/</code> フォルダ (またはその中身) をドロップするとスキンが適用されます。</li>
               <li>
                 右上 lil-gui パネルの <strong>Open Folder</strong> ボタンからネイティブのファイル選択ダイアログも使えます。
-                ドラッグ&ドロップと同じ処理経路を通るので、テーマとチャートが同居したフォルダもまとめて読み込めます。
+                ドラッグ&ドロップと同じ処理経路を通るので、LR2 / beatoraja のテーマとチャートが同居したフォルダもまとめて読み込めます。
                 ボタンを押し直せば別フォルダを追加で読み込めます。
               </li>
               <li>追加でドロップした場合、既存のライブラリに追加され、テーマも維持されます。</li>
@@ -499,7 +507,7 @@ app.innerHTML = `
             <ul class="help-list">
               <li><kbd>/</kbd> で検索入力にフォーカス。タイトル / アーティスト / ジャンルで絞り込めます。</li>
               <li><kbd>Esc</kbd> で検索条件をクリア。</li>
-              <li>曲の行をクリック、または LR2 スキンの <em>PLAY</em> ボタンで再生開始。</li>
+              <li>曲の行をクリック、または現在のスキンの <em>PLAY</em> ボタンで再生開始。</li>
             </ul>
 
             <h3 class="help-section-title">ゲームプレイ (デフォルトキー)</h3>
@@ -535,7 +543,7 @@ app.innerHTML = `
                 <strong>Record</strong> ボタンを押すと、次の再生を WebM として録画してダウンロードできます (ブラウザが MediaRecorder に対応している必要があります — Open source / Browser checks を参照)。
               </li>
               <li>
-                選曲画面で LR2 スキンの <strong>PLAY OPTION</strong> パネルを開くと、Random / Mirror / Auto-scratch / hi-speed などのプレイヤー側モディファイアを設定できます。
+                選曲画面で現在のスキンの <strong>PLAY OPTION</strong> パネルを開くと、Random / Mirror / Auto-scratch / hi-speed などのプレイヤー側モディファイアを設定できます。
               </li>
             </ul>
           </div>

--- a/packages/player-web/src/scene/beatoraja/decide.ts
+++ b/packages/player-web/src/scene/beatoraja/decide.ts
@@ -14,8 +14,6 @@
 //
 // What this scene does NOT do:
 //   - Score-best-record lookups (no DB layer)
-//   - Audio cues (the LR2 splash plays a per-theme `decide.wav`; beatoraja themes typically
-//     bundle their own — wiring decide BGM is a follow-up patch)
 //   - Per-side (1P / 2P) chart info — only single-player decide is exercised today.
 
 import { Container, Graphics, type Ticker } from 'pixi.js';

--- a/packages/player-web/src/scene/beatoraja/gameplay.ts
+++ b/packages/player-web/src/scene/beatoraja/gameplay.ts
@@ -19,9 +19,8 @@
 // own clock. The adapter keeps a single mutable `activeOps` Set + timer Map; `view.update(ctx)` re-samples
 // every destination keyframe against the current state.
 //
-// Notes / BGA / fallback chrome are not yet wired here — the skin paints lane backgrounds, key-beam
-// glows, judge plates and HUD text from the engine state, but the actual scrolling notes and BGA video
-// land in follow-up patches that add a sub-container layered on top of the skin view.
+// The gameplay scene layers authored skin chrome, scrolling notes, markers, BGA still/video textures, judge popups,
+// key-beam glows, LN hold effects, and HUD text on top of the same engine-driven state.
 
 import { Container, Graphics, Text, type Ticker } from 'pixi.js';
 import type { BeMusicJson } from '@be-music/json';

--- a/packages/player-web/src/scene/beatoraja/result.ts
+++ b/packages/player-web/src/scene/beatoraja/result.ts
@@ -13,13 +13,10 @@
 //     combobreak aliases, max combo, gauge percent. Best-record and rival diff slots stay 0
 //     (no DB / IR layer yet).
 //
-// What this scene does NOT yet do:
-//   - Score graph / gauge polyline rendering (`SRC_SCORECHART` / `SRC_GAUGECHART_*` in LR2;
-//     beatoraja's equivalent is per-skin authored chart polylines we don't yet emit)
-//   - Per-rank / clear-lamp op gates (CLEAR_RANK_AAA / CLEAR_LAMP_FULLCOMBO in prop.lua) —
-//     these need the score DB to compute "vs best" deltas; we surface only LIVE-run data
-//   - Result BGM (clear / fail jingles) — beatoraja themes ship per-theme audio that we
-//     haven't yet routed through the audio bus
+// What this scene still leaves to a score database:
+//   - Best-record and rival-difference slots.
+//   - Per-rank / clear-lamp comparisons that need "vs best" deltas. Current clear/rank ops reflect
+//     only the just-finished run.
 
 import { Container, Graphics, type Texture, type Ticker } from 'pixi.js';
 import type { PlayerSummary } from '@be-music/player/core/engine';


### PR DESCRIPTION
## Summary

Backfill the two doc commits that were authored during the `feat/beatoraja-skin`
branch but never pushed to `origin/feat/beatoraja-skin` before PR [#91](https://github.com/nulltask/be-music/pull/91)
was merged. As a result the v0.2.3 release of `@be-music/player-web-demo` shipped
without these updates even though the underlying functionality is in.

### What lands here

- **Help modal** (`packages/player-web-demo/src/main.ts`) — now states that
  beatoraja skins (`.json` / `.luaskin`) are read alongside LR2 (`.lr2skin`),
  documents that dropping a beatoraja `skin/` folder applies the theme the same
  way `LR2files/` does, and lists the four verified skins (LR2 default,
  beatoraja default `skin/default`, `ModernChic`, `GdbG Original Skin`).
  References to "the LR2 skin's PLAY / PLAY OPTION" are generalized to
  "the active skin's" since both rendering paths surface those buttons.
  Mirrored across the English and Japanese panes.
- **README / design docs** — `README.md`, `README.ja.md`, `docs/README.{md,ja.md}`,
  `docs/glossary.{md,ja.md}`, `docs/beatoraja-skin.{md,ja.md}`,
  `docs/player-spec.{md,ja.md}`, and `docs/player-web.{md,ja.md}` now describe
  LR2 + beatoraja side by side (package list, mixed drop handling, PLAY OPTION
  coverage, 9 KEY / POPN routing rules).
- **Stale "follow-up" comments** in
  `packages/player-web/src/scene/beatoraja/{decide,gameplay,result}.ts` are
  dropped now that the gameplay overlays, decide audio cues, and result data
  flow are all wired.

### Bump

`@be-music/player-web-demo` patch (0.2.3 → 0.2.4). No published-library
behaviour changes — purely demo help text and design-doc additions. The README
and `docs/` edits aren't tied to any package bump on their own.

## Test plan

- [x] `pnpm --filter @be-music/player-web-demo run typecheck`
- [ ] Manual: open the demo help modal and confirm both EN / JA panes list the
      four verified skins.