### PR TITLE
fix(bench): exclude sub-timer-resolution cases from the comparison

### DIFF
--- a/scripts/bench/compare-results.test.ts
+++ b/scripts/bench/compare-results.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildDiffMarkdown,
   compareSnapshots,
+  countUnreliableCases,
   resolveOverallVerdict,
   summarizeComparison,
   summarizeRows,
@@ -125,6 +126,42 @@ describe('compareSnapshots', () => {
     expect(rows[0]?.baseHz).toBe(100);
     expect(rows[0]?.headHz).toBe(110);
     expect(rows[0]?.deltaPercent).toBeCloseTo(10);
+  });
+
+  it('excludes a case whose head p50 latency is at/below the reliability floor, however large its hz delta', () => {
+    // A case this cheap (p50 <= 0.001ms) is timer-resolution noise, not a real 10,000% speedup — issue #202.
+    const rows = compareSnapshots(
+      createSnapshot({ 'chart.createBeatResolver': 1_000_000 }),
+      createSnapshot({ 'chart.createBeatResolver': 100_000_000 }),
+    );
+
+    expect(rows).toHaveLength(0);
+  });
+
+  it('excludes a case whose base p50 latency is at/below the reliability floor', () => {
+    const rows = compareSnapshots(
+      createSnapshot({ 'chart.createBeatResolver': 100_000_000 }),
+      createSnapshot({ 'chart.createBeatResolver': 1_000_000 }),
+    );
+
+    expect(rows).toHaveLength(0);
+  });
+
+  it('keeps a case whose p50 latency sits just above the reliability floor', () => {
+    const rows = compareSnapshots(createSnapshot({ 'utils.stable': 1000 }), createSnapshot({ 'utils.stable': 1000 }));
+
+    expect(rows).toHaveLength(1);
+  });
+});
+
+describe('countUnreliableCases', () => {
+  it('counts only comparable keys excluded for sub-timer-resolution latency', () => {
+    const count = countUnreliableCases(
+      createSnapshot({ 'chart.createBeatResolver': 1_000_000, 'utils.stable': 1000, 'utils.baseOnly': 500 }),
+      createSnapshot({ 'chart.createBeatResolver': 100_000_000, 'utils.stable': 1000, 'utils.headOnly': 500 }),
+    );
+
+    expect(count).toBe(1);
   });
 });
 

--- a/scripts/bench/compare-results.ts
+++ b/scripts/bench/compare-results.ts
@@ -9,7 +9,7 @@ import {
   resolveCliValue,
   runCliMain,
 } from './cli-utils.ts';
-import type { ExportsBenchmarkSnapshot } from './exports.types.ts';
+import type { BenchmarkTaskStats, ExportsBenchmarkSnapshot } from './exports.types.ts';
 import { resolveComparisonHz } from './task-stats.ts';
 
 interface CliDefaults {
@@ -46,11 +46,23 @@ export interface ComparisonSummary {
   meanDeltaPercent: number;
   thresholdPercent: number;
   overallVerdict: BenchmarkOverallVerdict;
+  /** Cases whose base or head p50 latency was at/below MIN_RELIABLE_LATENCY_MS — excluded, not just unchanged. */
+  unreliableCaseCount: number;
 }
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repositoryDir = resolve(scriptDir, '../..');
 const COMMENT_MARKER = '<!-- be-music-exports-benchmark -->';
+
+/**
+ * Below this per-call latency (median, in ms), a case's timing is dominated by measurement noise rather than the
+ * benchmarked function's own cost — a single call is cheap enough that the system timer can't resolve it reliably.
+ * Percent deltas computed from two noise floors can legitimately swing by 10-30x between independent runs of
+ * *identical* code (see issue #202: verified the same ~15-250ns closure-allocation case reproduces this under both
+ * tsx and node, with no change to the benchmarked code). Such cases are excluded from the regression/improvement
+ * lists rather than folded into "unchanged", since a percent computed from noise isn't a real "no change" either.
+ */
+const MIN_RELIABLE_LATENCY_MS = 0.001;
 
 const DEFAULTS: CliDefaults = {
   outputPath: resolve(repositoryDir, 'tmp/bench/exports-pr-comment.md'),
@@ -83,6 +95,7 @@ async function main(): Promise<void> {
           meanDeltaPercent: 0,
           thresholdPercent: options.thresholdPercent,
           overallVerdict: 'unchanged',
+          unreliableCaseCount: 0,
         };
 
   if (options.summaryPath) {
@@ -111,7 +124,7 @@ export function buildDiffMarkdown(
   topCount: number,
 ): string {
   const rows = compareSnapshots(baseSnapshot, headSnapshot);
-  const summary = summarizeRows(rows, thresholdPercent);
+  const summary = { ...summarizeRows(rows, thresholdPercent), unreliableCaseCount: countUnreliableCases(baseSnapshot, headSnapshot) };
 
   const regressions = rows
     .filter((row) => row.deltaPercent <= -thresholdPercent)
@@ -145,6 +158,7 @@ export function buildDiffMarkdown(
   lines.push(`| Cases improved (>= threshold) | ${summary.improvedCount} |`);
   lines.push(`| Cases regressed (<= -threshold) | ${summary.regressedCount} |`);
   lines.push(`| Cases unchanged | ${summary.unchangedCount} |`);
+  lines.push(`| Cases excluded (sub-timer-resolution) | ${summary.unreliableCaseCount} |`);
   lines.push(`| Head benchmarked cases | ${headSnapshot.totals.benchmarked} |`);
   lines.push(`| Head skipped cases | ${headSnapshot.totals.skipped} |`);
 
@@ -173,6 +187,22 @@ export function buildDiffMarkdown(
       lines.push(
         `| \`${row.key}\` | ${formatOps(row.baseHz)} | ${formatOps(row.headHz)} | ${formatPercent(row.deltaPercent)} |`,
       );
+    }
+  }
+
+  const unreliableKeys = resolveUnreliableCaseKeys(baseSnapshot, headSnapshot).slice(0, topCount);
+  if (unreliableKeys.length > 0) {
+    lines.push('');
+    lines.push('### Excluded (sub-timer-resolution)');
+    lines.push(
+      `Per-call latency at or below ${MIN_RELIABLE_LATENCY_MS}ms on at least one side — the reported time is measurement noise, not the case's real cost, so no percent change is shown.`,
+    );
+    lines.push('| API | Base median ops/s | Head median ops/s |');
+    lines.push('| --- | ---: | ---: |');
+    for (const key of unreliableKeys) {
+      const baseResult = baseSnapshot.results[key];
+      const headResult = headSnapshot.results[key];
+      lines.push(`| \`${key}\` | ${formatOps(baseResult?.medianHz ?? 0)} | ${formatOps(headResult?.medianHz ?? 0)} |`);
     }
   }
 
@@ -224,6 +254,20 @@ function buildHeadOnlyMarkdown(headSnapshot: ExportsBenchmarkSnapshot, topCount:
   return lines.join('\n');
 }
 
+/**
+ * True when either side's per-call latency is at/below MIN_RELIABLE_LATENCY_MS — the case's timing is noise, not
+ * signal, so it must not be reported as a regression, an improvement, or "unchanged" (all three imply the percent
+ * means something).
+ */
+function isUnreliableCase(
+  baseResult: Pick<BenchmarkTaskStats, 'p50Ms'>,
+  headResult: Pick<BenchmarkTaskStats, 'p50Ms'>,
+): boolean {
+  return (
+    !(baseResult.p50Ms > MIN_RELIABLE_LATENCY_MS) || !(headResult.p50Ms > MIN_RELIABLE_LATENCY_MS)
+  );
+}
+
 export function compareSnapshots(
   baseSnapshot: ExportsBenchmarkSnapshot,
   headSnapshot: ExportsBenchmarkSnapshot,
@@ -232,6 +276,9 @@ export function compareSnapshots(
   for (const [key, headResult] of Object.entries(headSnapshot.results)) {
     const baseResult = baseSnapshot.results[key];
     if (!baseResult) {
+      continue;
+    }
+    if (isUnreliableCase(baseResult, headResult)) {
       continue;
     }
     const baseHz = resolveComparisonHz(baseResult);
@@ -249,6 +296,24 @@ export function compareSnapshots(
   }
   rows.sort((left, right) => left.key.localeCompare(right.key));
   return rows;
+}
+
+/** Count of comparable keys (present on both sides) excluded from `compareSnapshots` as sub-timer-resolution noise. */
+export function countUnreliableCases(
+  baseSnapshot: ExportsBenchmarkSnapshot,
+  headSnapshot: ExportsBenchmarkSnapshot,
+): number {
+  let count = 0;
+  for (const [key, headResult] of Object.entries(headSnapshot.results)) {
+    const baseResult = baseSnapshot.results[key];
+    if (!baseResult) {
+      continue;
+    }
+    if (isUnreliableCase(baseResult, headResult)) {
+      count += 1;
+    }
+  }
+  return count;
 }
 
 export function resolveOverallVerdict(medianDeltaPercent: number, thresholdPercent: number): BenchmarkOverallVerdict {
@@ -278,6 +343,7 @@ export function summarizeRows(rows: ComparedRow[], thresholdPercent: number): Co
     meanDeltaPercent,
     thresholdPercent,
     overallVerdict: resolveOverallVerdict(medianDeltaPercent, thresholdPercent),
+    unreliableCaseCount: 0,
   };
 }
 
@@ -287,7 +353,25 @@ export function summarizeComparison(
   thresholdPercent: number,
 ): ComparisonSummary {
   const rows = compareSnapshots(baseSnapshot, headSnapshot);
-  return summarizeRows(rows, thresholdPercent);
+  return {
+    ...summarizeRows(rows, thresholdPercent),
+    unreliableCaseCount: countUnreliableCases(baseSnapshot, headSnapshot),
+  };
+}
+
+function resolveUnreliableCaseKeys(
+  baseSnapshot: ExportsBenchmarkSnapshot,
+  headSnapshot: ExportsBenchmarkSnapshot,
+): string[] {
+  const keys: string[] = [];
+  for (const [key, headResult] of Object.entries(headSnapshot.results)) {
+    const baseResult = baseSnapshot.results[key];
+    if (baseResult && isUnreliableCase(baseResult, headResult)) {
+      keys.push(key);
+    }
+  }
+  keys.sort((left, right) => left.localeCompare(right));
+  return keys;
 }
 
 function resolveNewlySkippedKeys(


### PR DESCRIPTION
Closes #202.

[PR #201](https://github.com/nulltask/be-music/pull/201)'s benchmark comment reported implausible improvements — `player-web.GameplayRecorder` +2733%, `chart.createBeatResolver` +1500%, 205 more cases at +90% or higher — for a PR that only changes how scripts are invoked (`tsx` → `node`), not any benchmarked function's implementation.

## Root cause

Several exports-benchmark cases (closure-allocating ones especially) run in tens to a few hundred nanoseconds per call under CI's timing budget (`--time 50 --warmup-time 25`) — below what tinybench's timer can resolve (`p50Ms == 0`). A percent computed from two independent runs of code this cheap is measurement noise, not signal.

Verified this directly: benchmarking the *identical* built code twice back-to-back (no code change at all) swings a case like `chart.eventToBeat` by ~58% (60.5M → 24.4M ops/s) purely from run-to-run noise. CI's base/head split (separate git worktrees / processes, see `.github/workflows/ci.yml` `benchmark-pr` job) is exactly the setup where that noise reads as a "regression" or "improvement" against the *other* run.

(I initially thought this meant PR #201 changed nothing real — see the correction comment on #202. It turns out tsx's esbuild-transpiled output and Node's type-stripped source do differ in how V8 optimizes closure-allocating call sites under a short timing budget, so #201 is a real, reproducible speedup for those cases. The percentages are directionally real but the *magnitude* reported for sub-tick-resolution cases isn't trustworthy either way, which is the actual bug this PR fixes.)

## Fix

Added a reliability floor to `scripts/bench/compare-results.ts`: `compareSnapshots` now excludes any case whose base or head median per-call latency (`p50Ms`) is at or below 0.001ms from the regression/improvement/unchanged classification entirely — not folded into "unchanged", since a percent computed from noise isn't a real "no change" either. Excluded cases get their own count (`ComparisonSummary.unreliableCaseCount`) and a labeled "Excluded (sub-timer-resolution)" section in the markdown report, so they stay visible instead of silently vanishing.

`countUnreliableCases` is exported separately from `compareSnapshots` so existing callers of `compareSnapshots` (and its existing tests) keep returning `ComparedRow[]` unchanged — no signature break.

## Testing

- Added test cases covering: a case excluded via head-side noise, one excluded via base-side noise, one that stays included just above the floor, and `countUnreliableCases` counting only comparable (both-sides-present) keys.
- Full `build`/`lint`/`typecheck`/`test` green (1975 tests).
- Manually generated two real benchmark snapshots with CI's exact timing and compared them: 71 of 75 comparable `chart`/`utils` cases were correctly excluded as sub-timer-resolution noise, and the two real regressions/one real improvement that remained are outside the floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
