### PR TITLE
chore(changesets): pin private-package versioning ahead of the v3 bump

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,10 +1,14 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@3.1.3/schema.json",
+  "$schema": "https://unpkg.com/@changesets/config@4.0.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
   "linked": [],
   "access": "public",
+  "privatePackages": {
+    "version": true,
+    "tag": false
+  },
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []


### PR DESCRIPTION
Companion to #184 (`@changesets/cli` 2.31.1 → 3.0.1).

## Why

Changesets 3.0.0 changed the `privatePackages` default: private packages are **no longer versioned or tagged** unless the config opts in. `@be-music/player-web-demo` is `"private": true` but has always been versioned — it carries a `CHANGELOG.md` and picks up dependent patch bumps from `@be-music/player-web` through `updateInternalDependencies: "patch"`.

Verified by running `changeset version` against the current unreleased changeset set with both CLIs:

| CLI | `@be-music/player-web-demo` |
| --- | --- |
| 2.31.1 (current) | 0.3.2 → **0.3.3** |
| 3.0.1, no config change | 0.3.2 → **0.3.2** (skipped) |
| 3.0.1, with this config | 0.3.2 → **0.3.3** |

All twelve other packages resolve to identical versions in every case, so this is the only behavioural difference the major bump introduces here.

## What

- Declare `privatePackages: { version: true, tag: false }` — the exact v2 default — so the demo keeps its version history and CHANGELOG entries.
- Refresh the `$schema` pin from `@changesets/config@3.1.3` to `@4.0.0`, the config package version that ships with the v3 CLI.

Both changes are accepted by 2.31.1 as well, so this can land before or after #184 without an intermediate broken state.