### PR TITLE
chore(deps-dev): replace @typescript/native-preview with typescript 7.0 RC

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -57,7 +57,6 @@
     "stringifier",
     "subartists",
     "SWBGA",
-    "tsgo",
     "Unjudged",
     "VIDEOFILE",
     "VOLWAV",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "devDependencies": {
     "@changesets/cli": "^2.31.0",
     "@types/node": "^25.9.1",
-    "@typescript/native-preview": "7.0.0-dev.20260613.1",
     "@vitest/coverage-v8": "^4.0.18",
     "oxfmt": "^0.54.0",
     "oxlint": "^1.69.0",
@@ -42,6 +41,7 @@
     "tinybench": "^6.0.2",
     "tsdown": "^0.22.2",
     "tsx": "^4.22.4",
+    "typescript": "7.0.1-rc",
     "vite": "^8.0.16",
     "vitest": "^4.0.18"
   },
@@ -52,6 +52,11 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild"
-    ]
+    ],
+    "peerDependencyRules": {
+      "allowedVersions": {
+        "typescript": "7.0.1-rc"
+      }
+    }
   }
 }

--- a/packages/audio-renderer/package.json
+++ b/packages/audio-renderer/package.json
@@ -30,7 +30,7 @@
     "build:sea": "tsx ../../scripts/build-sea.ts --package audio-renderer",
     "clean": "rimraf dist tsconfig.tsbuildinfo",
     "dev": "tsx --tsconfig ../../tsconfig.typecheck.json src/cli.ts",
-    "typecheck": "tsgo -p tsconfig.typecheck.json --pretty",
+    "typecheck": "tsc -p tsconfig.typecheck.json --pretty",
     "lint": "oxlint .",
     "lint:fix": "oxlint . --fix",
     "format": "oxfmt . --write",

--- a/packages/beatoraja-skin/package.json
+++ b/packages/beatoraja-skin/package.json
@@ -20,7 +20,7 @@
     "build:bundle": "tsdown",
     "build": "tsdown",
     "clean": "rimraf dist tsconfig.tsbuildinfo",
-    "typecheck": "tsgo -p tsconfig.typecheck.json --pretty",
+    "typecheck": "tsc -p tsconfig.typecheck.json --pretty",
     "lint": "oxlint .",
     "lint:fix": "oxlint . --fix",
     "format": "oxfmt . --write",

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -20,7 +20,7 @@
     "build:bundle": "tsdown",
     "build": "tsdown",
     "clean": "rimraf dist tsconfig.tsbuildinfo",
-    "typecheck": "tsgo -p tsconfig.typecheck.json --pretty",
+    "typecheck": "tsc -p tsconfig.typecheck.json --pretty",
     "lint": "oxlint .",
     "lint:fix": "oxlint . --fix",
     "format": "oxfmt . --write",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -24,7 +24,7 @@
     "build": "tsdown",
     "clean": "rimraf dist tsconfig.tsbuildinfo",
     "dev": "tsx --tsconfig ../../tsconfig.typecheck.json src/cli.ts",
-    "typecheck": "tsgo -p tsconfig.typecheck.json --pretty",
+    "typecheck": "tsc -p tsconfig.typecheck.json --pretty",
     "lint": "oxlint .",
     "lint:fix": "oxlint . --fix",
     "format": "oxfmt . --write",

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -20,7 +20,7 @@
     "build:bundle": "tsdown",
     "build": "tsdown",
     "clean": "rimraf dist tsconfig.tsbuildinfo",
-    "typecheck": "tsgo -p tsconfig.typecheck.json --pretty",
+    "typecheck": "tsc -p tsconfig.typecheck.json --pretty",
     "lint": "oxlint .",
     "lint:fix": "oxlint . --fix",
     "format": "oxfmt . --write",

--- a/packages/lr2-skin/package.json
+++ b/packages/lr2-skin/package.json
@@ -20,7 +20,7 @@
     "build:bundle": "tsdown",
     "build": "tsdown",
     "clean": "rimraf dist tsconfig.tsbuildinfo",
-    "typecheck": "tsgo -p tsconfig.typecheck.json --pretty",
+    "typecheck": "tsc -p tsconfig.typecheck.json --pretty",
     "lint": "oxlint .",
     "lint:fix": "oxlint . --fix",
     "format": "oxfmt . --write",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -24,7 +24,7 @@
     "build": "tsdown",
     "clean": "rimraf dist tsconfig.tsbuildinfo",
     "dev": "tsx --tsconfig ../../tsconfig.typecheck.json src/cli.ts",
-    "typecheck": "tsgo -p tsconfig.typecheck.json --pretty",
+    "typecheck": "tsc -p tsconfig.typecheck.json --pretty",
     "lint": "oxlint .",
     "lint:fix": "oxlint . --fix",
     "format": "oxfmt . --write",

--- a/packages/player-tui/package.json
+++ b/packages/player-tui/package.json
@@ -27,7 +27,7 @@
     "dev": "tsx --tsconfig ../../tsconfig.typecheck.json src/cli.ts",
     "diag:keyboard": "tsx --tsconfig ../../tsconfig.typecheck.json src/keyboard-diagnostic.ts",
     "diag:gameplay-input": "tsx --tsconfig ../../tsconfig.typecheck.json src/gameplay-input-diagnostic.ts",
-    "typecheck": "tsgo -p tsconfig.typecheck.json --pretty",
+    "typecheck": "tsc -p tsconfig.typecheck.json --pretty",
     "lint": "oxlint .",
     "lint:fix": "oxlint . --fix",
     "format": "oxfmt . --write",

--- a/packages/player-web-demo/package.json
+++ b/packages/player-web-demo/package.json
@@ -11,7 +11,7 @@
     "cf:r2:create": "wrangler r2 bucket create be-music-ffmpeg-core",
     "cf:r2:push": "pnpm run build:cf && node scripts/sync-ffmpeg-core.mjs --force",
     "clean": "rimraf dist tsconfig.tsbuildinfo node_modules/.vite",
-    "typecheck": "tsgo -p tsconfig.typecheck.json --pretty",
+    "typecheck": "tsc -p tsconfig.typecheck.json --pretty",
     "lint": "oxlint .",
     "lint:fix": "oxlint . --fix",
     "format": "oxfmt . --write",

--- a/packages/player-web/package.json
+++ b/packages/player-web/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "build": "tsdown",
     "clean": "rimraf dist tsconfig.tsbuildinfo",
-    "typecheck": "tsgo -p tsconfig.typecheck.json --pretty",
+    "typecheck": "tsc -p tsconfig.typecheck.json --pretty",
     "lint": "oxlint .",
     "lint:fix": "oxlint . --fix",
     "format": "oxfmt . --write",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -110,7 +110,7 @@
     "build:bundle": "tsdown",
     "build": "tsdown",
     "clean": "rimraf dist tsconfig.tsbuildinfo",
-    "typecheck": "tsgo -p tsconfig.typecheck.json --pretty",
+    "typecheck": "tsc -p tsconfig.typecheck.json --pretty",
     "lint": "oxlint .",
     "lint:fix": "oxlint . --fix",
     "format": "oxfmt . --write",

--- a/packages/stringifier/package.json
+++ b/packages/stringifier/package.json
@@ -24,7 +24,7 @@
     "build": "tsdown",
     "clean": "rimraf dist tsconfig.tsbuildinfo",
     "dev": "tsx --tsconfig ../../tsconfig.typecheck.json src/cli.ts",
-    "typecheck": "tsgo -p tsconfig.typecheck.json --pretty",
+    "typecheck": "tsc -p tsconfig.typecheck.json --pretty",
     "lint": "oxlint .",
     "lint:fix": "oxlint . --fix",
     "format": "oxfmt . --write",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -55,7 +55,7 @@
     "build:bundle": "tsdown",
     "build": "tsdown",
     "clean": "rimraf dist tsconfig.tsbuildinfo",
-    "typecheck": "tsgo -p tsconfig.typecheck.json --pretty",
+    "typecheck": "tsc -p tsconfig.typecheck.json --pretty",
     "lint": "oxlint .",
     "lint:fix": "oxlint . --fix",
     "format": "oxfmt . --write",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
-      '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260613.1
-        version: 7.0.0-dev.20260613.1
       '@vitest/coverage-v8':
         specifier: ^4.0.18
         version: 4.0.18(vitest@4.0.18(@types/node@25.9.1)(lightningcss@1.32.0)(tsx@4.22.4))
@@ -34,10 +31,13 @@ importers:
         version: 6.0.2
       tsdown:
         specifier: ^0.22.2
-        version: 0.22.2(@typescript/native-preview@7.0.0-dev.20260613.1)(tsx@4.22.4)(unrun@0.2.37)
+        version: 0.22.2(@typescript/native-preview@7.0.0-dev.20260613.1)(tsx@4.22.4)(typescript@7.0.1-rc)(unrun@0.2.37)
       tsx:
         specifier: ^4.22.4
         version: 4.22.4
+      typescript:
+        specifier: 7.0.1-rc
+        version: 7.0.1-rc
       vite:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)
@@ -1976,6 +1976,126 @@ packages:
     engines: {node: '>=16.20.0'}
     hasBin: true
 
+  '@typescript/typescript-aix-ppc64@7.0.1-rc':
+    resolution: {integrity: sha512-oqq2ZfEJ7BQuufcC3QBQndZLPNyamYNHLao8lKRBeeSkZKypBqxPSgkzrcFZtbYcIaBvpiyUnQP9MT7DEYHWbw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.1-rc':
+    resolution: {integrity: sha512-Slc0yTftT2F/uGDmtPst8ijydneL6uZaLEyr2UjahxZpbhTjHFBJ5agXtVz/TL4A+ldxzjzj+E8QtLZlh/5mXw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.1-rc':
+    resolution: {integrity: sha512-h68iFW/LbA1/BsGgSRGFw981/3s1f/rY27YrmeZNuN+ly7dI+fiDduwT9ZT9866x2onoKNRq7PTyxSKyKDzfAQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.1-rc':
+    resolution: {integrity: sha512-DE+ppd8Ix2c6OMuRkKY4PJ4hngMGJ9M95OQUP17p9xL/1IKXof7npIeuusMN/bgL5o5JzMfSGh+N+5scTYRg0Q==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.1-rc':
+    resolution: {integrity: sha512-ST1ozHMw0u+CLOnWkcTyWDMV4Qn9osZ6fd1V1lnKDM1t0hZIp81mdGpdHxyHJjd7jdGrb6Gb/QXcZ1uqZ0t5zw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.1-rc':
+    resolution: {integrity: sha512-N46pRihK3t5zD5MUtTQcdmQUqr1WI4U2nxno1gLwOtRSsB4krFkRjPHcQNG7h2DtRkX64rQiReX6WKwg2wprMA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.1-rc':
+    resolution: {integrity: sha512-gHmHwT5Naq5CKM8g9bbaGeEpnwQEvWCLn3fwP4K2m61VQdDKkPk0Dhab/OoZ4LV2SrMddmclYXTzpyg23YGt5g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.1-rc':
+    resolution: {integrity: sha512-G17Sao312rgiPBTh2F4nOpLpa3CcnBSaNhqNghZk2LNhnsp1RaMO5HMq2me21gqu9xLpc6CIgHtOzU6JBgNlfg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.1-rc':
+    resolution: {integrity: sha512-0FQspOb5UsQ4tQKvWgUO3pS9OIWkP7/8dPRWq+CRazJUeQZ4LBjtYK52jg5iIOrvItrVl2CwvRtrU3/9OihwJg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.1-rc':
+    resolution: {integrity: sha512-SUmwfVBEv6A2Ld0eWfcvW0FqrgemfQL8jFGOmV1qYxsDqumjE5DekHXqbstgmbE4SHr4rrjHjvmuGCY+kTH/vw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.1-rc':
+    resolution: {integrity: sha512-rxeqnNnGiYzv/LlPHi/3+4p0ooR1cNJLjRIHXKovtiVmxXGJq6gtw8VSpbHuWPekyFMXgIAoLCZN0SQ51rAALQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.1-rc':
+    resolution: {integrity: sha512-RYWCHCiPypxajdRHM2CNK/eM22e4Ex5TTjV2pXf7PTtBowGr0xX8i8kIMknyZS0LX2QfleYHouaoMVsFDSle3g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.1-rc':
+    resolution: {integrity: sha512-PfLJSu0JzroDkqw2m4nqflPEcn8yev0m/vHFQlY9EzHorzjR6QG0wL8AJHvnD1e6h1s76AZngJ5u+z1K/D/HKw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.1-rc':
+    resolution: {integrity: sha512-FfbPxH3dTfp8yVIaNM7bdWTixXuyxpzoemluqcqMROSIz+ImpCG3Q9HO9Ptzp9/giv+P9YYEnCMSXh61migj2w==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.1-rc':
+    resolution: {integrity: sha512-FzdTfSzhRYb6hlav6K3cI5RVgcvCTvNAu/vc+t7B6AmZkThQ+t/1ntnvT5fnHmY1Az2RIBw7/b+qtCEG61HJTQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.1-rc':
+    resolution: {integrity: sha512-PQGhlxfNig+0YQ9Wwzd0USPBkt6w/ZqkBQWsU7G/0JkTzunJel+jSWwhKw4947pak/m7hGSeYiI04xReDLGZww==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.1-rc':
+    resolution: {integrity: sha512-WJ7NYgO2mHmLUkI/tZ+hl8lFd26QPJqO8ONOHNuYbdsybLvSB6B6sep222JIVrOfPRDGvFinbGGB+l3m1FWRWA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.1-rc':
+    resolution: {integrity: sha512-UYjDeUxd765V9qcwlUPk4pEXyL0i3G76CJm9baK4i99u1pGO1psf3nXDw4MMmElVOPvGbZag99ZR/O59E2OX6w==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.1-rc':
+    resolution: {integrity: sha512-KzXzFSXZOm7zvEt2Aw0MsB2LbTL88znAiVqTDNAOHdlEb7brgmUQh/X2wM/8Be+N0fjEqWKl65cBKNwpWEbJiw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.1-rc':
+    resolution: {integrity: sha512-98R3+OqDr/r0/PLWEoXu88AE0lGVLNd335Ew8ONgzK1JWkNs4ou/5BGt3Or1ij4iXjH+c7PRL+jFjCbtWze+EA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
   '@uwx/libav.js-fat@6.0.0-nightly.29.f420ff.ffmpeg.6.1.1':
     resolution: {integrity: sha512-XMUWb4CEKAKZ8ONnBT/U6jwJlH+cvbTPj9ufdQ4H+nIaRDen8tcS2PyPAh2Smrxf6MmkvUqj4kH4/groYlNjOQ==}
 
@@ -3408,6 +3528,11 @@ packages:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
 
+  typescript@7.0.1-rc:
+    resolution: {integrity: sha512-drEP77wK7CCDlPfXZH4e008UUQOsw1DFmHmZOZjuNA+yoDLLnSNMZRXi90NbV/1LVo7SbNLq1bs3jjvk49TEqQ==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+
   unconfig-core@7.5.0:
     resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
 
@@ -4729,6 +4854,67 @@ snapshots:
       '@typescript/native-preview-linux-x64': 7.0.0-dev.20260613.1
       '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260613.1
       '@typescript/native-preview-win32-x64': 7.0.0-dev.20260613.1
+    optional: true
+
+  '@typescript/typescript-aix-ppc64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.1-rc':
+    optional: true
 
   '@uwx/libav.js-fat@6.0.0-nightly.29.f420ff.ffmpeg.6.1.1': {}
 
@@ -6000,7 +6186,7 @@ snapshots:
       hash-base: 3.1.2
       inherits: 2.0.4
 
-  rolldown-plugin-dts@0.25.2(@typescript/native-preview@7.0.0-dev.20260613.1)(rolldown@1.1.0):
+  rolldown-plugin-dts@0.25.2(@typescript/native-preview@7.0.0-dev.20260613.1)(rolldown@1.1.0)(typescript@7.0.1-rc):
     dependencies:
       '@babel/generator': 8.0.0-rc.6
       '@babel/helper-validator-identifier': 8.0.0-rc.6
@@ -6013,6 +6199,7 @@ snapshots:
       rolldown: 1.1.0
     optionalDependencies:
       '@typescript/native-preview': 7.0.0-dev.20260613.1
+      typescript: 7.0.1-rc
     transitivePeerDependencies:
       - oxc-resolver
 
@@ -6339,7 +6526,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  tsdown@0.22.2(@typescript/native-preview@7.0.0-dev.20260613.1)(tsx@4.22.4)(unrun@0.2.37):
+  tsdown@0.22.2(@typescript/native-preview@7.0.0-dev.20260613.1)(tsx@4.22.4)(typescript@7.0.1-rc)(unrun@0.2.37):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -6350,7 +6537,7 @@ snapshots:
       obug: 2.1.1
       picomatch: 4.0.4
       rolldown: 1.1.0
-      rolldown-plugin-dts: 0.25.2(@typescript/native-preview@7.0.0-dev.20260613.1)(rolldown@1.1.0)
+      rolldown-plugin-dts: 0.25.2(@typescript/native-preview@7.0.0-dev.20260613.1)(rolldown@1.1.0)(typescript@7.0.1-rc)
       semver: 7.8.1
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
@@ -6358,6 +6545,7 @@ snapshots:
       unconfig-core: 7.5.0
     optionalDependencies:
       tsx: 4.22.4
+      typescript: 7.0.1-rc
       unrun: 0.2.37
     transitivePeerDependencies:
       - '@ts-macro/tsc'
@@ -6381,6 +6569,29 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-typed-array: 1.1.15
+
+  typescript@7.0.1-rc:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.1-rc
+      '@typescript/typescript-darwin-arm64': 7.0.1-rc
+      '@typescript/typescript-darwin-x64': 7.0.1-rc
+      '@typescript/typescript-freebsd-arm64': 7.0.1-rc
+      '@typescript/typescript-freebsd-x64': 7.0.1-rc
+      '@typescript/typescript-linux-arm': 7.0.1-rc
+      '@typescript/typescript-linux-arm64': 7.0.1-rc
+      '@typescript/typescript-linux-loong64': 7.0.1-rc
+      '@typescript/typescript-linux-mips64el': 7.0.1-rc
+      '@typescript/typescript-linux-ppc64': 7.0.1-rc
+      '@typescript/typescript-linux-riscv64': 7.0.1-rc
+      '@typescript/typescript-linux-s390x': 7.0.1-rc
+      '@typescript/typescript-linux-x64': 7.0.1-rc
+      '@typescript/typescript-netbsd-arm64': 7.0.1-rc
+      '@typescript/typescript-netbsd-x64': 7.0.1-rc
+      '@typescript/typescript-openbsd-arm64': 7.0.1-rc
+      '@typescript/typescript-openbsd-x64': 7.0.1-rc
+      '@typescript/typescript-sunos-x64': 7.0.1-rc
+      '@typescript/typescript-win32-arm64': 7.0.1-rc
+      '@typescript/typescript-win32-x64': 7.0.1-rc
 
   unconfig-core@7.5.0:
     dependencies:


### PR DESCRIPTION
## What

Replace `@typescript/native-preview` with **TypeScript 7.0 RC (`typescript@7.0.1-rc`)**.

- Swap the root devDependency from `@typescript/native-preview 7.0.0-dev.20260613.1` to `typescript 7.0.1-rc`
- Point every package's `typecheck` script at `tsc` instead of `tsgo`
- Allow the TS7 RC via `pnpm.peerDependencyRules.allowedVersions` so `tsdown` / `rolldown-plugin-dts` no longer warn about the optional peer range
- Drop the now-unused `tsgo` cSpell entry

## Why

TypeScript 7.0 is no longer published as a separate `@typescript/native-preview` package — it ships under the `typescript` package on the `rc` tag, and the binary is the standard `tsc` again rather than `tsgo`.
Reference: https://devblogs.microsoft.com/typescript/announcing-typescript-7-0-rc/

## Verification

Ran the same four tasks as CI locally; all green.

- ✅ `pnpm run typecheck` — passes for all 13 packages with `tsc 7.0.1-rc`
- ✅ `pnpm run build` — `.d.ts` generation via `tsdown` works for every package (driven by `isolatedDeclarations`, so it does not depend on the compiler API)
- ✅ `pnpm run lint` — passes (the 2 pre-existing `no-useless-spread` warnings are unrelated to this change)
- ✅ `pnpm test` — 140 files / 1812 tests pass
- ✅ `pnpm install --frozen-lockfile` — lockfile is consistent

## Notes for reviewers

- This is a dev-tooling-only change with no effect on published package output, so no changeset is added.
- The remaining `@typescript/native-preview` references in the lockfile are **optional peer** metadata for `tsdown` / `rolldown-plugin-dts` that pnpm always records — even on a fresh resolution. The package is not actually installed (`node_modules/@typescript` does not exist), and the incremental vs. fresh lockfiles are byte-identical.