### PR TITLE
Add Cursor Cloud environment setup notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,11 @@
 # Benchmark Rules
 
 - When exported functions are added or removed, update benchmarks accordingly (add or delete benchmark cases).
+
+## Cursor Cloud specific instructions
+
+- Node.js: this repo requires Node `>=26` (`.node-version` pins `26.7.0`). The VM's default `node` on `PATH` (`/exec-daemon/node`) is v22 and would take precedence, so Node 26 is installed via `nvm` and prepended to `PATH` in `~/.bashrc`. Interactive shells get Node 26 automatically; a non-interactive script must prepend `"$HOME/.nvm/versions/node/v26.7.0/bin"` to `PATH` first. Node 26 dropped `corepack`, so the pinned pnpm (`10.30.3`) is installed globally under Node 26 rather than via corepack.
+- Standard commands live in the root `package.json` and `README.md`: `pnpm run lint`, `pnpm run typecheck`, `pnpm run build`, `pnpm test` (Vitest, run only from the workspace root — there is no per-package `test` script). CI (`.github/workflows/ci.yml`) runs exactly `lint`, `typecheck`, `build`, `test`.
+- `pnpm install` prints `Failed to create bin ...` warnings for `bms-parse`/`bms-audio-render`/`bms-stringify` and reports `Ignored build scripts: sharp, workerd`. Both are expected: the CLI bins only exist after `pnpm run build`, and only `esbuild` is allowed in `pnpm.onlyBuiltDependencies`. Neither blocks dev, tests, or the web demo.
+- CLI toolchain (parser/stringifier/audio-renderer/editor) runs through `tsx` via root aliases (e.g. `pnpm run parse in.bms out.json`, `pnpm run audio-render in.bms out.wav`), so a prior `pnpm run build` is not required for these.
+- Browser demo: `pnpm run player:web` starts Vite on `http://localhost:5173` (`--host 0.0.0.0`). To load a chart without native-folder drag-drop, use the URL auto-load param `?music=<zip-url>`; a same-origin zip works by placing it in `packages/player-web-demo/public/` (served at `/`), then visiting `http://localhost:5173/?music=/<file>.zip`. The song-select screen exposes an `AUTO PLAY` button that plays a chart end-to-end (falling notes → results screen) with no keyboard input.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for the `be-music` monorepo and documents the non-obvious startup caveats for future agents.

The only code change is an appended `## Cursor Cloud specific instructions` section in `AGENTS.md`. No application code was modified.

## Environment setup performed

- Installed Node.js `26.7.0` (repo requires `>=26`, `.node-version` pins `26.7.0`) via `nvm`. The VM's default `/exec-daemon/node` is v22 and took `PATH` precedence, so Node 26 is prepended in `~/.bashrc`.
- Node 26 dropped `corepack`, so the pinned pnpm `10.30.3` is installed globally under Node 26.
- Update script (runs on VM startup): prepend Node 26 to `PATH`, then `pnpm install --frozen-lockfile --prefer-offline`.

## Verification

All CI-equivalent tasks pass on Node 26 + pnpm 10.30.3:

| Task | Command | Result |
| --- | --- | --- |
| Lint | `pnpm run lint` | pass (pre-existing warnings only) |
| Typecheck | `pnpm run typecheck` | pass |
| Build | `pnpm run build` | pass (all 13 packages) |
| Test | `pnpm test` | 1905 passed / 149 files |
| CLI | `pnpm run parse` + `pnpm run audio-render` | BMS→JSON + valid 3.30s WAV |
| Web demo | `pnpm run player:web` | Vite on :5173, AUTO PLAY end-to-end |

### Browser demo (AUTO PLAY, end-to-end)

[be_music_web_player_autoplay_demo.mp4](https://cursor.com/agents/bc-c4c85426-9b9b-433a-a0a0-019e785e626d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbe_music_web_player_autoplay_demo.mp4)

[AUTO PLAY gameplay](https://cursor.com/agents/bc-c4c85426-9b9b-433a-a0a0-019e785e626d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbe_music_gameplay_autoplay.webp)

[Results screen: CLEARED, RANK AAA, SCORE 200000](https://cursor.com/agents/bc-c4c85426-9b9b-433a-a0a0-019e785e626d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbe_music_results_screen.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4c85426-9b9b-433a-a0a0-019e785e626d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4c85426-9b9b-433a-a0a0-019e785e626d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

