### PR TITLE
style: clear the accumulated oxfmt drift across the workspace

### DIFF
--- a/packages/audio-renderer/src/core/triggers.ts
+++ b/packages/audio-renderer/src/core/triggers.ts
@@ -212,7 +212,7 @@ export function createBmsonSamplePlaybackMap(
     let hasAnchor = false;
     let sliceIndex = 0;
 
-    for (let index = 0; index < entries.length; ) {
+    for (let index = 0; index < entries.length;) {
       const firstEntry = entries[index]!;
       const currentBeat = firstEntry.beat;
       let end = index + 1;

--- a/packages/beatoraja-skin/CHANGELOG.md
+++ b/packages/beatoraja-skin/CHANGELOG.md
@@ -36,7 +36,6 @@
   discovery wins ties against community themes that shadow it.
 
   ### `@be-music/player-web` (new beatoraja runtime + scenes)
-
   - Public entry point gains `loadBeatorajaThemeFromFiles()`, `loadBeatorajaTexturesFromBundle()`,
     `destinationToSpriteProps()`, `BeatorajaPlaySkinView`, the `BeatorajaRuntimeAdapter`, Pixi
     scenes for **decide / gameplay / result / select** (with notes / markers / BGA layers), drop
@@ -71,7 +70,6 @@
     (`21` / `26..29`). Real IIDX DP always pairs each side's keyboard with `21` and / or scratch.
 
   ### `@be-music/player` — direct lane-mode override
-
   - New optional `PlayerOptions.playVariant` (`'5' | '7' | '9' | '10' | '14' | '24'`) lets the host
     pin the engine's lane mode directly. Mirrors the renderer-side variant the host has already
     classified the chart as, so BME-format POPN-9 charts mount with the correct `f / v / g / b`

--- a/packages/chart/CHANGELOG.md
+++ b/packages/chart/CHANGELOG.md
@@ -33,7 +33,6 @@
   discovery wins ties against community themes that shadow it.
 
   ### `@be-music/player-web` (new beatoraja runtime + scenes)
-
   - Public entry point gains `loadBeatorajaThemeFromFiles()`, `loadBeatorajaTexturesFromBundle()`,
     `destinationToSpriteProps()`, `BeatorajaPlaySkinView`, the `BeatorajaRuntimeAdapter`, Pixi
     scenes for **decide / gameplay / result / select** (with notes / markers / BGA layers), drop
@@ -68,7 +67,6 @@
     (`21` / `26..29`). Real IIDX DP always pairs each side's keyboard with `21` and / or scratch.
 
   ### `@be-music/player` — direct lane-mode override
-
   - New optional `PlayerOptions.playVariant` (`'5' | '7' | '9' | '10' | '14' | '24'`) lets the host
     pin the engine's lane mode directly. Mirrors the renderer-side variant the host has already
     classified the chart as, so BME-format POPN-9 charts mount with the correct `f / v / g / b`

--- a/packages/chart/src/index.test.ts
+++ b/packages/chart/src/index.test.ts
@@ -589,12 +589,14 @@ describe('chart', () => {
     // BME POPN-9 — full 1P keyboard (`11..19`) authored as `#PLAYER 1`. Before the content-based rule the
     // chart classified as `'7'` (saw `18`/`19`, didn't see `2X`) and the engine's 7-key SP bindings dropped
     // the POPN-9 `f/v/g/b` on `16/17/18/19`.
-    expect(
-      resolveChartPlayVariant(chart('main.bme', ['11', '12', '13', '14', '15', '16', '17', '18', '19'])),
-    ).toBe('9');
+    expect(resolveChartPlayVariant(chart('main.bme', ['11', '12', '13', '14', '15', '16', '17', '18', '19']))).toBe(
+      '9',
+    );
     // PMS-STD hybrid with 1P scratch — non-standard but uses POPN-specific `22..25`. Routes to `'9'`
     // because `22..25` is the discriminator; the 1P-side scratch presence doesn't override it.
-    expect(resolveChartPlayVariant(chart('main.bme', ['11', '12', '13', '14', '15', '16', '22', '23', '24', '25']))).toBe('9');
+    expect(
+      resolveChartPlayVariant(chart('main.bme', ['11', '12', '13', '14', '15', '16', '22', '23', '24', '25'])),
+    ).toBe('9');
     // Sparse PMS-STD authoring — single `22` channel use without any `21`/`26..29`. Still routes to
     // `'9'` (a real IIDX 5K DP chart would have `21` and / or `26` for the leftmost 2P column / scratch).
     expect(resolveChartPlayVariant(chart('main.bme', ['11', '15', '22']))).toBe('9');

--- a/packages/lr2-skin/CHANGELOG.md
+++ b/packages/lr2-skin/CHANGELOG.md
@@ -54,7 +54,6 @@
   discovery wins ties against community themes that shadow it.
 
   ### `@be-music/player-web` (new beatoraja runtime + scenes)
-
   - Public entry point gains `loadBeatorajaThemeFromFiles()`, `loadBeatorajaTexturesFromBundle()`,
     `destinationToSpriteProps()`, `BeatorajaPlaySkinView`, the `BeatorajaRuntimeAdapter`, Pixi
     scenes for **decide / gameplay / result / select** (with notes / markers / BGA layers), drop
@@ -89,7 +88,6 @@
     (`21` / `26..29`). Real IIDX DP always pairs each side's keyboard with `21` and / or scratch.
 
   ### `@be-music/player` — direct lane-mode override
-
   - New optional `PlayerOptions.playVariant` (`'5' | '7' | '9' | '10' | '14' | '24'`) lets the host
     pin the engine's lane mode directly. Mirrors the renderer-side variant the host has already
     classified the chart as, so BME-format POPN-9 charts mount with the correct `f / v / g / b`

--- a/packages/lr2-skin/src/play-skin.test.ts
+++ b/packages/lr2-skin/src/play-skin.test.ts
@@ -35,9 +35,12 @@ function songWithChannels(channels: string[]): Lr2PlaySkinSong {
     chartPath: 'Song/main.bms',
     chart: {
       bms: {},
-      events: channels.map(
-        (channel, index): BeMusicEvent => ({ measure: index, channel, position: [0, 1], value: '01' }),
-      ),
+      events: channels.map((channel, index): BeMusicEvent => ({
+        measure: index,
+        channel,
+        position: [0, 1],
+        value: '01',
+      })),
     },
   };
 }

--- a/packages/parser/src/core/bmson.ts
+++ b/packages/parser/src/core/bmson.ts
@@ -476,7 +476,6 @@ export function createBmsonPositionResolver(
   };
 }
 
-
 /**
  * beatoraja bmson extension — long-note type values are `1` (LN), `2` (CN), `3` (HCN). Anything else (including the
  * spec-absent `0`) is treated as "unspecified" so the consumer falls back to the chart-level / player default.

--- a/packages/player-web-demo/CHANGELOG.md
+++ b/packages/player-web-demo/CHANGELOG.md
@@ -121,7 +121,6 @@
   discovery wins ties against community themes that shadow it.
 
   ### `@be-music/player-web` (new beatoraja runtime + scenes)
-
   - Public entry point gains `loadBeatorajaThemeFromFiles()`, `loadBeatorajaTexturesFromBundle()`,
     `destinationToSpriteProps()`, `BeatorajaPlaySkinView`, the `BeatorajaRuntimeAdapter`, Pixi
     scenes for **decide / gameplay / result / select** (with notes / markers / BGA layers), drop
@@ -156,7 +155,6 @@
     (`21` / `26..29`). Real IIDX DP always pairs each side's keyboard with `21` and / or scratch.
 
   ### `@be-music/player` — direct lane-mode override
-
   - New optional `PlayerOptions.playVariant` (`'5' | '7' | '9' | '10' | '14' | '24'`) lets the host
     pin the engine's lane mode directly. Mirrors the renderer-side variant the host has already
     classified the chart as, so BME-format POPN-9 charts mount with the correct `f / v / g / b`

--- a/packages/player-web/CHANGELOG.md
+++ b/packages/player-web/CHANGELOG.md
@@ -143,7 +143,6 @@
   discovery wins ties against community themes that shadow it.
 
   ### `@be-music/player-web` (new beatoraja runtime + scenes)
-
   - Public entry point gains `loadBeatorajaThemeFromFiles()`, `loadBeatorajaTexturesFromBundle()`,
     `destinationToSpriteProps()`, `BeatorajaPlaySkinView`, the `BeatorajaRuntimeAdapter`, Pixi
     scenes for **decide / gameplay / result / select** (with notes / markers / BGA layers), drop
@@ -178,7 +177,6 @@
     (`21` / `26..29`). Real IIDX DP always pairs each side's keyboard with `21` and / or scratch.
 
   ### `@be-music/player` — direct lane-mode override
-
   - New optional `PlayerOptions.playVariant` (`'5' | '7' | '9' | '10' | '14' | '24'`) lets the host
     pin the engine's lane mode directly. Mirrors the renderer-side variant the host has already
     classified the chart as, so BME-format POPN-9 charts mount with the correct `f / v / g / b`
@@ -261,7 +259,6 @@
   ## What changed
 
   ### `@be-music/player`
-
   - New `PlayerOptions.preparedChart` option lets the host hand the engine
     a pre-built `PreparedPlaybackChartData`. When provided,
     `autoPlay` / `manualPlay` use it verbatim and skip their own internal
@@ -282,7 +279,6 @@
     latch.
 
   ### `@be-music/player-web`
-
   - `PixiGameplayView.prepareSong` now calls `preparePlaybackChartData`
     itself, keeps the result on `this.preparedChart`, and forwards it to
     the engine through `engineOptions.preparedChart`. The renderer's

--- a/packages/player-web/src/chart/preview.ts
+++ b/packages/player-web/src/chart/preview.ts
@@ -276,11 +276,14 @@ export class ChartPreviewEngine {
       this.finishSource(handle);
       return;
     }
-    setTimeout(() => {
-      if (handle.stopping) {
-        this.finishSource(handle);
-      }
-    }, CHART_PREVIEW_STOP_FADE_OUT_SECONDS * 1000 + 50);
+    setTimeout(
+      () => {
+        if (handle.stopping) {
+          this.finishSource(handle);
+        }
+      },
+      CHART_PREVIEW_STOP_FADE_OUT_SECONDS * 1000 + 50,
+    );
   }
 
   private stopSourceImmediately(handle: PreviewSourceHandle): void {

--- a/packages/player-web/src/scene/default/gameplay-render.ts
+++ b/packages/player-web/src/scene/default/gameplay-render.ts
@@ -262,7 +262,14 @@ export function renderDefaultGameplayFrame(
     layerPool,
   );
   addText(layer, 'RANK', SCORE_PANEL.x + 148, SCORE_PANEL.y + 81, labelStyle(), layerPool);
-  addText(layer, rank, SCORE_PANEL.x + 226, SCORE_PANEL.y + 70, { ...metricStyle(22, GOLD, 1), maxWidth: 42 }, layerPool);
+  addText(
+    layer,
+    rank,
+    SCORE_PANEL.x + 226,
+    SCORE_PANEL.y + 70,
+    { ...metricStyle(22, GOLD, 1), maxWidth: 42 },
+    layerPool,
+  );
 
   for (const display of resolveJudgeDisplays(runtime, playfield)) {
     const combo = resolveVisibleCombo(display.judge, display.combo);
@@ -442,10 +449,13 @@ function drawPlayfield(frame: Graphics, playfield: FallbackPlayfieldLayout, prog
   const trackTop = wellTop + 6;
   const trackHeight = wellBottom - 12 - trackTop;
   frame.rect(trackX, trackTop, railW - 4, trackHeight).fill({ color: 0x000000, alpha: 0.55 });
-  const ratio = progressRatio !== undefined && Number.isFinite(progressRatio) ? Math.max(0, Math.min(1, progressRatio)) : 0;
+  const ratio =
+    progressRatio !== undefined && Number.isFinite(progressRatio) ? Math.max(0, Math.min(1, progressRatio)) : 0;
   if (ratio > 0) {
     const fillHeight = Math.max(2, Math.round(trackHeight * ratio));
-    frame.rect(trackX, trackTop + trackHeight - fillHeight, railW - 4, fillHeight).fill({ color: MAGENTA, alpha: 0.85 });
+    frame
+      .rect(trackX, trackTop + trackHeight - fillHeight, railW - 4, fillHeight)
+      .fill({ color: MAGENTA, alpha: 0.85 });
     frame.rect(trackX, trackTop + trackHeight - fillHeight, railW - 4, 2).fill({ color: 0xffffff, alpha: 0.85 });
   }
 
@@ -812,7 +822,17 @@ function resolveTextStyle(opts: {
       fontFamily: opts.fontFamily ?? FONT,
       letterSpacing: opts.letterSpacing ?? 0,
       stroke: opts.stroke,
-      ...(shadow ? { dropShadow: { color: shadow.color, alpha: shadow.alpha, blur: shadow.blur, distance: shadow.distance, angle: Math.PI / 2 } } : {}),
+      ...(shadow
+        ? {
+            dropShadow: {
+              color: shadow.color,
+              alpha: shadow.alpha,
+              blur: shadow.blur,
+              distance: shadow.distance,
+              angle: Math.PI / 2,
+            },
+          }
+        : {}),
     });
     TEXT_STYLE_CACHE.set(key, style);
   }

--- a/packages/player-web/src/scene/lr2/gameplay-hud.test.ts
+++ b/packages/player-web/src/scene/lr2/gameplay-hud.test.ts
@@ -59,7 +59,9 @@ describe('resolveGrooveGaugeBeads', () => {
   });
 
   test('clamps out-of-range / non-finite input', () => {
-    expect(resolveGrooveGaugeBeads(200).every((b) => b.cellOffset === LIT_RED || b.cellOffset === LIT_GREEN)).toBe(true);
+    expect(resolveGrooveGaugeBeads(200).every((b) => b.cellOffset === LIT_RED || b.cellOffset === LIT_GREEN)).toBe(
+      true,
+    );
     expect(resolveGrooveGaugeBeads(-10).every((b) => b.cellOffset === UNLIT_RED || b.cellOffset === UNLIT_GREEN)).toBe(
       true,
     );

--- a/packages/player-web/src/scene/lr2/gameplay-hud.ts
+++ b/packages/player-web/src/scene/lr2/gameplay-hud.ts
@@ -215,10 +215,7 @@ export interface GrooveGaugeBead {
  *
  * Pure function (no Pixi binding) so the cell-selection logic is unit-tested directly.
  */
-export function resolveGrooveGaugeBeads(
-  percent: number,
-  options: { survivalGauge?: boolean } = {},
-): GrooveGaugeBead[] {
+export function resolveGrooveGaugeBeads(percent: number, options: { survivalGauge?: boolean } = {}): GrooveGaugeBead[] {
   const clampedPercent = Math.max(0, Math.min(100, Number.isFinite(percent) ? percent : 0));
   const activeUnits = Math.round((clampedPercent / 100) * LR2_GROOVE_GAUGE_UNITS);
   const clearZoneUnit = Math.round((LR2_GROOVE_GAUGE_CLEAR_ZONE_PERCENT / 100) * LR2_GROOVE_GAUGE_UNITS);

--- a/packages/player-web/src/scene/lr2/gameplay-result-delay.test.ts
+++ b/packages/player-web/src/scene/lr2/gameplay-result-delay.test.ts
@@ -30,10 +30,7 @@ function mockBuffer(duration: number): AudioBuffer {
 describe('resolvePostChartResultDelayMs', () => {
   it('waits about two 4/4 measures after the last note before result transition', () => {
     const delay = resolvePostChartResultDelayMs(
-      [
-        note({ beat: 4, seconds: 2 }),
-        note({ beat: 12, seconds: 6 }),
-      ],
+      [note({ beat: 4, seconds: 2 }), note({ beat: 12, seconds: 6 })],
       resolver,
       6,
     );
@@ -65,9 +62,7 @@ describe('resolveGameplayAudioTailCleanupDelayMs', () => {
     const delay = resolveGameplayAudioTailCleanupDelayMs({
       chart,
       notes: [note({ event: mkEvent('11', '01'), seconds: 3 })],
-      autoSampleTriggers: [
-        { event: autoEvent, seconds: 5 } satisfies Pick<TimedSampleTrigger, 'event' | 'seconds'>,
-      ],
+      autoSampleTriggers: [{ event: autoEvent, seconds: 5 } satisfies Pick<TimedSampleTrigger, 'event' | 'seconds'>],
       decodedSamples: new Map([
         ['short.wav', mockBuffer(1)],
         ['tail.wav', mockBuffer(4)],

--- a/packages/player-web/src/scene/lr2/gameplay.ts
+++ b/packages/player-web/src/scene/lr2/gameplay.ts
@@ -5034,12 +5034,8 @@ export class PixiGameplayView {
       this.laneLayer
         .roundRect(x + 1, capTop, Math.max(2, w - 2), capHeight, 2)
         .fill({ color: pressed ? tone.capLit : tone.cap, alpha: pressed ? 1 : 0.92 });
-      this.laneLayer
-        .rect(x + 1, capTop, Math.max(2, w - 2), 2)
-        .fill({ color: 0xffffff, alpha: pressed ? 0.7 : 0.14 });
-      this.laneLayer
-        .rect(x + 1, capTop + capHeight - 2, Math.max(2, w - 2), 2)
-        .fill({ color: 0x000000, alpha: 0.35 });
+      this.laneLayer.rect(x + 1, capTop, Math.max(2, w - 2), 2).fill({ color: 0xffffff, alpha: pressed ? 0.7 : 0.14 });
+      this.laneLayer.rect(x + 1, capTop + capHeight - 2, Math.max(2, w - 2), 2).fill({ color: 0x000000, alpha: 0.35 });
       if (pressed) {
         // Under-glow bridging the cap to the judgement line — the "lit from within" press feedback.
         this.laneLayer.rect(x + 1, capTop - 2, Math.max(2, w - 2), 2).fill({ color: tone.top, alpha: 0.95 });

--- a/packages/player/CHANGELOG.md
+++ b/packages/player/CHANGELOG.md
@@ -98,7 +98,6 @@
   discovery wins ties against community themes that shadow it.
 
   ### `@be-music/player-web` (new beatoraja runtime + scenes)
-
   - Public entry point gains `loadBeatorajaThemeFromFiles()`, `loadBeatorajaTexturesFromBundle()`,
     `destinationToSpriteProps()`, `BeatorajaPlaySkinView`, the `BeatorajaRuntimeAdapter`, Pixi
     scenes for **decide / gameplay / result / select** (with notes / markers / BGA layers), drop
@@ -133,7 +132,6 @@
     (`21` / `26..29`). Real IIDX DP always pairs each side's keyboard with `21` and / or scratch.
 
   ### `@be-music/player` — direct lane-mode override
-
   - New optional `PlayerOptions.playVariant` (`'5' | '7' | '9' | '10' | '14' | '24'`) lets the host
     pin the engine's lane mode directly. Mirrors the renderer-side variant the host has already
     classified the chart as, so BME-format POPN-9 charts mount with the correct `f / v / g / b`
@@ -210,7 +208,6 @@
   ## What changed
 
   ### `@be-music/player`
-
   - New `PlayerOptions.preparedChart` option lets the host hand the engine
     a pre-built `PreparedPlaybackChartData`. When provided,
     `autoPlay` / `manualPlay` use it verbatim and skip their own internal
@@ -231,7 +228,6 @@
     latch.
 
   ### `@be-music/player-web`
-
   - `PixiGameplayView.prepareSong` now calls `preparePlaybackChartData`
     itself, keeps the result on `this.preparedChart`, and forwards it to
     the engine through `engineOptions.preparedChart`. The renderer's

--- a/packages/player/src/core/engine.ts
+++ b/packages/player/src/core/engine.ts
@@ -607,12 +607,7 @@ function isLongPlayableNote(note: TimedPlayableNote): boolean {
 }
 
 /** Judge indices, best to worst, in the order the ruleset window sets use. */
-const RULESET_JUDGE_KINDS: readonly [JudgeKind, JudgeKind, JudgeKind, JudgeKind] = [
-  'PERFECT',
-  'GREAT',
-  'GOOD',
-  'BAD',
-];
+const RULESET_JUDGE_KINDS: readonly [JudgeKind, JudgeKind, JudgeKind, JudgeKind] = ['PERFECT', 'GREAT', 'GOOD', 'BAD'];
 
 /**
  * Classify a signed timing delta against one ruleset window set, or `undefined` when the press cannot reach the
@@ -2160,7 +2155,8 @@ export async function autoPlay(json: BeMusicJson, options: PlayerOptions = {}): 
   const autoLongNoteScoresTail = (note: TimedPlayableNote): boolean => {
     const chartMode = resolvePlayableLongNoteMode(note);
     return (
-      chartMode !== undefined && isChargeLongNoteMode(resolveEffectiveLongNoteMode(autoRuleset.longNoteStyle, chartMode))
+      chartMode !== undefined &&
+      isChargeLongNoteMode(resolveEffectiveLongNoteMode(autoRuleset.longNoteStyle, chartMode))
     );
   };
 
@@ -2690,9 +2686,7 @@ export async function manualPlay(json: BeMusicJson, options: PlayerOptions = {})
     if (autoScratchEnabled) {
       writeOutput('Mode: AUTO SCRATCH (16ch/26ch only)\n');
     }
-    writeOutput(
-      `Judge window (${ruleset.id}): ${formatJudgeWindowSet(ruleset.windows.note)}\n`,
-    );
+    writeOutput(`Judge window (${ruleset.id}): ${formatJudgeWindowSet(ruleset.windows.note)}\n`);
     writeOutput('Press Space to pause/resume.\n');
     writeOutput('Press Shift+R to restart.\n');
     writeOutput(`Press ${highSpeedModifierLabel}+odd lane key to decrease HIGH-SPEED.\n`);
@@ -2740,10 +2734,7 @@ export async function manualPlay(json: BeMusicJson, options: PlayerOptions = {})
   // Widest reach across the whole chart — a mid-chart `#EXRANKxx` can widen the windows past the opening rank's.
   const maxBadWindowMs =
     1000 *
-    Math.max(
-      maxJudgeReachSeconds(0),
-      ...dynamicJudgeRankChanges.map((change) => maxJudgeReachSeconds(change.seconds)),
-    );
+    Math.max(maxJudgeReachSeconds(0), ...dynamicJudgeRankChanges.map((change) => maxJudgeReachSeconds(change.seconds)));
   const horizon = (totalSeconds * 1000) / speed + leadInMs + maxBadWindowMs + 1000;
   let interruptedReason: PlayerInterruptReason | undefined;
   const longHoldUntilMsByChannel = new Map<string, number>();
@@ -2918,8 +2909,7 @@ export async function manualPlay(json: BeMusicJson, options: PlayerOptions = {})
       const lastPressMs = lastLanePressMsByChannel.get(landmine.channel);
       const pressedBeforeCrossing = lastPressMs !== undefined && lastPressMs <= crossingMs;
       const heldAtCrossing = pressedBeforeCrossing
-        ? crossingMs - lastPressMs <= LONG_NOTE_REPEAT_HOLD_GRACE_MS ||
-          activeKittyPressedChannels.has(landmine.channel)
+        ? crossingMs - lastPressMs <= LONG_NOTE_REPEAT_HOLD_GRACE_MS || activeKittyPressedChannels.has(landmine.channel)
         : lastPressMs === undefined && activeKittyPressedChannels.has(landmine.channel);
       if (heldAtCrossing) {
         detonateLandmine(landmine, nowSec);
@@ -3209,7 +3199,11 @@ export async function manualPlay(json: BeMusicJson, options: PlayerOptions = {})
     let bestSelection: JudgeSelectionCandidate | undefined;
     // `scorableNotes` is sorted by time, so the scan visits candidates in the ascending order the selection
     // algorithms assume (`lowest` keeps the first, the others may displace it).
-    for (let index = lowerBoundBySeconds(scorableNotes, nowSec - reachSeconds); index < scorableNotes.length; index += 1) {
+    for (
+      let index = lowerBoundBySeconds(scorableNotes, nowSec - reachSeconds);
+      index < scorableNotes.length;
+      index += 1
+    ) {
       const note = scorableNotes[index]!;
       if (note.seconds - nowSec > reachSeconds) {
         break;
@@ -3239,7 +3233,10 @@ export async function manualPlay(json: BeMusicJson, options: PlayerOptions = {})
         judge,
         windows,
       };
-      if (bestSelection === undefined || preferJudgeCandidate(ruleset.selection, bestSelection, selection, inputTimeUs)) {
+      if (
+        bestSelection === undefined ||
+        preferJudgeCandidate(ruleset.selection, bestSelection, selection, inputTimeUs)
+      ) {
         best = note;
         bestSelection = selection;
       }
@@ -3265,7 +3262,11 @@ export async function manualPlay(json: BeMusicJson, options: PlayerOptions = {})
     const consumedIsLong = isLongPlayableNote(consumed);
     const consumedWasBad = consumedJudge === 3;
     const extras: TimedPlayableNote[] = [];
-    for (let index = lowerBoundBySeconds(scorableNotes, nowSec - reachSeconds); index < scorableNotes.length; index += 1) {
+    for (
+      let index = lowerBoundBySeconds(scorableNotes, nowSec - reachSeconds);
+      index < scorableNotes.length;
+      index += 1
+    ) {
       const note = scorableNotes[index]!;
       if (note.seconds - nowSec > reachSeconds) {
         break;
@@ -3463,7 +3464,6 @@ export async function manualPlay(json: BeMusicJson, options: PlayerOptions = {})
       }
     }
 
-
     let refreshedHold = false;
     for (const channel of candidateChannels) {
       if (!activeLongNotesByChannel.has(channel)) {
@@ -3493,7 +3493,12 @@ export async function manualPlay(json: BeMusicJson, options: PlayerOptions = {})
         // LN repeat-suppress window — same intent as the hold path above, just on the cooldown side. Treat as benign.
         return;
       }
-      const fallback = findLaneSoundCandidate(laneSoundNotes, candidateChannels, nowSec, maxJudgeEarlyReachSeconds(nowSec));
+      const fallback = findLaneSoundCandidate(
+        laneSoundNotes,
+        candidateChannels,
+        nowSec,
+        maxJudgeEarlyReachSeconds(nowSec),
+      );
       if (fallback) {
         if (!uiEnabled) {
           writePlayableSampleTriggerEventLog(
@@ -3866,7 +3871,7 @@ export async function manualPlay(json: BeMusicJson, options: PlayerOptions = {})
       const scheduledSec = elapsedMsToGameSeconds(scheduledMs, speed);
       const nowBeat = beatAtSeconds(nowSec);
       processReplayEventsUntil(nowSec);
-        playbackEventTracer.flushUntil(nowSec);
+      playbackEventTracer.flushUntil(nowSec);
 
       triggerRealtimeAudioVolumeEvents(scheduledSec);
       triggerNonPlayableRealtimeAudioEvents(scheduledSec);

--- a/packages/player/src/core/judge-window.test.ts
+++ b/packages/player/src/core/judge-window.test.ts
@@ -132,5 +132,4 @@ describe('judge-window', () => {
     // `#EXRANK 120` matches the documented `#DEFEXRANK 120` interpolation.
     expect(resolveBmsJudgeWindowsMsForExRankValue(120).great).toBeCloseTo(52, 6);
   });
-
 });

--- a/packages/player/src/judging.ts
+++ b/packages/player/src/judging.ts
@@ -102,7 +102,7 @@ export function findLaneSoundCandidate<T extends JudgeCandidate>(
   // LR2-style lane sound hold: do not look ahead to the closest future note. A lane's fallback sound only advances
   // when that note's early judgment window has opened, then remains current until the next same-lane window opens.
   const latestEligibleSeconds = nowSec + Math.max(0, activationWindowSec) + 1e-9;
-  for (let index = lowerBoundBySeconds(notes, latestEligibleSeconds); index > 0; ) {
+  for (let index = lowerBoundBySeconds(notes, latestEligibleSeconds); index > 0;) {
     index -= 1;
     const note = notes[index]!;
     if (!candidateChannels.has(note.channel)) {

--- a/packages/player/src/playlog/equivalence.test.ts
+++ b/packages/player/src/playlog/equivalence.test.ts
@@ -212,7 +212,7 @@ describe('engine / simulator equivalence', () => {
     expect(summary.poor).toBe(simulated.judge.poor);
   });
 
-  test("lr2: the empty POOR window is early-only", async () => {
+  test('lr2: the empty POOR window is early-only', async () => {
     // LR2's miss window is `{0, 1 s}` — a press up to a second BEFORE a note charges one, a press after never does.
     const json = chart([{ measure: 2, channel: '11', position: [0, 1], value: '01' }]);
 

--- a/packages/utils/src/cli-path.ts
+++ b/packages/utils/src/cli-path.ts
@@ -62,10 +62,8 @@ function isWindowsDrivePath(path: string): boolean {
   const driveLetter = path.charCodeAt(0);
   if (
     !(
-      (
-        (driveLetter >= 0x41 && driveLetter <= 0x5a) || // A..Z
-        (driveLetter >= 0x61 && driveLetter <= 0x7a)
-      ) // a..z
+      (driveLetter >= 0x41 && driveLetter <= 0x5a) || // A..Z
+      (driveLetter >= 0x61 && driveLetter <= 0x7a) // a..z
     )
   ) {
     return false;


### PR DESCRIPTION
Follow-up to the Dependabot batch (#180–#184). Pure `pnpm run format` output — no hand edits.

## Why

`format:check` is **not** in the CI Verify matrix (`lint`, `typecheck`, `build`, `test` only), so drift accumulated unnoticed. `pnpm run format:check` was already failing on `devel` **before** the oxfmt bump — verified by running oxfmt 0.57.0 against the pre-merge tree:

```
beatoraja-skin   CHANGELOG.md
chart            CHANGELOG.md, src/index.test.ts
lr2-skin         CHANGELOG.md
parser           src/core/bmson.ts
player-web-demo  CHANGELOG.md
player-web       CHANGELOG.md + 6 source files
player           CHANGELOG.md + 3 source files
```

## What the 0.57 → 0.64 bump actually changed

Diffing the two formatters' output over the same tree isolates exactly four files:

| File | Change |
| --- | --- |
| `audio-renderer/src/core/triggers.ts` | `for (…; )` → `for (…;)` |
| `player/src/judging.ts` | same empty-update `for` header |
| `lr2-skin/src/play-skin.test.ts` | annotated arrow returning an object literal now hugs the argument list |
| `utils/src/cli-path.ts` | redundant parenthesis nesting flattened |

Everything else in this diff predates the bump.

## CHANGELOG hunks

The `CHANGELOG.md` hunks remove the blank line between a `###` heading and the list that follows it inside a changeset body. Changesets 3.x formats its generated output with oxfmt (auto-detected), so future `changeset version` runs emit this shape themselves — these files stay clean from here on rather than re-drifting each release.

## Verification

`lint`, `typecheck`, `build` and the full suite (149 files / 1908 tests) all pass, and `format:check` is clean afterwards.

> [!NOTE]
> This touches `player-web/src/scene/default/gameplay-render.ts` and `player-web/src/scene/lr2/gameplay.ts`, which currently have uncommitted local work in progress. Worth landing either before that work starts or after it merges, to avoid a rebase conflict.