### PR TITLE
fix(ci): trigger SEA release on @be-music/player-tui bump, not engine

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,9 +36,9 @@ jobs:
       release_base: ${{ steps.release_refs.outputs.release_base }}
       has_releases: ${{ steps.release_packages.outputs.has_releases }}
       has_sea_releases: ${{ steps.release_packages.outputs.has_sea_releases }}
-      release_player: ${{ steps.release_packages.outputs.release_player }}
+      release_player_tui: ${{ steps.release_packages.outputs.release_player_tui }}
       release_audio_renderer: ${{ steps.release_packages.outputs.release_audio_renderer }}
-      player_version: ${{ steps.release_packages.outputs.player_version }}
+      player_tui_version: ${{ steps.release_packages.outputs.player_tui_version }}
       audio_renderer_version: ${{ steps.release_packages.outputs.audio_renderer_version }}
       releases_json: ${{ steps.release_packages.outputs.releases_json }}
       sea_releases_json: ${{ steps.release_packages.outputs.sea_releases_json }}
@@ -144,7 +144,7 @@ jobs:
           "archive_suffix=$os-$arch" >> $env:GITHUB_OUTPUT
 
       - name: Build player SEA executable
-        if: needs.prepare.outputs.release_player == 'true'
+        if: needs.prepare.outputs.release_player_tui == 'true'
         # The CLI / TUI bin moved to `@be-music/player-tui` during the player-tui-split refactor; the
         # `build:sea` script lives there now (the SEA bundle still ships under `be-music-player` for
         # backward compatibility with existing release assets).
@@ -224,7 +224,7 @@ jobs:
           fi
 
           files=()
-          if [ "${{ needs.prepare.outputs.release_player }}" = 'true' ]; then
+          if [ "${{ needs.prepare.outputs.release_player_tui }}" = 'true' ]; then
             files+=(packages/player-tui/dist-sea/be-music-player)
           fi
           if [ "${{ needs.prepare.outputs.release_audio_renderer }}" = 'true' ]; then
@@ -245,12 +245,12 @@ jobs:
 
           mkdir -p tmp/release-assets/player tmp/release-assets/audio-renderer
 
-          if [ "${{ needs.prepare.outputs.release_player }}" = 'true' ]; then
+          if [ "${{ needs.prepare.outputs.release_player_tui }}" = 'true' ]; then
             cp packages/player-tui/dist-sea/be-music-player tmp/release-assets/player/
             chmod +x tmp/release-assets/player/be-music-player
             (
               cd tmp/release-assets/player
-              zip -9 -q "../be-music-player-${{ needs.prepare.outputs.player_version }}-${suffix}.zip" be-music-player
+              zip -9 -q "../be-music-player-${{ needs.prepare.outputs.player_tui_version }}-${suffix}.zip" be-music-player
             )
           fi
 
@@ -270,7 +270,7 @@ jobs:
           $assetDir = 'tmp/release-assets'
 
           New-Item -ItemType Directory -Force -Path $assetDir | Out-Null
-          if ('${{ needs.prepare.outputs.release_player }}' -eq 'true') {
+          if ('${{ needs.prepare.outputs.release_player_tui }}' -eq 'true') {
             Copy-Item 'packages/player-tui/dist-sea/be-music-player.exe' "$assetDir/be-music-player.exe"
           }
           if ('${{ needs.prepare.outputs.release_audio_renderer }}' -eq 'true') {
@@ -344,7 +344,7 @@ jobs:
             exit 1
           fi
 
-          if [ "${{ needs.prepare.outputs.release_player }}" = 'true' ] && [ ! -f tmp/release-assets/be-music-player.exe ]; then
+          if [ "${{ needs.prepare.outputs.release_player_tui }}" = 'true' ] && [ ! -f tmp/release-assets/be-music-player.exe ]; then
             echo "Unsigned Windows SEA executable for player is missing." >&2
             exit 1
           fi
@@ -367,7 +367,7 @@ jobs:
             -passin "pass:$WINDOWS_SIGNING_PFX_PASSWORD" |
             openssl x509 -outform DER -out "tmp/release-assets/be-music-self-signed-windows.cer"
 
-          if [ "${{ needs.prepare.outputs.release_player }}" = 'true' ]; then
+          if [ "${{ needs.prepare.outputs.release_player_tui }}" = 'true' ]; then
             osslsigncode sign \
               -pkcs12 "$signing_dir/self-signed.pfx" \
               -pass "$WINDOWS_SIGNING_PFX_PASSWORD" \
@@ -376,7 +376,7 @@ jobs:
               -out "$signing_dir/player/be-music-player.exe"
             (
               cd "$signing_dir/player"
-              zip -9 -q "../../../release-assets/be-music-player-${{ needs.prepare.outputs.player_version }}-windows-x64.zip" be-music-player.exe
+              zip -9 -q "../../../release-assets/be-music-player-${{ needs.prepare.outputs.player_tui_version }}-windows-x64.zip" be-music-player.exe
             )
           fi
 

--- a/scripts/release/resolve-package-releases.ts
+++ b/scripts/release/resolve-package-releases.ts
@@ -7,8 +7,12 @@ const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repositoryDir = resolve(scriptDir, '..', '..');
 const packagesDir = resolve(repositoryDir, 'packages');
 
+// SEA-eligible packages, keyed by their package slug (directory name under `packages/`). The CLI/TUI
+// frontend lives in `@be-music/player-tui` since the player-tui split — the engine library
+// `@be-music/player` does not ship an executable, so it must NOT trigger SEA jobs. `archiveBaseName`
+// stays `be-music-player` (the user-facing binary name) regardless of the source package's slug.
 const SEA_RELEASES = new Map([
-  ['player', { archiveBaseName: 'be-music-player' }],
+  ['player-tui', { archiveBaseName: 'be-music-player' }],
   ['audio-renderer', { archiveBaseName: 'be-music-audio-render' }],
 ]);
 
@@ -192,7 +196,7 @@ async function main(): Promise<void> {
   }
 
   const seaReleases = releases.filter((release) => release.isSeaPackage);
-  const playerRelease = seaReleases.find((release) => release.packageSlug === 'player');
+  const playerTuiRelease = seaReleases.find((release) => release.packageSlug === 'player-tui');
   const audioRendererRelease = seaReleases.find((release) => release.packageSlug === 'audio-renderer');
 
   if (options.jsonOutput) {
@@ -207,9 +211,9 @@ async function main(): Promise<void> {
     const outputLines = [];
     setGitHubOutput(outputLines, 'has_releases', releases.length > 0 ? 'true' : 'false');
     setGitHubOutput(outputLines, 'has_sea_releases', seaReleases.length > 0 ? 'true' : 'false');
-    setGitHubOutput(outputLines, 'release_player', playerRelease ? 'true' : 'false');
+    setGitHubOutput(outputLines, 'release_player_tui', playerTuiRelease ? 'true' : 'false');
     setGitHubOutput(outputLines, 'release_audio_renderer', audioRendererRelease ? 'true' : 'false');
-    setGitHubOutput(outputLines, 'player_version', playerRelease?.version ?? '');
+    setGitHubOutput(outputLines, 'player_tui_version', playerTuiRelease?.version ?? '');
     setGitHubOutput(outputLines, 'audio_renderer_version', audioRendererRelease?.version ?? '');
     setGitHubOutput(outputLines, 'releases_json', JSON.stringify(releases));
     setGitHubOutput(outputLines, 'sea_releases_json', JSON.stringify(seaReleases));


### PR DESCRIPTION
## Summary

Re-aligns the SEA release trigger with the post-rename package structure.
After the player-tui-split refactor (`fcb2fca`), `@be-music/player` became
the engine library and `@be-music/player-tui` ships the actual CLI/TUI
binary, but the release resolver was still keyed off the `'player'` slug,
which now points at the engine library that contains no executable.

## Before / after

| Scenario | Old behaviour | New behaviour |
| --- | --- | --- |
| Engine-only bump (`@be-music/player` 0.3.1 → 0.4.0) | SEA built and tagged `@be-music/player@0.4.0` even though the bundled source is `player-tui@0.2.3` (v0.4.0 release was in this state) | SEA skipped (engine has no executable) |
| TUI-only bump (`@be-music/player-tui`) | SEA skipped — CLI fixes could not be re-distributed | SEA built and tagged `@be-music/player-tui@<version>` |
| Engine + TUI both bumped (typical) | SEA built, archive named with engine version | SEA built, archive named with TUI version (= the source it was built from) |

## Changes

- `scripts/release/resolve-package-releases.ts`: `SEA_RELEASES` key flipped from `'player'` to `'player-tui'`; the local `playerRelease` finder and the GitHub-output keys are renamed to `release_player_tui` / `player_tui_version` to match.
- `.github/workflows/release.yml`: all 8 references to `release_player` / `player_version` are renamed to `release_player_tui` / `player_tui_version`. The build command `pnpm --filter @be-music/player-tui run build:sea` is unchanged.
- `archiveBaseName` stays `be-music-player` — the user-facing product name does not change.

`scripts/build-sea.ts` is unchanged; its internal `--package player` argument is just a SEA target alias (already mapped to `packages/player-tui` via `SEA_TARGETS`), not the npm package slug.

## Test plan

- [x] `pnpm run typecheck`
- [x] Manually re-ran the resolver against the v0.4.0 commit window (`@be-music/player@0.3.1...@be-music/player@0.4.0`); under the new logic it emits `release_player_tui=true` and `player_tui_version=0.2.3`, matching the TUI source actually bundled into the SEA archive shipped at that release.
- [ ] Next release that includes a `@be-music/player-tui` bump should attach SEA bins to the `@be-music/player-tui@<version>` tag and skip the engine release.

## Out of scope

No changeset — this is a release-infrastructure fix; no published library content changes.